### PR TITLE
build: link using rustc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,14 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Run tests
+      - name: Build crate
+        run: cargo build -vv --lib
+
+      - name: Test crate
+        run: cargo test -vv --lib
+
+      - name: Build workspace
+        run: cargo build -vv --worksapce
+
+      - name: Test workspace
         run: cargo test -vv --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
           override: true
 
       - name: Run tests
-        run: cargo test --verbose --workspace
+        run: cargo test -vv --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
+      fail-fast: false
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,7 @@ jobs:
           override: true
 
       - name: Build crate
-        run: cargo build -vv --lib
-
-      - name: Test crate
-        run: cargo test -vv --lib
-
-      - name: Build workspace
         run: cargo build -vv --workspace
 
-      - name: Test workspace
+      - name: Test crate
         run: cargo test -vv --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: cargo test -vv --lib
 
       - name: Build workspace
-        run: cargo build -vv --worksapce
+        run: cargo build -vv --workspace
 
       - name: Test workspace
         run: cargo test -vv --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,6 @@ jobs:
         run: cargo build -vv --workspace
 
       - name: Test crate
-        run: cargo test -vv --workspace
+        run: |
+          cargo clean
+          cargo test -vv --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "curl",
  "docmatic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,16 +306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,12 +362,6 @@ checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl-probe"
@@ -632,28 +616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,9 +708,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "libc",
- "libloading",
  "log",
- "once_cell",
  "semver",
  "serde_json",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth"
-version = "0.0.16"
+version = "0.0.17"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,7 @@ exclude = [
 ]
 
 [dependencies]
-libloading = "0.7"
 libc = "0.2"
-once_cell = "1.19"
 
 [build-dependencies]
 curl = "0.4"

