### PR TITLE
[dslx_bridge] Start generating struct definitions.

### DIFF
--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.0.95";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.0.98";
 
 struct DsoInfo {
     extension: &'static str,

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -73,7 +73,13 @@ fn get_dso_info() -> DsoInfo {
     let lib_suffix = match (target_os.as_str(), target_arch.as_str()) {
         ("macos", "x86_64") => "x64",
         ("macos", "aarch64") => "arm64",
-        ("linux", "x86_64") => if is_rocky() { "rocky8" } else { "ubuntu2004" },
+        ("linux", "x86_64") => {
+            if is_rocky() {
+                "rocky8"
+            } else {
+                "ubuntu2004"
+            }
+        }
         _ => panic!(
             "Unhandled combination; target_os: {} target_arch: {}",
             target_os, target_arch

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -128,6 +128,11 @@ pub struct CDslxType {
 }
 
 #[repr(C)]
+pub struct CDslxTypeDim {
+    _private: [u8; 0], // Ensures the struct cannot be instantiated
+}
+
+#[repr(C)]
 pub struct CDslxExpr {
     _private: [u8; 0], // Ensures the struct cannot be instantiated
 }
@@ -183,6 +188,7 @@ extern "C" {
         bits_out: *mut *mut CIrBits,
     ) -> bool;
     pub fn xls_bits_free(bits: *mut CIrBits);
+    pub fn xls_bits_get_bit_count(bits: *const CIrBits) -> i64;
 
     pub fn xls_package_free(package: *mut CIrPackage);
     pub fn xls_c_str_free(c_str: *mut std::os::raw::c_char);
@@ -470,6 +476,12 @@ extern "C" {
         result_out: *mut *mut CIrValue,
     ) -> bool;
 
+    pub fn xls_dslx_type_to_string(
+        type_: *const CDslxType,
+        error_out: *mut *mut std::os::raw::c_char,
+        result_out: *mut *mut std::os::raw::c_char,
+    ) -> bool;    
+
     pub fn xls_dslx_type_info_get_const_expr(
         type_info: *mut CDslxTypeInfo,
         expr: *mut CDslxExpr,
@@ -488,6 +500,27 @@ extern "C" {
         error_out: *mut *mut std::os::raw::c_char,
         result_out: *mut bool,
     ) -> bool;
+
+    pub fn xls_dslx_type_is_bits_like(
+        type_: *const CDslxType,
+        is_signed: *mut *mut CDslxTypeDim,
+        size: *mut *mut CDslxTypeDim,
+    ) -> bool;
+
+    pub fn xls_dslx_type_dim_is_parametric(
+        dim: *const CDslxTypeDim,
+    ) -> bool;
+    pub fn xls_dslx_type_dim_get_as_bool(
+        dim: *const CDslxTypeDim,
+        error_out: *mut *mut std::os::raw::c_char,
+        result_out: *mut bool,
+    ) -> bool;
+    pub fn xls_dslx_type_dim_get_as_int64(
+        dim: *const CDslxTypeDim,
+        error_out: *mut *mut std::os::raw::c_char,
+        result_out: *mut i64,
+    ) -> bool;
+    pub fn xls_dslx_type_dim_free(dim: *mut CDslxTypeDim);
 }
 
 pub const DSLX_STDLIB_PATH: &str = env!("DSLX_STDLIB_PATH");

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -480,7 +480,7 @@ extern "C" {
         type_: *const CDslxType,
         error_out: *mut *mut std::os::raw::c_char,
         result_out: *mut *mut std::os::raw::c_char,
-    ) -> bool;    
+    ) -> bool;
 
     pub fn xls_dslx_type_info_get_const_expr(
         type_info: *mut CDslxTypeInfo,
@@ -507,9 +507,7 @@ extern "C" {
         size: *mut *mut CDslxTypeDim,
     ) -> bool;
 
-    pub fn xls_dslx_type_dim_is_parametric(
-        dim: *const CDslxTypeDim,
-    ) -> bool;
+    pub fn xls_dslx_type_dim_is_parametric(dim: *const CDslxTypeDim) -> bool;
     pub fn xls_dslx_type_dim_get_as_bool(
         dim: *const CDslxTypeDim,
         error_out: *mut *mut std::os::raw::c_char,

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -403,6 +403,10 @@ extern "C" {
         type_info: *mut CDslxTypeInfo,
         enum_def: *mut CDslxEnumDef,
     ) -> *mut CDslxType;
+    pub fn xls_dslx_type_info_get_type_struct_member(
+        type_info: *mut CDslxTypeInfo,
+        member: *mut CDslxStructMember,
+    ) -> *mut CDslxType;
     pub fn xls_dslx_type_info_get_type_type_alias(
         type_info: *mut CDslxTypeInfo,
         enum_def: *mut CDslxTypeAlias,

--- a/xlsynth/src/dslx.rs
+++ b/xlsynth/src/dslx.rs
@@ -261,10 +261,13 @@ impl StructDef {
     }
 
     pub fn get_member(&self, idx: usize) -> StructMember {
-        StructMember {
+        assert!(idx < self.get_member_count(), "member index out of bounds");
+        let result = StructMember {
             parent: self.parent.clone(),
             ptr: unsafe { sys::xls_dslx_struct_def_get_member(self.ptr, idx as i64) },
-        }
+        };
+        assert!(!result.ptr.is_null());
+        result
     }
 }
 
@@ -350,11 +353,68 @@ impl TypeInfo {
     }
 
     pub fn get_type_for_struct_member(&self, struct_member: &StructMember) -> Type {
-        Type {
+        assert!(!self.ptr.is_null());
+        assert!(!struct_member.ptr.is_null());
+        let result = Type {
             parent: self.parent.clone(),
             ptr: unsafe {
                 sys::xls_dslx_type_info_get_type_struct_member(self.ptr, struct_member.ptr)
             },
+        };
+        assert!(!result.ptr.is_null());
+        result
+    }
+}
+
+/// RAII-style wrapper around a `CDslxTypeDim` pointer that calls `free` on drop.
+struct TypeDimWrapper {
+    wrapped: *mut sys::CDslxTypeDim,
+}
+
+impl Drop for TypeDimWrapper {
+    fn drop(&mut self) {
+        unsafe {
+            sys::xls_dslx_type_dim_free(self.wrapped);
+        }
+    }
+}
+
+impl TypeDimWrapper {
+    fn is_parametric(&self) -> bool {
+        unsafe { sys::xls_dslx_type_dim_is_parametric(self.wrapped) }
+    }
+
+    fn get_as_bool(&self) -> Result<bool, XlsynthError> {
+        assert!(!self.wrapped.is_null());
+        let mut error_out = std::ptr::null_mut();
+        let mut result_out = false;
+        let success = unsafe {
+            sys::xls_dslx_type_dim_get_as_bool(self.wrapped, &mut error_out, &mut result_out)
+        };
+        if success {
+            assert!(error_out.is_null());
+            Ok(result_out)
+        } else {
+            assert!(!error_out.is_null());
+            let error_out_str: String = unsafe { c_str_to_rust(error_out) };
+            Err(XlsynthError(error_out_str))
+        }
+    }
+
+    fn get_as_i64(&self) -> Result<i64, XlsynthError> {
+        assert!(!self.wrapped.is_null());
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut result_out: i64 = 0;
+        let success = unsafe {
+            sys::xls_dslx_type_dim_get_as_int64(self.wrapped, &mut error_out, &mut result_out)
+        };
+        if success {
+            assert!(error_out.is_null());
+            Ok(result_out)
+        } else {
+            assert!(!error_out.is_null());
+            let error_out_str: String = unsafe { c_str_to_rust(error_out) };
+            Err(XlsynthError(error_out_str))
         }
     }
 }
@@ -364,7 +424,31 @@ pub struct Type {
     ptr: *mut sys::CDslxType,
 }
 
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_string().unwrap())
+    }
+}
+
 impl Type {
+    pub fn to_string(&self) -> Result<String, XlsynthError> {
+        let mut error_out = std::ptr::null_mut();
+        let mut result_out = std::ptr::null_mut();
+        let success = unsafe {
+            sys::xls_dslx_type_to_string(self.ptr, &mut error_out, &mut result_out)
+        };
+        if success {
+            assert!(error_out.is_null());
+            assert!(!result_out.is_null());
+            let result_out_str: String = unsafe { c_str_to_rust(result_out) };
+            Ok(result_out_str)
+        } else {
+            assert!(!error_out.is_null());
+            let error_out_str: String = unsafe { c_str_to_rust(error_out) };
+            Err(XlsynthError(error_out_str))
+        }
+    }
+
     pub fn get_total_bit_count(&self) -> Result<usize, XlsynthError> {
         let mut error_out = std::ptr::null_mut();
         let mut result_out = 0;
@@ -393,6 +477,26 @@ impl Type {
             assert!(!error_out.is_null());
             let error_out_str: String = unsafe { c_str_to_rust(error_out) };
             Err(XlsynthError(error_out_str))
+        }
+    }
+
+    /// Returns `Some((is_signed, bit_count))` if the type is bits-like, otherwise returns `None`.
+    pub fn is_bits_like(&self) -> Option<(bool, usize)> {
+        let mut is_signed = std::ptr::null_mut();
+        let mut size = std::ptr::null_mut();
+        let success = unsafe {
+            sys::xls_dslx_type_is_bits_like(self.ptr, &mut is_signed, &mut size)
+        };
+
+        let is_signed_wrapper = TypeDimWrapper { wrapped: is_signed };
+        let size_wrapper = TypeDimWrapper { wrapped: size };
+
+        if success {
+            let is_signed = is_signed_wrapper.get_as_bool().expect("get_as_bool success");
+            let size = size_wrapper.get_as_i64().expect("get_as_i64 success");
+            Some((is_signed, size as usize))
+        } else {
+            None
         }
     }
 }
@@ -499,13 +603,27 @@ mod tests {
         let member_a = struct_def.get_member(0);
         assert_eq!(member_a.get_name(), "a");
         let type_a = member_a.get_type();
-        let concrete_type_a = type_info.get_type_for_type_annotation(type_a);
-        assert_eq!(concrete_type_a.get_total_bit_count().unwrap(), 32);
+        // Inspect the inferred type information for the type AST node.
+        {
+            let concrete_type_a = type_info.get_type_for_type_annotation(type_a);
+            assert_eq!(concrete_type_a.to_string().unwrap(), "uN[32]");
+            assert_eq!(concrete_type_a.get_total_bit_count().unwrap(), 32);
+
+            let bits_like = concrete_type_a.is_bits_like().expect("u32 should be bits-like");
+            assert_eq!(bits_like, (false, 32));
+        }
 
         let member_b = struct_def.get_member(1);
         assert_eq!(member_b.get_name(), "b");
         let type_b = member_b.get_type();
-        let concrete_type_b = type_info.get_type_for_type_annotation(type_b);
-        assert_eq!(concrete_type_b.get_total_bit_count().unwrap(), 16);
+        // Inspect the inferred type information for the type AST node.
+        {
+            let concrete_type_b = type_info.get_type_for_type_annotation(type_b);
+            assert_eq!(concrete_type_b.to_string().unwrap(), "uN[16]");
+            assert_eq!(concrete_type_b.get_total_bit_count().unwrap(), 16);
+
+            let bits_like = concrete_type_b.is_bits_like().expect("u16 should be bits-like");
+            assert_eq!(bits_like, (false, 16));
+        }
     }
 }

--- a/xlsynth/src/dslx.rs
+++ b/xlsynth/src/dslx.rs
@@ -330,7 +330,7 @@ impl TypeInfo {
                 ptr: Rc::new(InterpValuePtr { ptr: result_out }),
             })
         } else {
-            assert!(!error_out.is_null());            
+            assert!(!error_out.is_null());
             let error_out_str: String = unsafe { c_str_to_rust(error_out) };
             Err(XlsynthError(error_out_str))
         }
