### PR TITLE
Make VAST API accessible and add API function for instantiation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "curl",
  "docmatic",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-sys"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "curl",
  "flate2",

--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-sys"
-version = "0.0.24"
+version = "0.0.25"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust (Native Library)"

--- a/xlsynth/Cargo.toml
+++ b/xlsynth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth"
-version = "0.0.24"
+version = "0.0.25"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/xlsynth"
 homepage = "https://github.com/xlsynth/xlsynth-crate"
 
 [dependencies]
-xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.24"}
+xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.25"}
 
 [dev-dependencies]
 docmatic = "0.1.2"

--- a/xlsynth/tests/vast_test.rs
+++ b/xlsynth/tests/vast_test.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use xlsynth::vast::*;
+
+    #[test]
+    fn test_vast() {
+        let mut file = VastFile::new(VastFileType::Verilog);
+        let mut module = file.add_module("main");
+        let input_type = file.make_bit_vector_type(32, false);
+        let output_type = file.make_scalar_type();
+        module.add_input("in", &input_type);
+        module.add_output("out", &output_type);
+        let verilog = file.emit();
+        let want = "module main(\n  input wire [31:0] in,\n  output wire out\n);\n\nendmodule\n";
+        assert_eq!(verilog, want);
+    }
+
+    #[test]
+    fn test_continuous_assignment_of_slice() {
+        let mut file = VastFile::new(VastFileType::Verilog);
+        let mut module = file.add_module("my_module");
+        let input_type = file.make_bit_vector_type(8, false);
+        let output_type = file.make_bit_vector_type(4, false);
+        let input = module.add_input("my_input", &input_type);
+        let output = module.add_output("my_output", &output_type);
+        let slice = file.make_slice(&input.to_indexable_expr(), 3, 0);
+        let assignment = file.make_continuous_assignment(&output.to_expr(), &slice.to_expr());
+        module.add_member_continuous_assignment(assignment);
+        let verilog = file.emit();
+        let want = "module my_module(
+  input wire [7:0] my_input,
+  output wire [3:0] my_output
+);
+  assign my_output = my_input[3:0];
+endmodule
+";
+        assert_eq!(verilog, want);
+    }
+
+    #[test]
+    fn test_instantiation() {
+        let mut file = VastFile::new(VastFileType::Verilog);
+
+        let data_type = file.make_bit_vector_type(8, false);
+
+        let mut a_module = file.add_module("A");
+        a_module.add_output("bus", &data_type);
+
+        let mut b_module = file.add_module("B");
+        let bus = b_module.add_wire("bus", &data_type);
+
+        // TODO(sherbst) 2024-09-16: Test parameters.
+
+        b_module.add_member_instantiation(file.make_instantiation(
+            "A",
+            "a_i",
+            &[],
+            &[],
+            &["bus"],
+            &[&bus.to_expr()],
+        ));
+
+        let verilog = file.emit();
+        let want = "module A(
+  output wire [7:0] bus
+);
+
+endmodule
+module B;
+  wire [7:0] bus;
+  A a_i (
+    .bus(bus)
+  );
+endmodule
+";
+        assert_eq!(verilog, want);
+    }
+}


### PR DESCRIPTION
This PR marks the structs and enums in `vast.rs` as `pub` to make them externally accessible, and adds tests of the external-facing API (`xlsynth/tests/vast_test.rs`). These tests are currently copies of tests in `xlsynth/src/vast.rs`.

Note: the instantiation test does not currently cover setting parameters values - I think that needs a mechanism for creating literal expressions, which I will implement in another PR.
