### PR TITLE
Enable creation of literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "curl",
  "docmatic",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-sys"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "curl",
  "flate2",

--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-sys"
-version = "0.0.25"
+version = "0.0.26"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust (Native Library)"

--- a/xlsynth/Cargo.toml
+++ b/xlsynth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth"
-version = "0.0.25"
+version = "0.0.26"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/xlsynth"
 homepage = "https://github.com/xlsynth/xlsynth-crate"
 
 [dependencies]
-xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.25"}
+xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.26"}
 
 [dev-dependencies]
 docmatic = "0.1.2"

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -28,7 +28,7 @@ pub enum IrFormatPreference {
 }
 
 impl IrFormatPreference {
-    fn to_string(&self) -> &'static str {
+    pub fn to_string(&self) -> &'static str {
         match self {
             IrFormatPreference::Default => "default",
             IrFormatPreference::Binary => "binary",

--- a/xlsynth/src/vast.rs
+++ b/xlsynth/src/vast.rs
@@ -12,7 +12,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::c_str_to_rust;
+use crate::{c_str_to_rust, XlsynthError};
 
 pub(crate) struct VastFilePtr(pub *mut sys::CVastFile);
 
@@ -244,6 +244,42 @@ impl VastFile {
         }
     }
 
+    /// Makes a literal expression from a string, `s`, using the given format,
+    /// `fmt`. `s` must be in the form `bits[N]:value`, where `N` is the bit
+    /// width and `value` is the value of the literal, expressed in decimal,
+    /// hex, or binary. For example, `s` might be "bits[16]:42" or
+    /// "bits[39]:0xABCD". `fmt` indicates how the literal should be formatted
+    /// in the output Verilog. Options include `default`, `binary`,
+    /// `signed_decimal`, `unsigned_decimal`, `hex`, `plain_binary`, and
+    /// `plain_hex`.
+    pub fn make_literal(&mut self, s: &str, fmt: &str) -> Result<Expr, XlsynthError> {
+        let v = crate::xls_parse_typed_value(s).unwrap();
+        let mut fmt = crate::xls_format_preference_from_string(fmt).unwrap();
+
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut literal_out: *mut sys::CVastLiteral = std::ptr::null_mut();
+
+        unsafe {
+            let success = sys::xls_vast_verilog_file_make_literal(
+                self.ptr.lock().unwrap().0,
+                v.to_bits().unwrap().ptr,
+                fmt,
+                true,
+                &mut error_out,
+                &mut literal_out,
+            );
+
+            if success {
+                Ok(Expr {
+                    inner: sys::xls_vast_literal_as_expression(literal_out),
+                    parent: self.ptr.clone(),
+                })
+            } else {
+                Err(XlsynthError(c_str_to_rust(error_out)))
+            }
+        }
+    }
+
     pub fn make_scalar_type(&mut self) -> VastDataType {
         let locked = self.ptr.lock().unwrap();
         let data_type = unsafe { sys::xls_vast_verilog_file_make_scalar_type(locked.0) };
@@ -343,13 +379,15 @@ endmodule
         let mut b_module = file.add_module("B");
         let bus = b_module.add_wire("bus", &data_type);
 
-        // TODO(sherbst) 2024-09-16: Test parameters.
+        let param_value = file
+            .make_literal("bits[32]:42", "unsigned_decimal")
+            .unwrap();
 
         b_module.add_member_instantiation(file.make_instantiation(
             "A",
             "a_i",
-            &[],
-            &[],
+            &["a_param"],
+            &[&param_value],
             &["bus"],
             &[&bus.to_expr()],
         ));
@@ -362,9 +400,30 @@ endmodule
 endmodule
 module B;
   wire [7:0] bus;
-  A a_i (
+  A #(
+    .a_param(32'd42)
+  ) a_i (
     .bus(bus)
   );
+endmodule
+";
+        assert_eq!(verilog, want);
+    }
+
+    #[test]
+    fn test_literal() {
+        let mut file = VastFile::new(VastFileType::Verilog);
+        let mut module = file.add_module("my_module");
+        let wire = module.add_wire("bus", &file.make_bit_vector_type(128, false));
+        let literal = file
+            .make_literal("bits[128]:0xFFEEDDCCBBAA99887766554433221100", "hex")
+            .unwrap();
+        let assignment = file.make_continuous_assignment(&wire.to_expr(), &literal);
+        module.add_member_continuous_assignment(assignment);
+        let verilog = file.emit();
+        let want = "module my_module;
+  wire [127:0] bus;
+  assign bus = 128'hffee_ddcc_bbaa_9988_7766_5544_3322_1100;
 endmodule
 ";
         assert_eq!(verilog, want);

--- a/xlsynth/tests/vast_test.rs
+++ b/xlsynth/tests/vast_test.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use xlsynth::vast::*;
+    use xlsynth::{ir_value::*, vast::*};
 
     #[test]
     fn test_vast() {
@@ -52,7 +52,7 @@ endmodule
         let bus = b_module.add_wire("bus", &data_type);
 
         let param_value = file
-            .make_literal("bits[32]:42", "unsigned_decimal")
+            .make_literal("bits[32]:42", &IrFormatPreference::UnsignedDecimal)
             .unwrap();
 
         b_module.add_member_instantiation(file.make_instantiation(
@@ -88,7 +88,10 @@ endmodule
         let mut module = file.add_module("my_module");
         let wire = module.add_wire("bus", &file.make_bit_vector_type(128, false));
         let literal = file
-            .make_literal("bits[128]:0xFFEEDDCCBBAA99887766554433221100", "hex")
+            .make_literal(
+                "bits[128]:0xFFEEDDCCBBAA99887766554433221100",
+                &IrFormatPreference::Hex,
+            )
             .unwrap();
         let assignment = file.make_continuous_assignment(&wire.to_expr(), &literal);
         module.add_member_continuous_assignment(assignment);


### PR DESCRIPTION
Provides a `make_literal` method for `VastFile` that accepts a literal value and format (both strings). The method returns an `Expr` that can be used in continuous assignments and for setting parameter values for module instances.