### PR TITLE
[driver] Add ability to run dslx2pipeline via runtime APIs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "cargo_metadata",
  "env_logger 0.11.5",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-driver"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "clap",
  "env_logger 0.11.5",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-sys"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "curl",
  "flate2",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ use xlsynth::{IrValue, IrPackage, IrFunction, XlsynthError};
 fn sample() -> Result<IrValue, XlsynthError> {
     let package: IrPackage = xlsynth::convert_dslx_to_ir(
         "fn id(x: u32) -> u32 { x }",
-        std::path::Path::new("/memfile/sample.x"))?;
+        std::path::Path::new("/memfile/sample.x"),
+        &xlsynth::DslxConvertOptions::default())?;
     let mangled = xlsynth::mangle_dslx_name("sample", "id")?;
     let f: IrFunction = package.get_function(&mangled)?;
     let ft: IrValue = IrValue::parse_typed("bits[32]:42")?;

--- a/sample-usage/src/main.rs
+++ b/sample-usage/src/main.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use multithread::validate_all_threads_compute_add1;
+use xlsynth::DslxConvertOptions;
 
 // Show that the API works even if the Rust (caller) program is using an
 // alternative allocator.
@@ -27,7 +28,8 @@ fn load_and_invoke(
     let dslx = std::fs::read_to_string(&dslx_path)?;
 
     // Convert the DSLX to IR.
-    let package = xlsynth::convert_dslx_to_ir(&dslx, dslx_path.as_path())?;
+    let package =
+        xlsynth::convert_dslx_to_ir(&dslx, dslx_path.as_path(), &DslxConvertOptions::default())?;
     let dslx_module_name = dslx_path.file_stem().unwrap().to_str().unwrap();
 
     // Determine what the mangled name is in the converted IR package.

--- a/sample-usage/src/multithread.rs
+++ b/sample-usage/src/multithread.rs
@@ -3,6 +3,7 @@
 use lazy_static::lazy_static;
 ///! Example of multi-threaded invocation of XLS functions.
 use rayon::prelude::*;
+use xlsynth::DslxConvertOptions;
 use xlsynth::IrPackage;
 use xlsynth::IrValue;
 
@@ -10,7 +11,8 @@ fn load_package(cargo_relpath: &str) -> IrPackage {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(cargo_relpath);
     let dslx = std::fs::read_to_string(&path).expect("read_to_string failed");
     let package =
-        xlsynth::convert_dslx_to_ir(&dslx, path.as_path()).expect("convert_dslx_to_ir failed");
+        xlsynth::convert_dslx_to_ir(&dslx, path.as_path(), &DslxConvertOptions::default())
+            .expect("convert_dslx_to_ir failed");
     package
 }
 

--- a/xlsynth-driver/Cargo.toml
+++ b/xlsynth-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-driver"
-version = "0.0.51"
+version = "0.0.52"
 edition = "2021"
 
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/xlsynth"
 homepage = "https://github.com/xlsynth/xlsynth-crate"
 
 [dependencies]
-xlsynth = { path = "../xlsynth", version = "0.0.51" }
+xlsynth = { path = "../xlsynth", version = "0.0.52" }
 clap = "2.33"
 tempfile = "3.13"
 toml = "0.8.19"

--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-sys"
-version = "0.0.51"
+version = "0.0.52"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust (Native Library)"

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.0.118";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.0.120";
 
 struct DsoInfo {
     extension: &'static str,

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -197,6 +197,11 @@ pub struct CDslxModuleMember {
     _private: [u8; 0], // Ensures the struct cannot be instantiated
 }
 
+#[repr(C)]
+pub struct CScheduleAndCodegenResult {
+    _private: [u8; 0], // Ensures the struct cannot be instantiated
+}
+
 pub type XlsFormatPreference = i32;
 
 pub type VastFileType = i32;
@@ -448,6 +453,25 @@ extern "C" {
         error_out: *mut *mut std::os::raw::c_char,
         typechecked_module_out: *mut *mut CDslxTypecheckedModule,
     ) -> bool;
+
+    // bool xls_schedule_and_codegen_package(
+    // struct xls_package* p, const char* scheduling_options_flags_proto,
+    // const char* codegen_flags_proto, bool with_delay_model, char** error_out,
+    // struct xls_schedule_and_codegen_result** result_out);
+    pub fn xls_schedule_and_codegen_package(
+        p: *mut CIrPackage,
+        scheduling_options_flags_proto: *const std::os::raw::c_char,
+        codegen_flags_proto: *const std::os::raw::c_char,
+        with_delay_model: bool,
+        error_out: *mut *mut std::os::raw::c_char,
+        result_out: *mut *mut CScheduleAndCodegenResult,
+    ) -> bool;
+
+    pub fn xls_schedule_and_codegen_result_get_verilog_text(
+        result: *mut CScheduleAndCodegenResult,
+    ) -> *mut std::os::raw::c_char;
+
+    pub fn xls_schedule_and_codegen_result_free(result: *mut CScheduleAndCodegenResult);
 
     pub fn xls_dslx_typechecked_module_free(module: *mut CDslxTypecheckedModule);
 

--- a/xlsynth/Cargo.toml
+++ b/xlsynth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth"
-version = "0.0.51"
+version = "0.0.52"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust"
@@ -13,7 +13,7 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 readme = "../README.md"
 
 [dependencies]
-xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.51"}
+xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.52"}
 cargo_metadata = "0.18"
 log = "0.4"
 

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -3,8 +3,11 @@
 use xlsynth_sys::{xls_bits_get_bit_count, CIrBits, CIrValue};
 
 use crate::{
-    xls_format_preference_from_string, xls_parse_typed_value, xls_value_eq, xls_value_free,
-    xls_value_get_bits, xls_value_to_string, xls_value_to_string_format_preference,
+    lib_support::{
+        xls_format_preference_from_string, xls_value_eq, xls_value_free, xls_value_get_bits,
+        xls_value_to_string, xls_value_to_string_format_preference,
+    },
+    xls_parse_typed_value,
     xlsynth_error::XlsynthError,
 };
 

--- a/xlsynth/src/lib.rs
+++ b/xlsynth/src/lib.rs
@@ -4,42 +4,25 @@ pub mod dslx;
 pub mod dslx_bridge;
 pub mod ir_package;
 pub mod ir_value;
+mod lib_support;
 pub mod vast;
 pub mod xlsynth_error;
 
 pub mod rust_bridge_builder;
 pub mod sv_bridge_builder;
 
-use std::ffi::{CStr, CString};
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::ffi::CString;
 
-use ir_package::{IrFunctionType, IrPackagePtr, IrType};
+use ir_package::ScheduleAndCodegenResult;
 pub use ir_value::{IrBits, IrSBits, IrUBits};
-use xlsynth_sys::{CIrBits, CIrPackage, CIrValue};
-use xlsynth_sys::{CIrFunction, CIrFunctionType, CIrType, XlsFormatPreference};
+use lib_support::xls_schedule_and_codegen_package;
+use lib_support::{c_str_to_rust, xls_mangle_dslx_name, xls_optimize_ir};
 
 pub use ir_package::IrFunction;
 pub use ir_package::IrPackage;
 pub use ir_value::IrValue;
 pub use xlsynth_error::XlsynthError;
-
-/// Converts a C string that was given from the XLS library into a Rust string
-/// and deallocates the original C string.
-unsafe fn c_str_to_rust(xls_c_str: *mut std::os::raw::c_char) -> String {
-    if xls_c_str.is_null() {
-        return String::new();
-    }
-
-    let c_str: &CStr = CStr::from_ptr(xls_c_str);
-    let result: String = String::from_utf8_lossy(c_str.to_bytes()).to_string();
-
-    // We release the C string via a call to the XLS library so that it can use the
-    // same allocator it used to allocate the string for deallocation and we don't
-    // need to assume the Rust code and dynmic library are using the same underlying
-    // allocator.
-    xlsynth_sys::xls_c_str_free(xls_c_str);
-    result
-}
+use xlsynth_sys::CIrValue;
 
 pub fn dslx_path_to_module_name(path: &std::path::Path) -> Result<&str, XlsynthError> {
     let stem = path.file_stem();
@@ -69,7 +52,12 @@ impl<'a> Default for DslxConvertOptions<'a> {
     }
 }
 
-pub fn xls_convert_dslx_to_ir(
+/// Converts a DSLX module's source text into an IR package. Returns the IR
+/// text.
+///
+/// `options` allows specification of standard library path and additional
+/// search paths where we look for DSLX modules.
+pub fn convert_dslx_to_ir_text(
     dslx: &str,
     path: &std::path::Path,
     options: &DslxConvertOptions,
@@ -145,382 +133,38 @@ pub fn xls_parse_typed_value(s: &str) -> Result<IrValue, XlsynthError> {
     }
 }
 
-pub(crate) fn xls_value_free(p: *mut CIrValue) -> Result<(), XlsynthError> {
-    unsafe {
-        xlsynth_sys::xls_value_free(p);
-        return Ok(());
-    }
-}
-
-pub(crate) fn xls_package_free(p: *mut CIrPackage) -> Result<(), XlsynthError> {
-    unsafe {
-        xlsynth_sys::xls_package_free(p);
-        return Ok(());
-    }
-}
-
-pub(crate) fn xls_value_to_string(p: *mut CIrValue) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_value_to_string(p, &mut c_str_out);
-        if success {
-            return Ok(c_str_to_rust(c_str_out));
-        }
-        return Err(XlsynthError(
-            "Failed to convert XLS value to string via C API".to_string(),
-        ));
-    }
-}
-
-pub(crate) fn xls_value_get_bits(p: *const CIrValue) -> Result<IrBits, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut bits_out: *mut CIrBits = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_value_get_bits(p, &mut error_out, &mut bits_out);
-        if success {
-            return Ok(IrBits { ptr: bits_out });
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-pub(crate) fn xls_format_preference_from_string(
-    s: &str,
-) -> Result<XlsFormatPreference, XlsynthError> {
-    unsafe {
-        let c_str = CString::new(s).unwrap();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result_out: XlsFormatPreference = -1;
-        let success = xlsynth_sys::xls_format_preference_from_string(
-            c_str.as_ptr(),
-            &mut error_out,
-            &mut result_out,
-        );
-        if success {
-            return Ok(result_out);
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-pub(crate) fn xls_value_to_string_format_preference(
-    p: *mut CIrValue,
-    fmt: XlsFormatPreference,
-) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_value_to_string_format_preference(
-            p,
-            fmt,
-            &mut error_out,
-            &mut c_str_out,
-        );
-        if success {
-            return Ok(c_str_to_rust(c_str_out));
-        }
-        return Err(XlsynthError(
-            "Failed to convert XLS value to string via C API".to_string(),
-        ));
-    }
-}
-
-pub(crate) fn xls_value_eq(
-    lhs: *const CIrValue,
-    rhs: *const CIrValue,
-) -> Result<bool, XlsynthError> {
-    unsafe {
-        return Ok(xlsynth_sys::xls_value_eq(lhs, rhs));
-    }
-}
-
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_parse_ir_package(
-///     const char* ir, const char* filename,
-///     char** error_out,
-///     struct xls_package** xls_package_out);
-/// ```
-pub(crate) fn xls_parse_ir_package(
-    ir: &str,
-    filename: Option<&str>,
-) -> Result<crate::ir_package::IrPackage, XlsynthError> {
-    unsafe {
-        let ir = CString::new(ir).unwrap();
-        // The filename is allowed to be a null pointer if there is no filename.
-        let filename_ptr = filename
-            .map(|s| CString::new(s).unwrap())
-            .map(|s| s.as_ptr())
-            .unwrap_or(std::ptr::null());
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut xls_package_out: *mut CIrPackage = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_parse_ir_package(
-            ir.as_ptr(),
-            filename_ptr,
-            &mut error_out,
-            &mut xls_package_out,
-        );
-        if success {
-            let package = crate::ir_package::IrPackage {
-                ptr: Arc::new(RwLock::new(IrPackagePtr(xls_package_out))),
-                filename: filename.map(|s| s.to_string()),
-            };
-            return Ok(package);
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_type_to_string(struct xls_type* type, char** error_out,
-/// char** result_out);
-/// ```
-pub(crate) fn xls_type_to_string(t: *const CIrType) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_type_to_string(t, &mut error_out, &mut c_str_out);
-        if success {
-            return Ok(c_str_to_rust(c_str_out));
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_package_get_type_for_value(struct xls_package* package,
-// struct xls_value* value, char** error_out,
-// struct xls_type** result_out);
-// ```
-pub(crate) fn xls_package_get_type_for_value(
-    package: *const CIrPackage,
-    value: *const CIrValue,
-) -> Result<IrType, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result_out: *mut CIrType = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_package_get_type_for_value(
-            package,
-            value,
-            &mut error_out,
-            &mut result_out,
-        );
-        if success {
-            let ir_type = IrType { ptr: result_out };
-            return Ok(ir_type);
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_package_get_function(s
-///    struct xls_package* package,
-///    const char* function_name, char** error_out,
-///    struct xls_function** result_out);
-/// ```
-pub(crate) fn xls_package_get_function(
-    package: &Arc<RwLock<IrPackagePtr>>,
-    guard: RwLockReadGuard<IrPackagePtr>,
-    function_name: &str,
-) -> Result<crate::ir_package::IrFunction, XlsynthError> {
-    unsafe {
-        let function_name = CString::new(function_name).unwrap();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result_out: *mut CIrFunction = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_package_get_function(
-            guard.const_c_ptr(),
-            function_name.as_ptr(),
-            &mut error_out,
-            &mut result_out,
-        );
-        if success {
-            let function = crate::ir_package::IrFunction {
-                parent: package.clone(),
-                ptr: result_out,
-            };
-            return Ok(function);
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_function_get_type(struct xls_function* function, char** error_out,
-/// struct xls_function_type** xls_fn_type_out);
-/// ```
-pub(crate) fn xls_function_get_type(
-    _package_write_guard: &RwLockWriteGuard<IrPackagePtr>,
-    function: *const CIrFunction,
-) -> Result<IrFunctionType, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut xls_fn_type_out: *mut CIrFunctionType = std::ptr::null_mut();
-        let success =
-            xlsynth_sys::xls_function_get_type(function, &mut error_out, &mut xls_fn_type_out);
-        if success {
-            let ir_type = IrFunctionType {
-                ptr: xls_fn_type_out,
-            };
-            return Ok(ir_type);
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_function_type_to_string(struct xls_function_type* xls_function_type,
-/// char** error_out, char** string_out);
-/// ```
-pub(crate) fn xls_function_type_to_string(
-    t: *const CIrFunctionType,
-) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_function_type_to_string(t, &mut error_out, &mut c_str_out);
-        if success {
-            return Ok(c_str_to_rust(c_str_out));
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-pub(crate) fn xls_function_get_name(function: *const CIrFunction) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_function_get_name(function, &mut error_out, &mut c_str_out);
-        if success {
-            return Ok(c_str_to_rust(c_str_out));
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_interpret_function(
-///     struct xls_function* function, size_t argc,
-///     const struct xls_value** args, char** error_out,
-///     struct xls_value** result_out);
-/// ```
-pub(crate) fn xls_interpret_function(
-    _package_guard: &RwLockReadGuard<IrPackagePtr>,
-    function: *const CIrFunction,
-    args: &[IrValue],
-) -> Result<IrValue, XlsynthError> {
-    unsafe {
-        let args_ptrs: Vec<*const CIrValue> =
-            args.iter().map(|v| -> *const CIrValue { v.ptr }).collect();
-        let argc = args_ptrs.len();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result_out: *mut CIrValue = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_interpret_function(
-            function,
-            argc,
-            args_ptrs.as_ptr(),
-            &mut error_out,
-            &mut result_out,
-        );
-        if success {
-            let result = IrValue { ptr: result_out };
-            return Ok(result);
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-/// Binding for the C API function:
-/// ```c
-/// bool xls_optimize_ir(const char* ir, const char* top, char** error_out,
-/// char** ir_out);
-/// ```
-pub(crate) fn xls_optimize_ir(ir: &str, top: &str) -> Result<String, XlsynthError> {
-    unsafe {
-        let ir = CString::new(ir).unwrap();
-        let top = CString::new(top).unwrap();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut ir_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success =
-            xlsynth_sys::xls_optimize_ir(ir.as_ptr(), top.as_ptr(), &mut error_out, &mut ir_out);
-        if success {
-            return Ok(c_str_to_rust(ir_out));
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-/// Binding for the C API function:
-/// ```c
-/// bool xls_mangle_dslx_name(const char* module_name, const char* function_name,
-/// char** error_out, char** mangled_out);
-/// ```
-pub(crate) fn xls_mangle_dslx_name(
-    module_name: &str,
-    function_name: &str,
-) -> Result<String, XlsynthError> {
-    unsafe {
-        let module_name = CString::new(module_name).unwrap();
-        let function_name = CString::new(function_name).unwrap();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut mangled_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_mangle_dslx_name(
-            module_name.as_ptr(),
-            function_name.as_ptr(),
-            &mut error_out,
-            &mut mangled_out,
-        );
-        if success {
-            return Ok(c_str_to_rust(mangled_out));
-        }
-        let error_out_str: String = c_str_to_rust(error_out);
-        return Err(XlsynthError(error_out_str));
-    }
-}
-
-/// Binding for the C API function:
-/// ```c
-/// bool xls_package_to_string(const struct xls_package* p, char** string_out) {
-/// ```
-pub(crate) fn xls_package_to_string(p: *const CIrPackage) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_package_to_string(p, &mut c_str_out);
-        if success {
-            return Ok(c_str_to_rust(c_str_out));
-        }
-        return Err(XlsynthError(
-            "Failed to convert XLS package to string via C API".to_string(),
-        ));
-    }
-}
-
-pub fn convert_dslx_to_ir(dslx: &str, path: &std::path::Path) -> Result<IrPackage, XlsynthError> {
-    let ir_text = xls_convert_dslx_to_ir(dslx, path, &DslxConvertOptions::default())?;
+/// Converts DSLX source text into an IR package.
+pub fn convert_dslx_to_ir(
+    dslx: &str,
+    path: &std::path::Path,
+    options: &DslxConvertOptions,
+) -> Result<IrPackage, XlsynthError> {
+    let ir_text = convert_dslx_to_ir_text(dslx, path, options)?;
     // Get the filename as an Option<&str>
     let filename = path.file_name().and_then(|s| s.to_str());
     IrPackage::parse_ir(&ir_text, filename)
 }
 
+/// Optimizes an IR package -- this produces a new IR package with the optimized
+/// IR contents.
 pub fn optimize_ir(ir: &IrPackage, top: &str) -> Result<IrPackage, XlsynthError> {
     let ir_text = xls_optimize_ir(&ir.to_string(), top)?;
     IrPackage::parse_ir(&ir_text, ir.filename())
+}
+
+pub fn schedule_and_codegen(
+    ir: &IrPackage,
+    scheduling_options_flags_proto: &str,
+    codegen_flags_proto: &str,
+) -> Result<ScheduleAndCodegenResult, XlsynthError> {
+    let guard = ir.ptr.write().unwrap();
+    xls_schedule_and_codegen_package(
+        &ir.ptr,
+        guard,
+        scheduling_options_flags_proto,
+        codegen_flags_proto,
+        false,
+    )
 }
 
 pub fn mangle_dslx_name(module: &str, name: &str) -> Result<String, XlsynthError> {
@@ -573,11 +217,14 @@ pub fn x_path_to_rs_bridge_via_env(relpath: &str) -> std::path::PathBuf {
 
 #[cfg(test)]
 mod tests {
+    use lib_support::xls_format_preference_from_string;
+    use xlsynth_sys::XlsFormatPreference;
+
     use super::*;
 
     #[test]
     fn test_convert_dslx_to_ir() {
-        let ir = xls_convert_dslx_to_ir(
+        let ir = convert_dslx_to_ir_text(
             "fn f(x: u32) -> u32 { x }",
             std::path::Path::new("/memfile/test_mod.x"),
             &DslxConvertOptions::default(),

--- a/xlsynth/src/lib_support.rs
+++ b/xlsynth/src/lib_support.rs
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Support functions that are not exposed as primary APIs from `lib.rs` but
+//! support the implementation of functions exposed via `lib.rs`.`
+//!
+//! (Things in this module are generally crate-visible vs public to provide that
+//! support.)
+
+use std::{
+    ffi::{CStr, CString},
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
+
+use xlsynth_sys::{
+    CIrBits, CIrFunction, CIrFunctionType, CIrPackage, CIrType, CIrValue,
+    CScheduleAndCodegenResult, XlsFormatPreference,
+};
+
+use crate::{
+    ir_package::{IrFunctionType, IrPackagePtr, IrType, ScheduleAndCodegenResult},
+    IrBits, IrValue, XlsynthError,
+};
+
+/// Binding for the C API function:
+/// ```c
+/// bool xls_package_to_string(const struct xls_package* p, char** string_out) {
+/// ```
+pub(crate) fn xls_package_to_string(p: *const CIrPackage) -> Result<String, XlsynthError> {
+    unsafe {
+        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_package_to_string(p, &mut c_str_out);
+        if success {
+            return Ok(c_str_to_rust(c_str_out));
+        }
+        return Err(XlsynthError(
+            "Failed to convert XLS package to string via C API".to_string(),
+        ));
+    }
+}
+
+/// Converts a C string that was given from the XLS library into a Rust string
+/// and deallocates the original C string.
+pub(crate) unsafe fn c_str_to_rust(xls_c_str: *mut std::os::raw::c_char) -> String {
+    if xls_c_str.is_null() {
+        return String::new();
+    }
+
+    let c_str: &CStr = CStr::from_ptr(xls_c_str);
+    let result: String = String::from_utf8_lossy(c_str.to_bytes()).to_string();
+
+    // We release the C string via a call to the XLS library so that it can use the
+    // same allocator it used to allocate the string for deallocation and we don't
+    // need to assume the Rust code and dynmic library are using the same underlying
+    // allocator.
+    xlsynth_sys::xls_c_str_free(xls_c_str);
+    result
+}
+
+pub(crate) fn xls_value_free(p: *mut CIrValue) -> Result<(), XlsynthError> {
+    unsafe {
+        xlsynth_sys::xls_value_free(p);
+        return Ok(());
+    }
+}
+
+pub(crate) fn xls_package_free(p: *mut CIrPackage) -> Result<(), XlsynthError> {
+    unsafe {
+        xlsynth_sys::xls_package_free(p);
+        return Ok(());
+    }
+}
+
+pub(crate) fn xls_value_to_string(p: *mut CIrValue) -> Result<String, XlsynthError> {
+    unsafe {
+        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_value_to_string(p, &mut c_str_out);
+        if success {
+            return Ok(c_str_to_rust(c_str_out));
+        }
+        return Err(XlsynthError(
+            "Failed to convert XLS value to string via C API".to_string(),
+        ));
+    }
+}
+
+pub(crate) fn xls_value_get_bits(p: *const CIrValue) -> Result<IrBits, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut bits_out: *mut CIrBits = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_value_get_bits(p, &mut error_out, &mut bits_out);
+        if success {
+            return Ok(IrBits { ptr: bits_out });
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+pub(crate) fn xls_format_preference_from_string(
+    s: &str,
+) -> Result<XlsFormatPreference, XlsynthError> {
+    unsafe {
+        let c_str = CString::new(s).unwrap();
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut result_out: XlsFormatPreference = -1;
+        let success = xlsynth_sys::xls_format_preference_from_string(
+            c_str.as_ptr(),
+            &mut error_out,
+            &mut result_out,
+        );
+        if success {
+            return Ok(result_out);
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+pub(crate) fn xls_value_to_string_format_preference(
+    p: *mut CIrValue,
+    fmt: XlsFormatPreference,
+) -> Result<String, XlsynthError> {
+    unsafe {
+        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_value_to_string_format_preference(
+            p,
+            fmt,
+            &mut error_out,
+            &mut c_str_out,
+        );
+        if success {
+            return Ok(c_str_to_rust(c_str_out));
+        }
+        return Err(XlsynthError(
+            "Failed to convert XLS value to string via C API".to_string(),
+        ));
+    }
+}
+
+pub(crate) fn xls_value_eq(
+    lhs: *const CIrValue,
+    rhs: *const CIrValue,
+) -> Result<bool, XlsynthError> {
+    unsafe {
+        return Ok(xlsynth_sys::xls_value_eq(lhs, rhs));
+    }
+}
+
+/// Bindings for the C API function:
+/// ```c
+/// bool xls_parse_ir_package(
+///     const char* ir, const char* filename,
+///     char** error_out,
+///     struct xls_package** xls_package_out);
+/// ```
+pub(crate) fn xls_parse_ir_package(
+    ir: &str,
+    filename: Option<&str>,
+) -> Result<crate::ir_package::IrPackage, XlsynthError> {
+    unsafe {
+        let ir = CString::new(ir).unwrap();
+        // The filename is allowed to be a null pointer if there is no filename.
+        let filename_ptr = filename
+            .map(|s| CString::new(s).unwrap())
+            .map(|s| s.as_ptr())
+            .unwrap_or(std::ptr::null());
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut xls_package_out: *mut CIrPackage = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_parse_ir_package(
+            ir.as_ptr(),
+            filename_ptr,
+            &mut error_out,
+            &mut xls_package_out,
+        );
+        if success {
+            let package = crate::ir_package::IrPackage {
+                ptr: Arc::new(RwLock::new(IrPackagePtr(xls_package_out))),
+                filename: filename.map(|s| s.to_string()),
+            };
+            return Ok(package);
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+/// Bindings for the C API function:
+/// ```c
+/// bool xls_type_to_string(struct xls_type* type, char** error_out,
+/// char** result_out);
+/// ```
+pub(crate) fn xls_type_to_string(t: *const CIrType) -> Result<String, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_type_to_string(t, &mut error_out, &mut c_str_out);
+        if success {
+            return Ok(c_str_to_rust(c_str_out));
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+/// Bindings for the C API function:
+/// ```c
+/// bool xls_package_get_type_for_value(struct xls_package* package,
+// struct xls_value* value, char** error_out,
+// struct xls_type** result_out);
+// ```
+pub(crate) fn xls_package_get_type_for_value(
+    package: *const CIrPackage,
+    value: *const CIrValue,
+) -> Result<IrType, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut result_out: *mut CIrType = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_package_get_type_for_value(
+            package,
+            value,
+            &mut error_out,
+            &mut result_out,
+        );
+        if success {
+            let ir_type = IrType { ptr: result_out };
+            return Ok(ir_type);
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+/// Bindings for the C API function:
+/// ```c
+/// bool xls_package_get_function(s
+///    struct xls_package* package,
+///    const char* function_name, char** error_out,
+///    struct xls_function** result_out);
+/// ```
+pub(crate) fn xls_package_get_function(
+    package: &Arc<RwLock<IrPackagePtr>>,
+    guard: RwLockReadGuard<IrPackagePtr>,
+    function_name: &str,
+) -> Result<crate::ir_package::IrFunction, XlsynthError> {
+    unsafe {
+        let function_name = CString::new(function_name).unwrap();
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut result_out: *mut CIrFunction = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_package_get_function(
+            guard.const_c_ptr(),
+            function_name.as_ptr(),
+            &mut error_out,
+            &mut result_out,
+        );
+        if success {
+            let function = crate::ir_package::IrFunction {
+                parent: package.clone(),
+                ptr: result_out,
+            };
+            return Ok(function);
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+/// Bindings for the C API function:
+/// ```c
+/// bool xls_function_get_type(struct xls_function* function, char** error_out,
+/// struct xls_function_type** xls_fn_type_out);
+/// ```
+pub(crate) fn xls_function_get_type(
+    _package_write_guard: &RwLockWriteGuard<IrPackagePtr>,
+    function: *const CIrFunction,
+) -> Result<IrFunctionType, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut xls_fn_type_out: *mut CIrFunctionType = std::ptr::null_mut();
+        let success =
+            xlsynth_sys::xls_function_get_type(function, &mut error_out, &mut xls_fn_type_out);
+        if success {
+            let ir_type = IrFunctionType {
+                ptr: xls_fn_type_out,
+            };
+            return Ok(ir_type);
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+/// Bindings for the C API function:
+/// ```c
+/// bool xls_function_type_to_string(struct xls_function_type* xls_function_type,
+/// char** error_out, char** string_out);
+/// ```
+pub(crate) fn xls_function_type_to_string(
+    t: *const CIrFunctionType,
+) -> Result<String, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_function_type_to_string(t, &mut error_out, &mut c_str_out);
+        if success {
+            return Ok(c_str_to_rust(c_str_out));
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+pub(crate) fn xls_function_get_name(function: *const CIrFunction) -> Result<String, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_function_get_name(function, &mut error_out, &mut c_str_out);
+        if success {
+            return Ok(c_str_to_rust(c_str_out));
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+/// Bindings for the C API function:
+/// ```c
+/// bool xls_interpret_function(
+///     struct xls_function* function, size_t argc,
+///     const struct xls_value** args, char** error_out,
+///     struct xls_value** result_out);
+/// ```
+pub(crate) fn xls_interpret_function(
+    _package_guard: &RwLockReadGuard<IrPackagePtr>,
+    function: *const CIrFunction,
+    args: &[IrValue],
+) -> Result<IrValue, XlsynthError> {
+    unsafe {
+        let args_ptrs: Vec<*const CIrValue> =
+            args.iter().map(|v| -> *const CIrValue { v.ptr }).collect();
+        let argc = args_ptrs.len();
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut result_out: *mut CIrValue = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_interpret_function(
+            function,
+            argc,
+            args_ptrs.as_ptr(),
+            &mut error_out,
+            &mut result_out,
+        );
+        if success {
+            let result = IrValue { ptr: result_out };
+            return Ok(result);
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+/// Binding for the C API function:
+/// ```c
+/// bool xls_optimize_ir(const char* ir, const char* top, char** error_out,
+/// char** ir_out);
+/// ```
+pub(crate) fn xls_optimize_ir(ir: &str, top: &str) -> Result<String, XlsynthError> {
+    unsafe {
+        let ir = CString::new(ir).unwrap();
+        let top = CString::new(top).unwrap();
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut ir_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let success =
+            xlsynth_sys::xls_optimize_ir(ir.as_ptr(), top.as_ptr(), &mut error_out, &mut ir_out);
+        if success {
+            return Ok(c_str_to_rust(ir_out));
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+/// Binding for the C API function:
+/// ```c
+/// bool xls_mangle_dslx_name(const char* module_name, const char* function_name,
+/// char** error_out, char** mangled_out);
+/// ```
+pub(crate) fn xls_mangle_dslx_name(
+    module_name: &str,
+    function_name: &str,
+) -> Result<String, XlsynthError> {
+    unsafe {
+        let module_name = CString::new(module_name).unwrap();
+        let function_name = CString::new(function_name).unwrap();
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut mangled_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_mangle_dslx_name(
+            module_name.as_ptr(),
+            function_name.as_ptr(),
+            &mut error_out,
+            &mut mangled_out,
+        );
+        if success {
+            return Ok(c_str_to_rust(mangled_out));
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+pub(crate) fn xls_schedule_and_codegen_package(
+    _package: &Arc<RwLock<IrPackagePtr>>,
+    guard: RwLockWriteGuard<IrPackagePtr>,
+    scheduling_options_flags_proto_str: &str,
+    codegen_flags_proto_str: &str,
+    with_delay_model: bool,
+) -> Result<ScheduleAndCodegenResult, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut result_out: *mut CScheduleAndCodegenResult = std::ptr::null_mut();
+        let scheduling_options_flags_proto =
+            CString::new(scheduling_options_flags_proto_str).unwrap();
+        let codegen_flags_proto = CString::new(codegen_flags_proto_str).unwrap();
+        let success = xlsynth_sys::xls_schedule_and_codegen_package(
+            guard.mut_c_ptr(),
+            scheduling_options_flags_proto.as_ptr(),
+            codegen_flags_proto.as_ptr(),
+            with_delay_model,
+            &mut error_out,
+            &mut result_out,
+        );
+        if success {
+            assert!(!result_out.is_null());
+            let result = ScheduleAndCodegenResult { ptr: result_out };
+            return Ok(result);
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}

--- a/xlsynth/src/vast.rs
+++ b/xlsynth/src/vast.rs
@@ -4,7 +4,7 @@
 
 #![allow(unused)]
 
-use xlsynth_sys as sys;
+use xlsynth_sys::{self as sys};
 
 use std::{
     ffi::CString,
@@ -12,7 +12,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::{c_str_to_rust, ir_value::IrFormatPreference, XlsynthError};
+use crate::{
+    c_str_to_rust, ir_value::IrFormatPreference, lib_support::xls_format_preference_from_string,
+    xls_parse_typed_value, XlsynthError,
+};
 
 pub(crate) struct VastFilePtr(pub *mut sys::CVastFile);
 
@@ -293,8 +296,8 @@ impl VastFile {
         s: &str,
         fmt: &IrFormatPreference,
     ) -> Result<Expr, XlsynthError> {
-        let v = crate::xls_parse_typed_value(s).unwrap();
-        let mut fmt = crate::xls_format_preference_from_string(fmt.to_string()).unwrap();
+        let v = xls_parse_typed_value(s).unwrap();
+        let mut fmt = xls_format_preference_from_string(fmt.to_string()).unwrap();
 
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut literal_out: *mut sys::CVastLiteral = std::ptr::null_mut();


### PR DESCRIPTION
Also factors out a bunch of non-public support code from lib.rs in the xlsynth package to lib_support.rs

This PR will initially fail but I'll re-run when the v0.0.120 DSO has finished releasing.