--- a/build.rs
+++ b/build.rs
@@ -92,7 +92,7 @@ fn main() {
 
     // Ensure the DSO is copied to the correct location
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-search={}", out_dir);
     println!("cargo:rustc-link-lib=dylib:+verbatim={}", dso_name);
     println!("cargo:rustc-env=XLS_DSO_VERSION_TAG={}", DSO_VERSION_TAG);
     println!("cargo:rustc-env=XLS_DSO_PATH={}", out_dir);

--- a/build.rs
+++ b/build.rs
@@ -27,11 +27,12 @@ fn main() {
     let dso_url = format!("{}libxls.{}", url_base, dso_extension.unwrap());
     let tarball_url = format!("{}/dslx_stdlib.tar.gz", url_base);
     let out_dir = std::env::var("OUT_DIR").unwrap();
-    let dso_path = PathBuf::from(&out_dir).join(format!(
+    let dso_name = format!(
         "libxls-{}.{}",
         DSO_VERSION_TAG,
         dso_extension.unwrap()
-    ));
+    );
+    let dso_path = PathBuf::from(&out_dir).join(&dso_name);
 
     // Check if the DSO has already been downloaded
     if dso_path.exists() {
@@ -92,7 +93,7 @@ fn main() {
     // Ensure the DSO is copied to the correct location
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-link-search=native={}", out_dir);
-    println!("cargo:rustc-link-lib=dylib={}-{}", "xls", DSO_VERSION_TAG);
+    println!("cargo:rustc-link-lib=dylib:+verbatim={}", dso_name);
     println!("cargo:rustc-env=XLS_DSO_VERSION_TAG={}", DSO_VERSION_TAG);
     println!("cargo:rustc-env=XLS_DSO_PATH={}", out_dir);
     println!(

--- a/build.rs
+++ b/build.rs
@@ -92,7 +92,9 @@ fn main() {
     // Ensure the DSO is copied to the correct location
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-lib={}-{}", "xls", DSO_VERSION_TAG);
     println!("cargo:rustc-env=XLS_DSO_VERSION_TAG={}", DSO_VERSION_TAG);
+    println!("cargo:rustc-env=XLS_DSO_PATH={}", out_dir);    
     println!(
         "cargo:rustc-env=DSLX_STDLIB_PATH={}/xls/dslx/stdlib/",
         stdlib_path.display()

--- a/build.rs
+++ b/build.rs
@@ -27,11 +27,12 @@ fn main() {
     let dso_url = format!("{}libxls.{}", url_base, dso_extension.unwrap());
     let tarball_url = format!("{}/dslx_stdlib.tar.gz", url_base);
     let out_dir = std::env::var("OUT_DIR").unwrap();
-    let dso_path = PathBuf::from(&out_dir).join(format!(
+    let dso_name = format!(
         "libxls-{}.{}",
         DSO_VERSION_TAG,
         dso_extension.unwrap()
-    ));
+    );
+    let dso_path = PathBuf::from(&out_dir).join(&dso_name);
 
     // Check if the DSO has already been downloaded
     if dso_path.exists() {
@@ -60,6 +61,22 @@ fn main() {
             std::fs::remove_file(&dso_path).expect("Failed to remove file");
             panic!("Download failed with status: {:?}", status);
         }
+
+	#[cfg(target_os = "macos")]
+	{
+	    println!("cargo:info=Fixing DSO id: to {}", dso_name);
+            // Download the DSO id
+            let status = Command::new("install_name_tool")
+		.arg("-id")
+		.arg(format!("@rpath/{}", &dso_name))
+		.arg(&dso_path)
+		.status()
+		.expect("Failed to fix DSO id");
+	    
+            if !status.success() {
+		panic!("Fixing DSO id failed with status: {:?}", status);
+            }
+	}
     }
 
     let stdlib_path = PathBuf::from(&out_dir).join(format!("dslx_stdlib_{}", DSO_VERSION_TAG));

--- a/build.rs
+++ b/build.rs
@@ -92,7 +92,7 @@ fn main() {
     // Ensure the DSO is copied to the correct location
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-link-search=native={}", out_dir);
-    println!("cargo:rustc-link-lib={}-{}", "xls", DSO_VERSION_TAG);
+    println!("cargo:rustc-link-lib=dylib={}-{}", "xls", DSO_VERSION_TAG);
     println!("cargo:rustc-env=XLS_DSO_VERSION_TAG={}", DSO_VERSION_TAG);
     println!("cargo:rustc-env=XLS_DSO_PATH={}", out_dir);
     println!(

--- a/build.rs
+++ b/build.rs
@@ -27,12 +27,11 @@ fn main() {
     let dso_url = format!("{}libxls.{}", url_base, dso_extension.unwrap());
     let tarball_url = format!("{}/dslx_stdlib.tar.gz", url_base);
     let out_dir = std::env::var("OUT_DIR").unwrap();
-    let dso_name = format!(
+    let dso_path = PathBuf::from(&out_dir).join(format!(
         "libxls-{}.{}",
         DSO_VERSION_TAG,
         dso_extension.unwrap()
-    );
-    let dso_path = PathBuf::from(&out_dir).join(&dso_name);
+    ));
 
     // Check if the DSO has already been downloaded
     if dso_path.exists() {
@@ -92,8 +91,8 @@ fn main() {
 
     // Ensure the DSO is copied to the correct location
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rustc-link-search={}", out_dir);
-    println!("cargo:rustc-link-lib=dylib:+verbatim={}", dso_name);
+    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-lib=dylib=xls-{}", DSO_VERSION_TAG);
     println!("cargo:rustc-env=XLS_DSO_VERSION_TAG={}", DSO_VERSION_TAG);
     println!("cargo:rustc-env=XLS_DSO_PATH={}", out_dir);
     println!(

--- a/build.rs
+++ b/build.rs
@@ -94,7 +94,7 @@ fn main() {
     println!("cargo:rustc-link-search=native={}", out_dir);
     println!("cargo:rustc-link-lib={}-{}", "xls", DSO_VERSION_TAG);
     println!("cargo:rustc-env=XLS_DSO_VERSION_TAG={}", DSO_VERSION_TAG);
-    println!("cargo:rustc-env=XLS_DSO_PATH={}", out_dir);    
+    println!("cargo:rustc-env=XLS_DSO_PATH={}", out_dir);
     println!(
         "cargo:rustc-env=DSLX_STDLIB_PATH={}/xls/dslx/stdlib/",
         stdlib_path.display()

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -2,97 +2,154 @@
 
 //! Wrappers around the C API for the XLS dynamic shared object.
 
-use libloading::{Library, Symbol};
-use once_cell::sync::OnceCell;
 use std::ffi::CString;
-use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::ir_package::{IrFunctionType, IrPackagePtr, IrType};
 use crate::ir_value::IrValue;
 use crate::xlsynth_error::XlsynthError;
 
 extern crate libc;
-extern crate libloading;
 
-const DSO_VERSION_TAG: &str = env!("XLS_DSO_VERSION_TAG");
+mod ffi {
+    #[repr(C)]
+    pub struct CIrValue {
+        _private: [u8; 0], // Ensures the struct cannot be instantiated
+    }
 
-static LIBRARY: OnceCell<Mutex<Library>> = OnceCell::new();
+    #[repr(C)]
+    pub struct CIrPackage {
+        _private: [u8; 0], // Ensures the struct cannot be instantiated
+    }
 
-fn get_library() -> &'static Mutex<Library> {
-    LIBRARY.get_or_init(|| {
-        let dso_extension = if cfg!(target_os = "macos") {
-            "dylib"
-        } else if cfg!(target_os = "linux") {
-            "so"
-        } else {
-            panic!("Running on an unknown OS");
-        };
-        let so_filename = format!("libxls-{}.{}", DSO_VERSION_TAG, dso_extension);
-        let library = unsafe {
-            Library::new(so_filename.clone()).expect("dynamic library should be present")
-        };
-        Mutex::new(library)
-    })
+    #[repr(C)]
+    pub struct CIrFunction {
+        _private: [u8; 0], // Ensures the struct cannot be instantiated
+    }
+
+    #[repr(C)]
+    pub(crate) struct CIrType {
+        _private: [u8; 0], // Ensures the struct cannot be instantiated
+    }
+
+    #[repr(C)]
+    pub(crate) struct CIrFunctionType {
+        _private: [u8; 0], // Ensures the struct cannot be instantiated
+    }
+
+    pub type XlsFormatPreference = i32;
+
+    extern "C" {
+        pub fn xls_convert_dslx_to_ir(
+            dslx: *const std::os::raw::c_char,
+            path: *const std::os::raw::c_char,
+            module_name: *const std::os::raw::c_char,
+            dslx_stdlib_path: *const std::os::raw::c_char,
+            additional_search_paths: *const *const std::os::raw::c_char,
+            additional_search_paths_count: libc::size_t,
+            error_out: *mut *mut std::os::raw::c_char,
+            ir_out: *mut *mut std::os::raw::c_char,
+        ) -> bool;
+        pub fn xls_parse_typed_value(
+            text: *const std::os::raw::c_char,
+            error_out: *mut *mut std::os::raw::c_char,
+            value_out: *mut *mut CIrValue,
+        ) -> bool;
+        pub fn xls_value_free(value: *mut CIrValue);
+        pub fn xls_package_free(package: *mut CIrPackage);
+        pub fn xls_value_to_string(
+            value: *const CIrValue,
+            str_out: *mut *mut std::os::raw::c_char,
+        ) -> bool;
+        pub fn xls_format_preference_from_string(
+            s: *const std::os::raw::c_char,
+            error_out: *mut *mut std::os::raw::c_char,
+            result_out: *mut XlsFormatPreference,
+        ) -> bool;
+        pub fn xls_value_to_string_format_preference(
+            value: *const CIrValue,
+            fmt: XlsFormatPreference,
+            error_out: *mut *mut std::os::raw::c_char,
+            str_out: *mut *mut std::os::raw::c_char,
+        ) -> bool;
+        pub fn xls_value_eq(value: *const CIrValue, value: *const CIrValue) -> bool;
+        pub fn xls_parse_ir_package(
+            ir: *const std::os::raw::c_char,
+            filename: *const std::os::raw::c_char,
+            error_out: *mut *mut std::os::raw::c_char,
+            xls_package_out: *mut *mut CIrPackage,
+        ) -> bool;
+        pub fn xls_type_to_string(
+            t: *const CIrType,
+            error_out: *mut *mut std::os::raw::c_char,
+            result_out: *mut *mut std::os::raw::c_char,
+        ) -> bool;
+        pub fn xls_package_get_type_for_value(
+            package: *const CIrPackage,
+            value: *const CIrValue,
+            error_out: *mut *mut std::os::raw::c_char,
+            result_out: *mut *mut CIrType,
+        ) -> bool;
+        pub fn xls_package_get_function(
+            package: *const CIrPackage,
+            function_name: *const std::os::raw::c_char,
+            error_out: *mut *mut std::os::raw::c_char,
+            result_out: *mut *mut CIrFunction,
+        ) -> bool;
+        pub fn xls_function_get_type(
+            function: *const CIrFunction,
+            error_out: *mut *mut std::os::raw::c_char,
+            xls_fn_type_out: *mut *mut CIrFunctionType,
+        ) -> bool;
+        pub fn xls_function_type_to_string(
+            t: *const CIrFunctionType,
+            error_out: *mut *mut std::os::raw::c_char,
+            string_out: *mut *mut std::os::raw::c_char,
+        ) -> bool;
+        pub fn xls_function_get_name(
+            function: *const CIrFunction,
+            error_out: *mut *mut std::os::raw::c_char,
+            name_out: *mut *mut std::os::raw::c_char,
+        ) -> bool;
+        pub fn xls_interpret_function(
+            function: *const CIrFunction,
+            argc: libc::size_t,
+            args: *const *const CIrValue,
+            error_out: *mut *mut std::os::raw::c_char,
+            result_out: *mut *mut CIrValue,
+        ) -> bool;
+        pub fn xls_optimize_ir(
+            ir: *const std::os::raw::c_char,
+            top: *const std::os::raw::c_char,
+            error_out: *mut *mut std::os::raw::c_char,
+            ir_out: *mut *mut std::os::raw::c_char,
+        ) -> bool;
+        pub fn xls_mangle_dslx_name(
+            module_name: *const std::os::raw::c_char,
+            function_name: *const std::os::raw::c_char,
+            error_out: *mut *mut std::os::raw::c_char,
+            mangled_out: *mut *mut std::os::raw::c_char,
+        ) -> bool;
+        pub fn xls_package_to_string(
+            p: *const CIrPackage,
+            string_out: *mut *mut std::os::raw::c_char,
+        ) -> bool;
+    }
 }
 
-#[repr(C)]
-pub(crate) struct CIrValue {
-    _private: [u8; 0], // Ensures the struct cannot be instantiated
-}
-
-#[repr(C)]
-pub(crate) struct CIrPackage {
-    _private: [u8; 0], // Ensures the struct cannot be instantiated
-}
-
-#[repr(C)]
-pub(crate) struct CIrFunction {
-    _private: [u8; 0], // Ensures the struct cannot be instantiated
-}
-
-#[repr(C)]
-pub(crate) struct CIrType {
-    _private: [u8; 0], // Ensures the struct cannot be instantiated
-}
-
-#[repr(C)]
-pub(crate) struct CIrFunctionType {
-    _private: [u8; 0], // Ensures the struct cannot be instantiated
-}
-
-pub(crate) type XlsFormatPreference = i32;
-
-type XlsValueToString =
-    unsafe extern "C" fn(value: *const CIrValue, str_out: *mut *mut std::os::raw::c_char) -> bool;
+pub(crate) type CIrValue = ffi::CIrValue;
+pub(crate) type CIrPackage = ffi::CIrPackage;
+pub(crate) type CIrFunction = ffi::CIrFunction;
+pub(crate) type CIrFunctionType = ffi::CIrFunctionType;
+pub(crate) type CIrType = ffi::CIrType;
+pub(crate) type XlsFormatPreference = ffi::XlsFormatPreference;
 
 pub fn xls_convert_dslx_to_ir(dslx: &str, path: &std::path::Path) -> Result<String, XlsynthError> {
-    type XlsConvertDslxToIr = unsafe extern "C" fn(
-        dslx: *const std::os::raw::c_char,
-        path: *const std::os::raw::c_char,
-        module_name: *const std::os::raw::c_char,
-        dslx_stdlib_path: *const std::os::raw::c_char,
-        additional_search_paths: *const *const std::os::raw::c_char,
-        additional_search_paths_count: libc::size_t,
-        error_out: *mut *mut std::os::raw::c_char,
-        ir_out: *mut *mut std::os::raw::c_char,
-    ) -> bool;
-
     // Extract the module name from the path; e.g. "foo/bar/baz.x" -> "baz"
     let module_name = path.file_stem().unwrap().to_str().unwrap();
     let path_str = path.to_str().unwrap();
 
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym_convert_dslx_to_ir: Symbol<XlsConvertDslxToIr> =
-            match lib.get(b"xls_convert_dslx_to_ir") {
-                Ok(f) => f,
-                Err(e) => {
-                    return Err(XlsynthError(format!(
-                        "Failed to load symbol `xls_convert_dslx_to_ir`: {}",
-                        e
-                    )))
-                }
-            };
         let dslx = CString::new(dslx).unwrap();
         let c_path = CString::new(path_str).unwrap();
         let c_module_name = CString::new(module_name).unwrap();
@@ -105,7 +162,7 @@ pub fn xls_convert_dslx_to_ir(dslx: &str, path: &std::path::Path) -> Result<Stri
         let mut ir_out: *mut std::os::raw::c_char = std::ptr::null_mut();
 
         // Call the function
-        let success = dlsym_convert_dslx_to_ir(
+        let success = ffi::xls_convert_dslx_to_ir(
             dslx.as_ptr(),
             c_path.as_ptr(),
             c_module_name.as_ptr(),
@@ -135,27 +192,11 @@ pub fn xls_convert_dslx_to_ir(dslx: &str, path: &std::path::Path) -> Result<Stri
 }
 
 pub fn xls_parse_typed_value(s: &str) -> Result<IrValue, XlsynthError> {
-    type XlsParseTypedValue = unsafe extern "C" fn(
-        text: *const std::os::raw::c_char,
-        error_out: *mut *mut std::os::raw::c_char,
-        value_out: *mut *mut CIrValue,
-    ) -> bool;
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsParseTypedValue> = match lib.get(b"xls_parse_typed_value") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_parse_typed_value`: {}",
-                    e
-                )))
-            }
-        };
-
         let c_str = CString::new(s).unwrap();
         let mut ir_value_out: *mut CIrValue = std::ptr::null_mut();
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = dlsym(c_str.as_ptr(), &mut error_out, &mut ir_value_out);
+        let success = ffi::xls_parse_typed_value(c_str.as_ptr(), &mut error_out, &mut ir_value_out);
         if success {
             return Ok(IrValue { ptr: ir_value_out });
         } else {
@@ -171,54 +212,22 @@ pub fn xls_parse_typed_value(s: &str) -> Result<IrValue, XlsynthError> {
 
 pub(crate) fn xls_value_free(p: *mut CIrValue) -> Result<(), XlsynthError> {
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<unsafe extern "C" fn(*mut CIrValue)> = match lib.get(b"xls_value_free") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_value_free`: {}",
-                    e
-                )))
-            }
-        };
-        dlsym(p);
+        ffi::xls_value_free(p);
         return Ok(());
     }
 }
 
 pub(crate) fn xls_package_free(p: *mut CIrPackage) -> Result<(), XlsynthError> {
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<unsafe extern "C" fn(*mut CIrPackage)> =
-            match lib.get(b"xls_package_free") {
-                Ok(f) => f,
-                Err(e) => {
-                    return Err(XlsynthError(format!(
-                        "Failed to load symbol `xls_package_free`: {}",
-                        e
-                    )))
-                }
-            };
-        dlsym(p);
+        ffi::xls_package_free(p);
         return Ok(());
     }
 }
 
 pub(crate) fn xls_value_to_string(p: *mut CIrValue) -> Result<String, XlsynthError> {
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsValueToString> = match lib.get(b"xls_value_to_string") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_value_to_string`: {}",
-                    e
-                )))
-            }
-        };
-
         let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = dlsym(p, &mut c_str_out);
+        let success = ffi::xls_value_to_string(p, &mut c_str_out);
         if success {
             let s: String = if !c_str_out.is_null() {
                 CString::from_raw(c_str_out).into_string().unwrap()
@@ -227,45 +236,19 @@ pub(crate) fn xls_value_to_string(p: *mut CIrValue) -> Result<String, XlsynthErr
             };
             return Ok(s);
         }
-        return Err(XlsynthError(
-            "Failed to convert XLS value to string via C API".to_string(),
-        ));
+        return Err(XlsynthError("Failed to convert XLS value to string via C API".to_string()));
     }
 }
 
 pub(crate) fn xls_format_preference_from_string(
     s: &str,
 ) -> Result<XlsFormatPreference, XlsynthError> {
-    // Invokes the function with signature:
-    // ```c
-    // bool xls_format_preference_from_string(const char* s, char** error_out,
-    //   xls_format_preference* result_out);
-    // ```
-    //
-    // Note that the format preference enum is `int32_t``.
-    type XlsFormatPreferenceFromString = unsafe extern "C" fn(
-        s: *const std::os::raw::c_char,
-        error_out: *mut *mut std::os::raw::c_char,
-        result_out: *mut XlsFormatPreference,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsFormatPreferenceFromString> =
-            match lib.get(b"xls_format_preference_from_string") {
-                Ok(f) => f,
-                Err(e) => {
-                    return Err(XlsynthError(format!(
-                        "Failed to load symbol `xls_format_preference_from_string`: {}",
-                        e
-                    )))
-                }
-            };
-
         let c_str = CString::new(s).unwrap();
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut result_out: XlsFormatPreference = -1;
-        let success = dlsym(c_str.as_ptr(), &mut error_out, &mut result_out);
+        let success =
+            ffi::xls_format_preference_from_string(c_str.as_ptr(), &mut error_out, &mut result_out);
         if success {
             return Ok(result_out);
         }
@@ -282,29 +265,11 @@ pub(crate) fn xls_value_to_string_format_preference(
     p: *mut CIrValue,
     fmt: XlsFormatPreference,
 ) -> Result<String, XlsynthError> {
-    type XlsValueToStringFormatPreference = unsafe extern "C" fn(
-        value: *const CIrValue,
-        fmt: XlsFormatPreference,
-        error_out: *mut *mut std::os::raw::c_char,
-        str_out: *mut *mut std::os::raw::c_char,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsValueToStringFormatPreference> =
-            match lib.get(b"xls_value_to_string_format_preference") {
-                Ok(f) => f,
-                Err(e) => {
-                    return Err(XlsynthError(format!(
-                        "Failed to load symbol `xls_value_to_string_format_preference`: {}",
-                        e
-                    )))
-                }
-            };
-
         let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = dlsym(p, fmt, &mut error_out, &mut c_str_out);
+        let success =
+            ffi::xls_value_to_string_format_preference(p, fmt, &mut error_out, &mut c_str_out);
         if success {
             let s: String = if !c_str_out.is_null() {
                 CString::from_raw(c_str_out).into_string().unwrap()
@@ -313,9 +278,7 @@ pub(crate) fn xls_value_to_string_format_preference(
             };
             return Ok(s);
         }
-        return Err(XlsynthError(
-            "Failed to convert XLS value to string via C API".to_string(),
-        ));
+        return Err(XlsynthError("Failed to convert XLS value to string via C API".to_string()));
     }
 }
 
@@ -324,18 +287,7 @@ pub(crate) fn xls_value_eq(
     rhs: *const CIrValue,
 ) -> Result<bool, XlsynthError> {
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<unsafe extern "C" fn(*const CIrValue, *const CIrValue) -> bool> =
-            match lib.get(b"xls_value_eq") {
-                Ok(f) => f,
-                Err(e) => {
-                    return Err(XlsynthError(format!(
-                        "Failed to load symbol `xls_value_eq`: {}",
-                        e
-                    )))
-                }
-            };
-        return Ok(dlsym(lhs, rhs));
+        return Ok(ffi::xls_value_eq(lhs, rhs));
     }
 }
 
@@ -350,25 +302,7 @@ pub(crate) fn xls_parse_ir_package(
     ir: &str,
     filename: Option<&str>,
 ) -> Result<crate::ir_package::IrPackage, XlsynthError> {
-    type XlsParseIrPackage = unsafe extern "C" fn(
-        ir: *const std::os::raw::c_char,
-        filename: *const std::os::raw::c_char,
-        error_out: *mut *mut std::os::raw::c_char,
-        xls_package_out: *mut *mut CIrPackage,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsParseIrPackage> = match lib.get(b"xls_parse_ir_package") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_parse_ir_package`: {}",
-                    e
-                )))
-            }
-        };
-
         let ir = CString::new(ir).unwrap();
         // The filename is allowed to be a null pointer if there is no filename.
         let filename_ptr = filename
@@ -377,7 +311,7 @@ pub(crate) fn xls_parse_ir_package(
             .unwrap_or(std::ptr::null());
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut xls_package_out: *mut CIrPackage = std::ptr::null_mut();
-        let success = dlsym(
+        let success = ffi::xls_parse_ir_package(
             ir.as_ptr(),
             filename_ptr,
             &mut error_out,
@@ -405,27 +339,10 @@ pub(crate) fn xls_parse_ir_package(
 /// char** result_out);
 /// ```
 pub(crate) fn xls_type_to_string(t: *const CIrType) -> Result<String, XlsynthError> {
-    type XlsTypeToString = unsafe extern "C" fn(
-        t: *const CIrType,
-        error_out: *mut *mut std::os::raw::c_char,
-        result_out: *mut *mut std::os::raw::c_char,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsTypeToString> = match lib.get(b"xls_type_to_string") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_type_to_string`: {}",
-                    e
-                )))
-            }
-        };
-
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = dlsym(t, &mut error_out, &mut c_str_out);
+        let success = ffi::xls_type_to_string(t, &mut error_out, &mut c_str_out);
         if success {
             let out_str = if !c_str_out.is_null() {
                 CString::from_raw(c_str_out).into_string().unwrap()
@@ -453,29 +370,11 @@ pub(crate) fn xls_package_get_type_for_value(
     package: *const CIrPackage,
     value: *const CIrValue,
 ) -> Result<IrType, XlsynthError> {
-    type XlsPackageGetTypeForValue = unsafe extern "C" fn(
-        package: *const CIrPackage,
-        value: *const CIrValue,
-        error_out: *mut *mut std::os::raw::c_char,
-        result_out: *mut *mut CIrType,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsPackageGetTypeForValue> =
-            match lib.get(b"xls_package_get_type_for_value") {
-                Ok(f) => f,
-                Err(e) => {
-                    return Err(XlsynthError(format!(
-                        "Failed to load symbol `xls_package_get_type_for_value`: {}",
-                        e
-                    )))
-                }
-            };
-
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut result_out: *mut CIrType = std::ptr::null_mut();
-        let success = dlsym(package, value, &mut error_out, &mut result_out);
+        let success =
+            ffi::xls_package_get_type_for_value(package, value, &mut error_out, &mut result_out);
         if success {
             let ir_type = IrType { ptr: result_out };
             return Ok(ir_type);
@@ -488,7 +387,6 @@ pub(crate) fn xls_package_get_type_for_value(
         return Err(XlsynthError(error_out_str));
     }
 }
-
 /// Bindings for the C API function:
 /// ```c
 /// bool xls_package_get_function(s
@@ -501,39 +399,19 @@ pub(crate) fn xls_package_get_function(
     guard: RwLockReadGuard<IrPackagePtr>,
     function_name: &str,
 ) -> Result<crate::ir_package::IrFunction, XlsynthError> {
-    type XlsPackageGetFunction = unsafe extern "C" fn(
-        package: *const CIrPackage,
-        function_name: *const std::os::raw::c_char,
-        error_out: *mut *mut std::os::raw::c_char,
-        result_out: *mut *mut CIrFunction,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsPackageGetFunction> = match lib.get(b"xls_package_get_function") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_package_get_function`: {}",
-                    e
-                )))
-            }
-        };
-
         let function_name = CString::new(function_name).unwrap();
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut result_out: *mut CIrFunction = std::ptr::null_mut();
-        let success = dlsym(
+        let success = ffi::xls_package_get_function(
             guard.const_c_ptr(),
             function_name.as_ptr(),
             &mut error_out,
             &mut result_out,
         );
         if success {
-            let function = crate::ir_package::IrFunction {
-                parent: package.clone(),
-                ptr: result_out,
-            };
+            let function =
+                crate::ir_package::IrFunction { parent: package.clone(), ptr: result_out };
             return Ok(function);
         }
         let error_out_str: String = if !error_out.is_null() {
@@ -554,31 +432,12 @@ pub(crate) fn xls_function_get_type(
     _package_write_guard: &RwLockWriteGuard<IrPackagePtr>,
     function: *const CIrFunction,
 ) -> Result<IrFunctionType, XlsynthError> {
-    type XlsFunctionGetType = unsafe extern "C" fn(
-        function: *const CIrFunction,
-        error_out: *mut *mut std::os::raw::c_char,
-        xls_fn_type_out: *mut *mut CIrFunctionType,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsFunctionGetType> = match lib.get(b"xls_function_get_type") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_function_get_type`: {}",
-                    e
-                )))
-            }
-        };
-
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut xls_fn_type_out: *mut CIrFunctionType = std::ptr::null_mut();
-        let success = dlsym(function, &mut error_out, &mut xls_fn_type_out);
+        let success = ffi::xls_function_get_type(function, &mut error_out, &mut xls_fn_type_out);
         if success {
-            let ir_type = IrFunctionType {
-                ptr: xls_fn_type_out,
-            };
+            let ir_type = IrFunctionType { ptr: xls_fn_type_out };
             return Ok(ir_type);
         }
         let error_out_str: String = if !error_out.is_null() {
@@ -598,27 +457,10 @@ pub(crate) fn xls_function_get_type(
 pub(crate) fn xls_function_type_to_string(
     t: *const CIrFunctionType,
 ) -> Result<String, XlsynthError> {
-    type XlsFunctionTypeToString = unsafe extern "C" fn(
-        t: *const CIrFunctionType,
-        error_out: *mut *mut std::os::raw::c_char,
-        string_out: *mut *mut std::os::raw::c_char,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsFunctionTypeToString> = match lib.get(b"xls_function_type_to_string") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_function_type_to_string`: {}",
-                    e
-                )))
-            }
-        };
-
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = dlsym(t, &mut error_out, &mut c_str_out);
+        let success = ffi::xls_function_type_to_string(t, &mut error_out, &mut c_str_out);
         if success {
             let out_str = if !c_str_out.is_null() {
                 CString::from_raw(c_str_out).into_string().unwrap()
@@ -637,27 +479,10 @@ pub(crate) fn xls_function_type_to_string(
 }
 
 pub(crate) fn xls_function_get_name(function: *const CIrFunction) -> Result<String, XlsynthError> {
-    type XlsFunctionGetName = unsafe extern "C" fn(
-        function: *const CIrFunction,
-        error_out: *mut *mut std::os::raw::c_char,
-        name_out: *mut *mut std::os::raw::c_char,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsFunctionGetName> = match lib.get(b"xls_function_get_name") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_function_get_name`: {}",
-                    e
-                )))
-            }
-        };
-
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = dlsym(function, &mut error_out, &mut c_str_out);
+        let success = ffi::xls_function_get_name(function, &mut error_out, &mut c_str_out);
         if success {
             let out_str = if !c_str_out.is_null() {
                 CString::from_raw(c_str_out).into_string().unwrap()
@@ -687,32 +512,13 @@ pub(crate) fn xls_interpret_function(
     function: *const CIrFunction,
     args: &[IrValue],
 ) -> Result<IrValue, XlsynthError> {
-    type XlsInterpretFunction = unsafe extern "C" fn(
-        function: *const CIrFunction,
-        argc: libc::size_t,
-        args: *const *const CIrValue,
-        error_out: *mut *mut std::os::raw::c_char,
-        result_out: *mut *mut CIrValue,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsInterpretFunction> = match lib.get(b"xls_interpret_function") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_interpret_function`: {}",
-                    e
-                )))
-            }
-        };
-
         let args_ptrs: Vec<*const CIrValue> =
             args.iter().map(|v| -> *const CIrValue { v.ptr }).collect();
         let argc = args_ptrs.len();
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut result_out: *mut CIrValue = std::ptr::null_mut();
-        let success = dlsym(
+        let success = ffi::xls_interpret_function(
             function,
             argc,
             args_ptrs.as_ptr(),
@@ -738,30 +544,12 @@ pub(crate) fn xls_interpret_function(
 /// char** ir_out);
 /// ```
 pub(crate) fn xls_optimize_ir(ir: &str, top: &str) -> Result<String, XlsynthError> {
-    type XlsOptimizeIr = unsafe extern "C" fn(
-        ir: *const std::os::raw::c_char,
-        top: *const std::os::raw::c_char,
-        error_out: *mut *mut std::os::raw::c_char,
-        ir_out: *mut *mut std::os::raw::c_char,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsOptimizeIr> = match lib.get(b"xls_optimize_ir") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_optimize_ir`: {}",
-                    e
-                )))
-            }
-        };
-
         let ir = CString::new(ir).unwrap();
         let top = CString::new(top).unwrap();
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut ir_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = dlsym(ir.as_ptr(), top.as_ptr(), &mut error_out, &mut ir_out);
+        let success = ffi::xls_optimize_ir(ir.as_ptr(), top.as_ptr(), &mut error_out, &mut ir_out);
         if success {
             let ir_out_str = if !ir_out.is_null() {
                 CString::from_raw(ir_out).into_string().unwrap()
@@ -788,30 +576,12 @@ pub(crate) fn xls_mangle_dslx_name(
     module_name: &str,
     function_name: &str,
 ) -> Result<String, XlsynthError> {
-    type XlsMangleDslxName = unsafe extern "C" fn(
-        module_name: *const std::os::raw::c_char,
-        function_name: *const std::os::raw::c_char,
-        error_out: *mut *mut std::os::raw::c_char,
-        mangled_out: *mut *mut std::os::raw::c_char,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsMangleDslxName> = match lib.get(b"xls_mangle_dslx_name") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_mangle_dslx_name`: {}",
-                    e
-                )))
-            }
-        };
-
         let module_name = CString::new(module_name).unwrap();
         let function_name = CString::new(function_name).unwrap();
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut mangled_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = dlsym(
+        let success = ffi::xls_mangle_dslx_name(
             module_name.as_ptr(),
             function_name.as_ptr(),
             &mut error_out,
@@ -839,25 +609,9 @@ pub(crate) fn xls_mangle_dslx_name(
 /// bool xls_package_to_string(const struct xls_package* p, char** string_out) {
 /// ```
 pub(crate) fn xls_package_to_string(p: *const CIrPackage) -> Result<String, XlsynthError> {
-    type XlsPackageToString = unsafe extern "C" fn(
-        p: *const CIrPackage,
-        string_out: *mut *mut std::os::raw::c_char,
-    ) -> bool;
-
     unsafe {
-        let lib = get_library().lock().unwrap();
-        let dlsym: Symbol<XlsPackageToString> = match lib.get(b"xls_package_to_string") {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(XlsynthError(format!(
-                    "Failed to load symbol `xls_package_to_string`: {}",
-                    e
-                )))
-            }
-        };
-
         let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = dlsym(p, &mut c_str_out);
+        let success = ffi::xls_package_to_string(p, &mut c_str_out);
         if success {
             let s: String = if !c_str_out.is_null() {
                 CString::from_raw(c_str_out).into_string().unwrap()
@@ -866,9 +620,7 @@ pub(crate) fn xls_package_to_string(p: *const CIrPackage) -> Result<String, Xlsy
             };
             return Ok(s);
         }
-        return Err(XlsynthError(
-            "Failed to convert XLS package to string via C API".to_string(),
-        ));
+        return Err(XlsynthError("Failed to convert XLS package to string via C API".to_string()));
     }
 }
 
@@ -899,7 +651,10 @@ fn __test_mod__f(x: bits[32]) -> bits[32] {
     #[test]
     fn test_parse_typed_value_garbage() {
         let e: XlsynthError = xls_parse_typed_value("asdf").expect_err("should not parse");
-        assert_eq!(e.0, "INVALID_ARGUMENT: Expected token of type \"(\" @ 1:1, but found: Token(\"ident\", value=\"asdf\") @ 1:1");
+        assert_eq!(
+            e.0,
+            "INVALID_ARGUMENT: Expected token of type \"(\" @ 1:1, but found: Token(\"ident\", value=\"asdf\") @ 1:1"
+        );
     }
 
     #[test]

--- a/tests/readme_test.rs
+++ b/tests/readme_test.rs
@@ -5,5 +5,7 @@ extern crate docmatic;
 #[test]
 fn test_readme() {
     let readme_path = "README.md";
-    docmatic::assert_file(readme_path);
+    docmatic::Assert::default()
+        .library_path(env!("XLS_DSO_PATH"))
+        .test_file(readme_path);
 }


### PR DESCRIPTION
This add `rustc` cargo directives to link to `libxls` dso using regular C compiler flags (`-L` and `-l`) rather than relying on `libloading`.

This has the advantage of decoupling `c_api.rs` from the linkage type and can also allow static linking (and thus fixes #1) in bazel based environment.

This also patch the DSO using `install_name_tool` so that ld doesn't fail to link by trying to discover it from the bazel build path.