### PR TITLE
[xlsynth] Show arrays being passed to/from IR functions including multidimensional ones.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "cargo_metadata",
  "env_logger 0.11.5",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-driver"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "clap",
  "env_logger 0.11.5",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-sys"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "curl",
  "flate2",

--- a/xlsynth-driver/Cargo.toml
+++ b/xlsynth-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-driver"
-version = "0.0.53"
+version = "0.0.54"
 edition = "2021"
 
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/xlsynth"
 homepage = "https://github.com/xlsynth/xlsynth-crate"
 
 [dependencies]
-xlsynth = { path = "../xlsynth", version = "0.0.53" }
+xlsynth = { path = "../xlsynth", version = "0.0.54" }
 clap = "2.33"
 tempfile = "3.13"
 toml = "0.8.19"

--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-sys"
-version = "0.0.53"
+version = "0.0.54"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust (Native Library)"

--- a/xlsynth/Cargo.toml
+++ b/xlsynth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth"
-version = "0.0.53"
+version = "0.0.54"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust"
@@ -13,7 +13,7 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 readme = "../README.md"
 
 [dependencies]
-xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.53"}
+xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.54"}
 cargo_metadata = "0.18"
 log = "0.4"
 

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -211,6 +211,9 @@ impl Drop for IrValue {
 
 impl Clone for IrValue {
     fn clone(&self) -> Self {
+        // TODO(cdleary): 2024-12-14 We should either add a C API for cloning IR values
+        // more efficiently than this text serdes, or implement refcounted CIrValue
+        // pointers on the Rust side of the fence.
         IrValue::parse_typed(&self.to_string()).unwrap()
     }
 }

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -209,6 +209,12 @@ impl Drop for IrValue {
     }
 }
 
+impl Clone for IrValue {
+    fn clone(&self) -> Self {
+        IrValue::parse_typed(&self.to_string()).unwrap()
+    }
+}
+
 /// Typed wrapper around an `IrBits` value that has a particular
 /// compile-time-known bit width and whose type notes the value
 /// should be treated as unsigned.
@@ -382,5 +388,19 @@ mod tests {
                 .expect("fmt success"),
             "bits[2]:3"
         );
+    }
+
+    #[test]
+    fn test_ir_value_parse_array_value() {
+        let text = "[bits[32]:1, bits[32]:2]";
+        let v = IrValue::parse_typed(text).expect("parse success");
+        assert_eq!(v.to_string(), text);
+    }
+
+    #[test]
+    fn test_ir_value_parse_2d_array_value() {
+        let text = "[[bits[32]:1, bits[32]:2], [bits[32]:3, bits[32]:4], [bits[32]:5, bits[32]:6]]";
+        let v = IrValue::parse_typed(text).expect("parse success");
+        assert_eq!(v.to_string(), text);
     }
 }

--- a/xlsynth/tests/function_zoo.x
+++ b/xlsynth/tests/function_zoo.x
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+fn sum_elements<N: u32>(elements: u32[N]) -> u32 {
+    let result: u32 = for (i, accum) in u32:0..array_size(elements) {
+        accum + elements[i]
+    }(u32:0);
+    result
+}
+
+pub fn sum_elements_2(elements: u32[2]) -> u32 {
+    sum_elements(elements)
+}
+
+pub fn make_u32x2(a: u32, b: u32) -> u32[2] {
+    [a, b]
+}
+
+/// Creates a two-dimensional array having three rows of `u32[2]` values.
+fn make_u32_3x2(a: u32[2], b: u32[2], c: u32[2]) -> u32[2][3] {
+    [a, b, c]
+}

--- a/xlsynth/tests/ir_interpret_test.rs
+++ b/xlsynth/tests/ir_interpret_test.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use xlsynth::*;
+
+/// Demonstrates running functions that produce/accept array IR values.
+#[test]
+fn test_ir_interpret_array_values() {
+    let path = std::path::Path::new("tests/function_zoo.x");
+    let dslx = std::fs::read_to_string(path).unwrap();
+    let ir = convert_dslx_to_ir(&dslx, &path, &DslxConvertOptions::default()).unwrap();
+
+    let make_u32x2_mangled = mangle_dslx_name("function_zoo", "make_u32x2").unwrap();
+    let make_u32x2 = ir.get_function(&make_u32x2_mangled).unwrap();
+
+    let array = make_u32x2
+        .interpret(&[IrValue::u32(1), IrValue::u32(2)])
+        .unwrap();
+    assert_eq!(array.to_string(), "[bits[32]:1, bits[32]:2]");
+
+    let sum_elements_2_mangled = mangle_dslx_name("function_zoo", "sum_elements_2").unwrap();
+    let sum_elements_2 = ir.get_function(&sum_elements_2_mangled).unwrap();
+    let result = sum_elements_2.interpret(&[array.clone()]).unwrap();
+    assert_eq!(result.to_string(), "bits[32]:3");
+
+    let make_u32_3x2_mangled = mangle_dslx_name("function_zoo", "make_u32_3x2").unwrap();
+    let make_u32_3x2 = ir.get_function(&make_u32_3x2_mangled).unwrap();
+    let result = make_u32_3x2
+        .interpret(&[array.clone(), array.clone(), array.clone()])
+        .unwrap();
+    assert_eq!(
+        result.to_string(),
+        "[[bits[32]:1, bits[32]:2], [bits[32]:1, bits[32]:2], [bits[32]:1, bits[32]:2]]"
+    );
+}


### PR DESCRIPTION
This also adds a facility for cloning IR values -- it's not optimal but doing it this way doesn't need any change in the API to be simultaneously released.