@@ -366,7 +366,8 @@ impl TypeInfo {
     }
 }
 
-/// RAII-style wrapper around a `CDslxTypeDim` pointer that calls `free` on drop.
+/// RAII-style wrapper around a `CDslxTypeDim` pointer that calls `free` on
+/// drop.
 struct TypeDimWrapper {
     wrapped: *mut sys::CDslxTypeDim,
 }
@@ -434,9 +435,8 @@ impl Type {
     pub fn to_string(&self) -> Result<String, XlsynthError> {
         let mut error_out = std::ptr::null_mut();
         let mut result_out = std::ptr::null_mut();
-        let success = unsafe {
-            sys::xls_dslx_type_to_string(self.ptr, &mut error_out, &mut result_out)
-        };
+        let success =
+            unsafe { sys::xls_dslx_type_to_string(self.ptr, &mut error_out, &mut result_out) };
         if success {
             assert!(error_out.is_null());
             assert!(!result_out.is_null());
@@ -459,7 +459,7 @@ impl Type {
             assert!(error_out.is_null());
             Ok(result_out as usize)
         } else {
-            assert!(!error_out.is_null());            
+            assert!(!error_out.is_null());
             let error_out_str: String = unsafe { c_str_to_rust(error_out) };
             Err(XlsynthError(error_out_str))
         }
@@ -480,19 +480,21 @@ impl Type {
         }
     }
 
-    /// Returns `Some((is_signed, bit_count))` if the type is bits-like, otherwise returns `None`.
+    /// Returns `Some((is_signed, bit_count))` if the type is bits-like,
+    /// otherwise returns `None`.
     pub fn is_bits_like(&self) -> Option<(bool, usize)> {
         let mut is_signed = std::ptr::null_mut();
         let mut size = std::ptr::null_mut();
-        let success = unsafe {
-            sys::xls_dslx_type_is_bits_like(self.ptr, &mut is_signed, &mut size)
-        };
+        let success =
+            unsafe { sys::xls_dslx_type_is_bits_like(self.ptr, &mut is_signed, &mut size) };
 
         let is_signed_wrapper = TypeDimWrapper { wrapped: is_signed };
         let size_wrapper = TypeDimWrapper { wrapped: size };
 
         if success {
-            let is_signed = is_signed_wrapper.get_as_bool().expect("get_as_bool success");
+            let is_signed = is_signed_wrapper
+                .get_as_bool()
+                .expect("get_as_bool success");
             let size = size_wrapper.get_as_i64().expect("get_as_i64 success");
             Some((is_signed, size as usize))
         } else {
@@ -609,7 +611,9 @@ mod tests {
             assert_eq!(concrete_type_a.to_string().unwrap(), "uN[32]");
             assert_eq!(concrete_type_a.get_total_bit_count().unwrap(), 32);
 
-            let bits_like = concrete_type_a.is_bits_like().expect("u32 should be bits-like");
+            let bits_like = concrete_type_a
+                .is_bits_like()
+                .expect("u32 should be bits-like");
             assert_eq!(bits_like, (false, 32));
         }
 
@@ -622,7 +626,9 @@ mod tests {
             assert_eq!(concrete_type_b.to_string().unwrap(), "uN[16]");
             assert_eq!(concrete_type_b.get_total_bit_count().unwrap(), 16);
 
-            let bits_like = concrete_type_b.is_bits_like().expect("u16 should be bits-like");
+            let bits_like = concrete_type_b
+                .is_bits_like()
+                .expect("u16 should be bits-like");
             assert_eq!(bits_like, (false, 16));
         }
     }

--- a/xlsynth/src/dslx.rs
+++ b/xlsynth/src/dslx.rs
@@ -256,12 +256,9 @@ impl StructDef {
         unsafe { sys::xls_dslx_struct_def_is_parametric(self.ptr) }
     }
 
-    // TODO(cdleary): 2024-10-06 This implementation is missing from the library.
-    /*
     pub fn get_member_count(&self) -> usize {
         unsafe { sys::xls_dslx_struct_def_get_member_count(self.ptr) as usize }
     }
-    */
 
     pub fn get_member(&self, idx: usize) -> StructMember {
         StructMember {
@@ -349,6 +346,15 @@ impl TypeInfo {
         Type {
             parent: self.parent.clone(),
             ptr: unsafe { sys::xls_dslx_type_info_get_type_enum_def(self.ptr, enum_def.ptr) },
+        }
+    }
+
+    pub fn get_type_for_struct_member(&self, struct_member: &StructMember) -> Type {
+        Type {
+            parent: self.parent.clone(),
+            ptr: unsafe {
+                sys::xls_dslx_type_info_get_type_struct_member(self.ptr, struct_member.ptr)
+            },
         }
     }
 }
@@ -488,8 +494,7 @@ mod tests {
             .expect("struct definition");
         assert_eq!(struct_def.get_identifier(), "MyStruct");
 
-        // TODO(cdleary): 2024-10-06 This implementation is missing from the library.
-        // assert_eq!(struct_def.get_member_count(), 2);
+        assert_eq!(struct_def.get_member_count(), 2);
 
         let member_a = struct_def.get_member(0);
         assert_eq!(member_a.get_name(), "a");

--- a/xlsynth/src/dslx_bridge.rs
+++ b/xlsynth/src/dslx_bridge.rs
@@ -66,6 +66,23 @@ fn convert_enum_to_rust(
     Ok(lines.join("\n"))
 }
 
+fn convert_struct_to_rust(
+    struct_def: &dslx::StructDef,
+    type_info: &dslx::TypeInfo,
+) -> Result<String, XlsynthError> {
+    let mut lines: Vec<String> = vec![];
+    let struct_name = struct_def.get_identifier();
+    lines.push(format!("pub struct {} {{", struct_name));
+    for i in 0..struct_def.get_member_count() {
+        let member = struct_def.get_member(i);
+        let member_name = member.get_name();
+        let member_type = type_info.get_type_for_struct_member(&member);
+        todo!("convert struct member type to Rust type");
+    }
+    lines.push("}\n".to_string());
+    Ok(lines.join("\n"))
+}
+
 pub fn convert_leaf_module(
     import_data: &mut dslx::ImportData,
     dslx_program: &str,
@@ -93,7 +110,8 @@ pub fn convert_leaf_module(
                 chunks.push(convert_enum_to_rust(&enum_def, &type_info)?)
             }
             dslx::TypeDefinitionKind::StructDef => {
-                todo!("convert struct definition from DSLX to Rust")
+                let struct_def = module.get_type_definition_as_struct_def(i).unwrap();
+                chunks.push(convert_struct_to_rust(&struct_def, &type_info)?)
             }
             dslx::TypeDefinitionKind::TypeAlias => todo!("convert type alias from DSLX to Rust"),
             dslx::TypeDefinitionKind::ColonRef => todo!("convert colon ref from DSLX to Rust"),

--- a/xlsynth/src/dslx_bridge.rs
+++ b/xlsynth/src/dslx_bridge.rs
@@ -78,8 +78,12 @@ fn convert_struct_to_rust(
         let member_name = member.get_name();
         let member_type = type_info.get_type_for_struct_member(&member);
         if let Some((is_signed, bit_count)) = member_type.is_bits_like() {
-            lines.push(format!("    pub {}: Ir{}Bits<{}>,",
-                member_name, if is_signed { "S" } else { "U" }, bit_count));
+            lines.push(format!(
+                "    pub {}: Ir{}Bits<{}>,",
+                member_name,
+                if is_signed { "S" } else { "U" },
+                bit_count
+            ));
         } else {
             todo!("convert struct member type to Rust type: {}", member_type);
         }

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use xlsynth_sys::{CIrBits, CIrValue, xls_bits_get_bit_count};
+use xlsynth_sys::{xls_bits_get_bit_count, CIrBits, CIrValue};
 
 use crate::{
     xls_format_preference_from_string, xls_parse_typed_value, xls_value_eq, xls_value_free,
@@ -172,7 +172,8 @@ impl Drop for IrValue {
     }
 }
 
-/// Typed wrapper around an `IrBits` value that has a particular compile-time-known bit width and whose type notes the value
+/// Typed wrapper around an `IrBits` value that has a particular
+/// compile-time-known bit width and whose type notes the value
 /// should be treated as unsigned.
 pub struct IrUBits<const BIT_COUNT: usize> {
     wrapped: IrBits,
@@ -193,7 +194,8 @@ impl<const BIT_COUNT: usize> IrUBits<BIT_COUNT> {
     }
 }
 
-/// Typed wrapper around an `IrBits` value that has a particular compile-time-known bit width and whose type notes the value
+/// Typed wrapper around an `IrBits` value that has a particular
+/// compile-time-known bit width and whose type notes the value
 /// should be treated as signed.
 pub struct IrSBits<const BIT_COUNT: usize> {
     wrapped: IrBits,

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use xlsynth_sys::{CIrBits, CIrValue};
+use xlsynth_sys::{CIrBits, CIrValue, xls_bits_get_bit_count};
 
 use crate::{
     xls_format_preference_from_string, xls_parse_typed_value, xls_value_eq, xls_value_free,
@@ -11,6 +11,14 @@ use crate::{
 pub struct IrBits {
     #[allow(dead_code)]
     pub(crate) ptr: *mut CIrBits,
+}
+
+impl IrBits {
+    pub fn get_bit_count(&self) -> usize {
+        let bit_count = unsafe { xls_bits_get_bit_count(self.ptr) };
+        assert!(bit_count >= 0);
+        bit_count as usize
+    }
 }
 
 pub enum IrFormatPreference {
@@ -161,6 +169,48 @@ impl std::fmt::Debug for IrValue {
 impl Drop for IrValue {
     fn drop(&mut self) {
         xls_value_free(self.ptr).expect("dealloc success");
+    }
+}
+
+/// Typed wrapper around an `IrBits` value that has a particular compile-time-known bit width and whose type notes the value
+/// should be treated as unsigned.
+pub struct IrUBits<const BIT_COUNT: usize> {
+    wrapped: IrBits,
+}
+
+impl<const BIT_COUNT: usize> IrUBits<BIT_COUNT> {
+    const SIGNEDNESS: bool = false;
+
+    pub fn new(wrapped: IrBits) -> Result<Self, XlsynthError> {
+        if wrapped.get_bit_count() != BIT_COUNT {
+            return Err(XlsynthError(format!(
+                "Expected {} bits, got {}",
+                BIT_COUNT,
+                wrapped.get_bit_count()
+            )));
+        }
+        Ok(Self { wrapped })
+    }
+}
+
+/// Typed wrapper around an `IrBits` value that has a particular compile-time-known bit width and whose type notes the value
+/// should be treated as signed.
+pub struct IrSBits<const BIT_COUNT: usize> {
+    wrapped: IrBits,
+}
+
+impl<const BIT_COUNT: usize> IrSBits<BIT_COUNT> {
+    const SIGNEDNESS: bool = true;
+
+    pub fn new(wrapped: IrBits) -> Result<Self, XlsynthError> {
+        if wrapped.get_bit_count() != BIT_COUNT {
+            return Err(XlsynthError(format!(
+                "Expected {} bits, got {}",
+                BIT_COUNT,
+                wrapped.get_bit_count()
+            )));
+        }
+        Ok(Self { wrapped })
     }
 }
 

--- a/xlsynth/src/lib.rs
+++ b/xlsynth/src/lib.rs
@@ -11,7 +11,7 @@ use std::ffi::{CStr, CString};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use ir_package::{IrFunctionType, IrPackagePtr, IrType};
-pub use ir_value::{IrBits, IrUBits, IrSBits};
+pub use ir_value::{IrBits, IrSBits, IrUBits};
 use xlsynth_sys::{CIrBits, CIrPackage, CIrValue};
 use xlsynth_sys::{CIrFunction, CIrFunctionType, CIrType, XlsFormatPreference};
 

--- a/xlsynth/src/lib.rs
+++ b/xlsynth/src/lib.rs
@@ -11,7 +11,7 @@ use std::ffi::{CStr, CString};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use ir_package::{IrFunctionType, IrPackagePtr, IrType};
-use ir_value::IrBits;
+pub use ir_value::{IrBits, IrUBits, IrSBits};
 use xlsynth_sys::{CIrBits, CIrPackage, CIrValue};
 use xlsynth_sys::{CIrFunction, CIrFunctionType, CIrType, XlsFormatPreference};
 


### PR DESCRIPTION
Adds support for some new C APIs that help us reflect on struct definitions and their type information.

Also creates a typed wrapper around IrBits that imbues it with a constexpr signedness and bit count, which we use in struct definition generation.

Bumps DSO version required to v0.0.98.