### PR TITLE
Rework types; keep an Arc/lock around a Drop-implementing type for Package...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "curl",
  "docmatic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth"
-version = "0.0.14"
+version = "0.0.15"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust"

--- a/sample_usage/src/multithread.rs
+++ b/sample_usage/src/multithread.rs
@@ -13,17 +13,14 @@ fn load_package(cargo_relpath: &str) -> IrPackage {
     package
 }
 
-lazy_static! {
-    static ref SAMPLE_PACKAGE: xlsynth::IrPackage = load_package("src/sample.x");
-}
-
 // Do a lazy_static initialization of the function.
 lazy_static! {
     // Load sample.x and expose the "add1" function so that threads can invoke it via the XLS
     // interpreter.
     static ref ADD1_FUNCTION: xlsynth::IrFunction = {
+        let package = load_package("src/sample.x");
         let mangled = xlsynth::mangle_dslx_name("sample", "add1").expect("mangle_dslx_name failed");
-        let function = SAMPLE_PACKAGE.get_function(&mangled).expect("get_function failed");
+        let function = package.get_function(&mangled).expect("get_function failed");
         assert_eq!(function.get_name(), mangled);
         function
     };


### PR DESCRIPTION
…so function can prevent its backing package from being deallocated.

Previously we implemented drop on the user-facing IrPackage which did not keep the package alive appropriately when the user held only the IrFunction.