### PR TITLE
c_api: add XLS_DSO_PATH

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -93,6 +93,7 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-link-search=native={}", out_dir);
     println!("cargo:rustc-env=XLS_DSO_VERSION_TAG={}", DSO_VERSION_TAG);
+    println!("cargo:rustc-env=XLS_DSO_PATH={}", out_dir);    
     println!(
         "cargo:rustc-env=DSLX_STDLIB_PATH={}/xls/dslx/stdlib/",
         stdlib_path.display()

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -5,6 +5,7 @@
 use libloading::{Library, Symbol};
 use once_cell::sync::OnceCell;
 use std::ffi::CString;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::ir_package::{IrFunctionType, IrPackagePtr, IrType};
@@ -14,6 +15,7 @@ use crate::xlsynth_error::XlsynthError;
 extern crate libc;
 extern crate libloading;
 
+const DSO_PATH: &str = env!("XLS_DSO_PATH");
 const DSO_VERSION_TAG: &str = env!("XLS_DSO_VERSION_TAG");
 
 static LIBRARY: OnceCell<Mutex<Library>> = OnceCell::new();
@@ -27,9 +29,13 @@ fn get_library() -> &'static Mutex<Library> {
         } else {
             panic!("Running on an unknown OS");
         };
-        let so_filename = format!("libxls-{}.{}", DSO_VERSION_TAG, dso_extension);
+        let so_path = PathBuf::from(DSO_PATH).join(format!(
+            "libxls-{}.{}",
+            DSO_VERSION_TAG,
+            dso_extension
+        ));
         let library = unsafe {
-            Library::new(so_filename.clone()).expect("dynamic library should be present")
+            Library::new(so_path.clone()).expect("dynamic library should be present")
         };
         Mutex::new(library)
     })


### PR DESCRIPTION
This makes it easier  to build xlsynth against a shared library artifact in monorepo-like environment (e.g: google internal repository).
