### PR TITLE
[xlsynth] Implement delay estimator in Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,16 @@ jobs:
           curl -L -o slang "https://github.com/xlsynth/slang-rs/releases/download/ci/slang"
           chmod +x slang
 
+      - name: Install protobuf compiler
+        run: |
+          wget https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
+          unzip protoc-29.1-linux-x86_64.zip -d protoc
+          sudo mv protoc/bin/protoc /usr/local/bin/protoc
+          sudo mv protoc /tmp/  # Move these out of the way to not interfere with build.
+          sudo mv protoc-*.zip /tmp/  # Move these out of the way to not interfere with build.
+          # Emit the protobuf compiler version number.
+          protoc --version
+
       - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
@@ -55,17 +65,66 @@ jobs:
           export SLANG_PATH=`realpath slang` 
           cargo test --workspace
 
-  # Note: we don't currently have a downloadable binary for slang on macOS or older Ubuntu (due to
+  # Note: we don't currently have a downloadable binary for slang on older Ubuntu (due to
   # GLIBC compatibility), so we make a job that skips the slang download / envvar export.
-  build-and-test-no-slang:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-20.04]
-      fail-fast: false
+  build-and-test-ubuntu-2004-no-slang:
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+
+      - name: Install protobuf compiler
+        run: |
+          wget https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
+          unzip protoc-29.1-linux-x86_64.zip -d protoc
+          sudo mv protoc/bin/protoc /usr/local/bin/protoc
+          sudo mv protoc /tmp/  # Move these out of the way to not interfere with build.
+          sudo mv protoc-*.zip /tmp/  # Move these out of the way to not interfere with build.
+          # Emit the protobuf compiler version number.
+          protoc --version
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run pre-commit
+        env:
+          SKIP: no-commit-to-branch
+        run: |
+          pre-commit install
+          pre-commit run --all-files
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Build crate
+        run: cargo build --workspace -vv
+
+      - name: Test crate
+        run: |
+          cargo clean
+          cargo test --workspace
+  
+  build-and-test-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install protobuf compiler
+        run: |
+          wget https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-osx-aarch_64.zip
+          unzip protoc-29.1-osx-aarch_64.zip -d protoc
+          sudo mv protoc/bin/protoc /usr/local/bin/protoc
+          sudo mv protoc /tmp/  # Move these out of the way to not interfere with build.
+          sudo mv protoc-*.zip /tmp/  # Move these out of the way to not interfere with build.
+          # Emit the protobuf compiler version number.
+          protoc --version
 
       - name: Install pre-commit
         run: |
@@ -102,9 +161,21 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Install protobuf compiler
+        run: |
+          yum install -y wget unzip
+          wget https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
+          unzip protoc-29.1-linux-x86_64.zip -d protoc
+          mv protoc/bin/protoc /usr/local/bin/protoc
+          mv protoc /tmp/  # Move these out of the way to not interfere with build.
+          mv protoc-*.zip /tmp/  # Move these out of the way to not interfere with build.
+          # Emit the protobuf compiler version number.
+          protoc --version
+
       - name: Set up dependencies
         run: |
           yum install -y gcc openssl-devel libffi-devel make curl
+          yum install -y protobuf-compiler
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           echo "source $HOME/.cargo/env" >> $HOME/.bashrc
           source $HOME/.cargo/env

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 target/
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +157,18 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "camino"
@@ -328,19 +361,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
@@ -396,6 +416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +430,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "generic-array"
@@ -416,6 +448,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,9 +466,21 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -441,12 +496,6 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "home"
@@ -465,23 +514,22 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi 0.4.0",
- "libc",
- "windows-sys 0.52.0",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -489,6 +537,24 @@ name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -543,6 +609,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "logos"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.6.29",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,12 +675,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray-stats"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af5a8477ac96877b5bd1fd67e0c28736c12943aba24eda92b127e036b0c8f400"
+dependencies = [
+ "indexmap 1.9.3",
+ "itertools 0.10.5",
+ "ndarray",
+ "noisy_float",
+ "num-integer",
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "nnls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc49f059edd9ad0f2512a13f5d6eb1636dee542bfd98a504b40ed7188d00437b"
+dependencies = [
+ "approx",
+ "ndarray",
+ "ndarray-stats",
+]
+
+[[package]]
+name = "noisy_float"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978fe6e6ebc0bf53de533cd456ca2d9de13de13856eda1518a285d7705a213af"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -683,10 +855,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.6.0",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -699,12 +890,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.12.1",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057237efdb71cf4b3f9396302a3d6599a92fa94063ba537b66130980ea9909f3"
+dependencies = [
+ "logos",
+ "once_cell",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -715,6 +981,42 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -754,7 +1056,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -765,8 +1067,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -805,7 +1113,7 @@ version = "0.1.0"
 dependencies = [
  "cargo_metadata",
  "docmatic",
- "env_logger 0.11.5",
+ "env_logger",
  "lazy_static",
  "log",
  "mimalloc",
@@ -953,21 +1261,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "test-helpers"
 version = "0.0.1"
 dependencies = [
  "cargo_metadata",
  "curl",
- "env_logger 0.10.2",
+ "env_logger",
  "log",
  "semver",
  "serde_json",
@@ -1043,7 +1342,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1099,6 +1398,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "which"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,15 +1440,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1264,7 +1560,7 @@ name = "xlsynth"
 version = "0.0.54"
 dependencies = [
  "cargo_metadata",
- "env_logger 0.11.5",
+ "env_logger",
  "log",
  "pretty_assertions",
  "test-helpers",
@@ -1276,13 +1572,28 @@ name = "xlsynth-driver"
 version = "0.0.54"
 dependencies = [
  "clap",
- "env_logger 0.11.5",
+ "env_logger",
  "log",
+ "prost-build",
  "serde",
  "tempfile",
  "test-helpers",
  "toml 0.8.19",
  "xlsynth",
+]
+
+[[package]]
+name = "xlsynth-estimator"
+version = "0.0.54"
+dependencies = [
+ "env_logger",
+ "log",
+ "ndarray",
+ "nnls",
+ "prost",
+ "prost-build",
+ "prost-reflect",
+ "prost-types",
 ]
 
 [[package]]
@@ -1300,3 +1611,24 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "xlsynth",
     "xlsynth-sys",
     "xlsynth-driver",
+    "xlsynth-estimator",
     "sample-usage",
 ]
 resolver = "2"

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 slang-rs = "0.12.0"
 tempfile = "3.13"
 log = "0.4"
-env_logger = "0.10"
+env_logger = "0.11"
 
 [dev-dependencies]
 xlsynth-sys = { path = "../xlsynth-sys" }

--- a/test-helpers/tests/spdx_test.rs
+++ b/test-helpers/tests/spdx_test.rs
@@ -56,6 +56,10 @@ fn find_missing_spdx_files(root: &Path) -> Vec<PathBuf> {
                 continue;
             }
 
+            if path.file_name().unwrap().to_str().unwrap() == "estimator_model.proto" {
+                continue;
+            }
+
             if let Some(extension) = path.extension() {
                 if extension == "md" || extension == "lock" || extension == "toml" {
                     continue;

--- a/xlsynth-driver/Cargo.toml
+++ b/xlsynth-driver/Cargo.toml
@@ -16,8 +16,11 @@ clap = "2.33"
 tempfile = "3.13"
 toml = "0.8.19"
 serde = { version = "1.0", features = ["derive"] }
-env_logger = "0.11.5"
+env_logger = "0.11"
 log = "0.4"
 
 [dev-dependencies]
 test-helpers = { path = "../test-helpers" }
+
+[build-dependencies]
+prost-build = "0.12"

--- a/xlsynth-estimator/Cargo.toml
+++ b/xlsynth-estimator/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "xlsynth-estimator"
+version = "0.0.54"
+edition = "2021"
+
+authors = ["Christopher D. Leary <cdleary@gmail.com>"]
+description = "Delay estimation facilities via Rust"
+license = "Apache-2.0"
+repository = "https://github.com/xlsynth/xlsynth-crate"
+documentation = "https://docs.rs/xlsynth"
+homepage = "https://github.com/xlsynth/xlsynth-crate"
+
+[dependencies]
+prost = "0.12"
+prost-types = "0.12"
+prost-reflect = { version = "0.12", features = ["text-format"] }
+nnls = "0.3"
+ndarray = { version="0.15", features = ["approx-0_5"] }
+log = "0.4"
+env_logger = "0.11"
+
+[build-dependencies]
+prost-build = "0.12"

--- a/xlsynth-estimator/build.rs
+++ b/xlsynth-estimator/build.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+
+    let descriptor_path = std::path::PathBuf::from(out_dir.clone()).join("descriptors.bin");
+
+    prost_build::Config::new()
+        .out_dir(out_dir.clone())
+        .file_descriptor_set_path(descriptor_path)
+        .compile_protos(
+            &["proto/estimator_model.proto", "proto/sample_node.proto"],
+            &["proto"],
+        )
+        .expect("compilation of proto");
+    println!("cargo:rerun-if-changed=proto/estimator_model.proto");
+    println!("cargo:rerun-if-changed=proto/sample_node.proto");
+}

--- a/xlsynth-estimator/proto/estimator_model.proto
+++ b/xlsynth-estimator/proto/estimator_model.proto
@@ -1,0 +1,385 @@
+// Copyright 2020 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package xls.estimator_model;
+
+// Enum describing the metric that the estimator is estimating. Every estimator
+// is specific to one metric.
+enum Metric {
+  UNSPECIFIED_METRIC = 0;
+  DELAY_METRIC = 1;
+  AREA_METRIC = 2;
+}
+
+// Enum describing a specialization of the estimator model of an operation. A
+// specialization describes a condition under which a metric (such as delay or
+// area) of the operation is appreciably different then the general case.
+// For example, a synthesized multiply is generally faster if both operands are
+// identical and the delay model may include a specialized delay computation for
+// this case (OPERANDS_IDENTICAL).
+enum SpecializationKind {
+  NO_SPECIALIZATION = 0;
+
+  // All of the operands of the operation are the same.
+  // e.g. "square" for mul, "double" for add
+  OPERANDS_IDENTICAL = 1;
+
+  // The operation includes a literal operand.
+  HAS_LITERAL_OPERAND = 2;
+}
+
+// Describes more specifics of the condition under which the delay/area of the
+// operation differs. For example, if the kind is HAS_LITERAL_OPERAND, this
+// might specify that the literal operand must be operand 1.
+message LiteralOperandDetails {
+  // If none are specified, then any operand is allowed to be non-literal.
+  repeated int64 allowed_nonliteral_operand = 1;
+
+  // If none are specified, then no specific operand is required to be literal.
+  repeated int64 required_literal_operand = 2;
+}
+
+// Describes an XLS operation (xls::Node) for the purposes of delay/area
+// modeling.
+message Operation {
+  // XLS Op (e.g., kAdd).
+  string op = 1;
+
+  // Number of bits of the result of the operation. For array-types this is the
+  // number of bits in each element.
+  int64 bit_count = 2;
+
+  // Operands.
+  message Operand {
+    // Number of bits of the operand. For array types this is the number of bits
+    // in each element.
+    int64 bit_count = 1;
+
+    // If the operand is array-typed, this is the number of elements in the
+    // array.
+    int64 element_count = 2;
+  }
+  repeated Operand operands = 3;
+
+  // The category of specialization of this operation, if any. For example, if
+  // the operands of the xls::Node represented by this proto are all identical,
+  // this field would be OPERANDS_IDENTICAL.
+  SpecializationKind specialization = 4;
+
+  message LiteralOperandInstanceDetails {
+    repeated int64 literal_operand = 1;
+    repeated int64 nonliteral_operand = 2;
+  }
+  LiteralOperandInstanceDetails literal_operand_details = 5;
+}
+
+// Describes a measured data point of the delay and area of an operation.
+message DataPoint {
+  Operation operation = 1;
+
+  // The measured delay in ps.
+  int64 delay = 2;
+
+  // An optional offset which should be subtracted from the 'delay' value to
+  // compute the actual delay of the operation. This can be used to account for
+  // overhead such as clock-to-Q and setup time which may included in the
+  // measured delay, but is not a component of the delay of the logic of the
+  // operation. This value is per data point because it may change if underlying
+  // synthesis rules change and a delay model may be built up over a period of
+  // time spanning these rules changes.
+  int64 delay_offset = 3;
+
+  // Total area includes both sequential area and combinational area.
+  double total_area = 4;
+
+  double sequential_area = 5;
+}
+
+// Describes an aspect (bit count, number of operands, etc.) of an XLS operation
+// which may be used as a input in the estimator for the operation.
+message EstimatorFactor {
+  enum Source {
+    INVALID_VARIABLE_SOURCE = 0;
+
+    // The bit count of the result of the operation.
+    RESULT_BIT_COUNT = 1;
+
+    // The bit count of a particular operand of the operation. The specific
+    // operand is indicated by the field operand_number.
+    OPERAND_BIT_COUNT = 2;
+
+    // The total number of operands of the operation.
+    OPERAND_COUNT = 3;
+
+    // The number of element of a particular operand of the operation. The
+    // operand must be array-typed. The specific operand is indicated by the
+    // field operand_number.
+    OPERAND_ELEMENT_COUNT = 4;
+
+    // The width of an element number in a particular array-typed operand of the
+    // operation. The specific operand is indicated by the field operand_number.
+    OPERAND_ELEMENT_BIT_COUNT = 5;
+  }
+  Source source = 1;
+
+  // If 'source' is one of the OPERAND_* values then this indicates the operand
+  // number to use
+  int64 operand_number = 2;
+}
+
+// Describes a nested mathematical expression combining estimator factors (and
+// possibly constants). Useful when data for an op cannot be described by a
+// linear combination of individual factors.
+message EstimatorExpression {
+  // The expression is a binary op combining two subexpressions.
+  enum BinaryOperation {
+    INVALID = 0;
+    ADD = 1;
+    DIVIDE = 2;
+    MAX = 3;
+    MIN = 4;
+    MULTIPLY = 5;
+    POWER = 6;
+    SUB = 7;
+  }
+
+  // An expression can be either a BinaryOperation,
+  // a EstimatorFactor, or an int.
+  oneof expression_type {
+    BinaryOperation bin_op = 1;
+
+    // The expression is simply an estimator factor.
+    EstimatorFactor factor = 2;
+
+    // The expression is a constant.
+    int64 constant = 3;
+  }
+
+  // Left and right hand side expressions combined by the BinaryOperation,
+  // if present.
+  EstimatorExpression lhs_expression = 4;
+  EstimatorExpression rhs_expression = 5;
+}
+
+// Settings used for K-fold cross-validation of a regression estimor.
+// A regression model will fail to build if it does not pass cross validation.
+message KFoldValidator {
+  // Note: oneof used here because proto3 does not support optional
+  // fields without experimental features enabled.
+  oneof optional_num_cross_validation_folds {
+    // The number of folds to use for cross validation.
+    // default = 5
+    int64 num_cross_validation_folds = 1;
+  }
+
+  oneof optional_max_data_point_error {
+    // The maximum allowable absolute error for any single data point.
+    // default = infinity
+    float max_data_point_error = 2;
+  }
+  oneof optional_max_fold_geomean_error {
+    // max_fold_geomean_error: The maximum allowable geomean absolute error over
+    // all data points in a given test set.
+    // default = infinity
+    float max_fold_geomean_error = 3;
+  }
+}
+
+// Describes a estimator estimation model which fits a curve to the measured
+// data points for the operation. The function (curve) includes a constant term
+// and terms which are linear and logarithm functions of the indicated
+// expressions. For example, if the expressions are the result bit count and the
+// operand count then the function for the estimated delay has the form:
+//
+//   delay_est = P_0 + P_1 * result_bit_count + P_2 * log2(result_bit_count) +
+//                     P_3 * operand_count    + P_4 * log2(operand_count)
+//
+// Where P_i are learned parameters.
+message RegressionEstimator {
+  repeated EstimatorExpression expressions = 1;
+
+  // Note: oneof used here because proto3 does not support optional
+  // fields without experimental features enabled.
+  oneof optional_kfold_validator {
+    // K-Fold validation settings.
+    KFoldValidator kfold_validator = 2;
+  }
+}
+
+// Similar to RegressionEstimator but includes more terms: x**2, xlogx, x, logx.
+// For example, if the expressions are u and v, where u is the result bit count,
+// and v is the operand count, then the area estimator has the form:
+//   area_est = P_0 + P_1 * u**2 + P_2 * u*log(u) + P_3 * u + P_4 * log(u) +
+//                    P_5 * v**2 + P_6 * v*log(v) + P_7 * v + P_8 * log(v)
+//
+// Where P_i are learned parameters.
+message AreaRegressionEstimator {
+  repeated EstimatorExpression expressions = 1;
+
+  // Note: oneof used here because proto3 does not support optional
+  // fields without experimental features enabled.
+  oneof optional_kfold_validator {
+    // K-Fold validation settings.
+    KFoldValidator kfold_validator = 2;
+  }
+}
+
+// Describes a estimation model in which the measured data points define
+// bounding boxes in the space of expressions. The estimated delay (or area) for
+// an operation X is equal to the delay (or area) of the first bounding box
+// containing the point defined by the operation. For example, suppose the
+// factors of a bounding box estimator are the result bit count and the operand
+// count, and the measured data points are:
+//
+//   (1) result_bit_count=8, operand_count=3    : 100ps
+//   (2) result_bit_count=5, operand_count=12   : 150ps
+//   (3) result_bit_count=10, operand_count=16  : 200ps
+//
+// Then the delay of an operation with result_bit_count=5 and operand_count=6
+// would be 150ps because the point (result_bit_count=5, operand_count=6) is
+// contained in the bounding box of (result_bit_count=5, operand_count=12).
+//
+// The bounding box model is sensitive to the order in which the data points are
+// listed in the DelayModel proto because the bounding boxes are tested
+// sequentially and the first match is used.
+// TODO(meheff): To avoid this undesirable sensitivity, perhaps take the minimum
+// delay among the enclosing bounding boxes.
+message BoundingBoxEstimator {
+  repeated EstimatorFactor factors = 1;
+}
+
+// Estimator which uses logical effort computation to approximate
+// delay. Specifically, ops with this estimator are handled by the method
+// DelayEstimator::GetLogicalEffortDelayInPs. Typically only logical operations
+// (AND, OR, etc) and a small number of other simple operations are handled via
+// logical effort.
+message LogicalEffortEstimator {
+  // The delay of a single inverter in ps.
+  int64 tau_in_ps = 1;
+}
+
+// Message describing a delay estimation model.
+message Estimator {
+  oneof estimator {
+    // An estimator which returns a fixed value given by 'fixed'.
+    int64 fixed = 1;
+
+    // An estimator which aliases the model of a different op given by
+    // alias_op. For example, kAdd and kSub have very similar delay
+    // characteristics so the estimator for kSub may be defined as an alias of
+    // kAdd by setting 'alias_op' to 'kAdd'.
+    string alias_op = 2;
+
+    // A curve-fitting model.
+    RegressionEstimator regression = 3;
+
+    // A bounding box model.
+    BoundingBoxEstimator bounding_box = 4;
+
+    // A logical effort estimator.
+    LogicalEffortEstimator logical_effort = 5;
+
+    // A curve-fitting model for area.
+    AreaRegressionEstimator area_regression = 6;
+  }
+}
+
+// Describes a model for computing the delay/area of a single operation
+// (e.g. kAdd).
+message OpModel {
+  // The xls::Op for this model (e.g., kAdd).
+  string op = 1;
+
+  // The estimator to use to compute the metric.
+  Estimator estimator = 2;
+
+  // Zero or more estimators to use under specialized conditions indicated by
+  // 'kind'. For example, the OpModel for 'kUMul' may include a specialization
+  // of kind OPERANDS_IDENTICAL because the delay characteristics are different
+  // for multiplies if both operands are the same.
+  message Specialization {
+    SpecializationKind kind = 1;
+    Estimator estimator = 2;
+    message Details {
+      oneof specialization_details {
+        LiteralOperandDetails literal_operand_details = 1;
+      }
+    }
+    Details details = 3;
+  }
+  repeated Specialization specializations = 3;
+}
+
+// Describes an estimator model used for estimating a specific characteristic of
+// an XLS operation. For example, this could be use to hold a collection of
+// estimator models and data points for estimating the area of every op.
+message EstimatorModel {
+  // The models for each op.
+  repeated OpModel op_models = 1;
+
+  // Measured delays of XLS operations used as input data for
+  // RegressionEstimator, AreaRegressionEstimator, and BoundingBoxEstimator.
+  repeated DataPoint data_points = 2;
+
+  // The metric this estimator model is estimating.
+  Metric metric = 3;
+}
+
+// The op model describes the estimator for each XLS op type supported by this
+// model.
+message OpModels {
+  repeated OpModel op_models = 1;
+}
+
+// Data points gathered from timing characterization or area characterization
+//   (op, parameterization, specialization, result delay/area)
+//   used for XLS regression estimators.
+message DataPoints {
+  repeated DataPoint data_points = 1;
+}
+
+// For an operand that is an array type, there will be one or more element
+// counts.
+// This contains
+//   * which operand these element counts apply to
+//   * the element count(s)
+message OperandElementCounts {
+  optional int64 operand_number = 1;
+  repeated int64 element_counts = 2;
+}
+
+// Detailed specification of the operand and result types
+message Parameterization {
+  optional int64 result_width = 1;
+  repeated int64 operand_widths = 2;
+  // --- anything below is used only with array types ---
+  repeated int64 result_element_counts = 3;
+  repeated OperandElementCounts operand_element_counts = 4;
+}
+
+// Specifies the set of sample points for a particular op
+message OpSamples {
+  optional string op = 1;
+  repeated Parameterization samples = 2;
+  optional SpecializationKind specialization = 3;
+  optional string attributes = 4;
+}
+
+// Multiple OpSamples messages
+// There can be multiple op_samples with the same 'op'.
+message OpSamplesList {
+  repeated OpSamples op_samples = 1;
+}

--- a/xlsynth-estimator/proto/sample_node.proto
+++ b/xlsynth-estimator/proto/sample_node.proto
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package xlsynth.estimator;
+
+/// A sample node structure with the information that's required for testing the delay estimator.
+message SampleNode {
+    string op = 1;
+    uint64 result_bit_count = 2;
+    repeated uint64 operand_bit_count = 3;
+    repeated uint64 operand_element_count = 4;
+    repeated uint64 operand_element_bit_count = 5;
+    uint64 operand_count = 6;
+    repeated bool operand_is_literal = 7;
+    bool all_operands_identical = 8;
+    bool has_literal_operand = 9;
+    repeated bool literal_operands = 10;
+}

--- a/xlsynth-estimator/src/estimator.rs
+++ b/xlsynth-estimator/src/estimator.rs
@@ -1,0 +1,973 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use ndarray::{Array1, Array2};
+use prost::Message;
+use prost_reflect::DescriptorPool;
+use std::collections::HashSet;
+use std::convert::TryFrom;
+// Generated code from proto
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/xls.estimator_model.rs"));
+}
+
+use proto::estimator_factor::Source as FactorSource;
+
+/// This is the interface for a node for which we want to be able to predict
+/// delay.
+pub trait Node {
+    fn op(&self) -> &str;
+
+    /// Returns the (flat) bit count of the result.
+    fn result_bit_count(&self) -> u64;
+    /// Returns the (flat) bit count of operand `i`.
+    fn operand_bit_count(&self, i: usize) -> u64;
+
+    /// Returns the number of elements in the operand, if it is an aggregate
+    /// type.
+    fn operand_element_count(&self, i: usize) -> Option<u64>;
+
+    /// Returns the (flat) bit count of the element type of operand `i`, if it
+    /// is an array type.
+    fn operand_element_bit_count(&self, i: usize) -> Option<u64>;
+
+    /// Returns the number of operands.
+    fn operand_count(&self) -> u64;
+
+    /// Returns true if all operands are identical.
+    fn all_operands_identical(&self) -> bool;
+
+    /// Returns true if there is at least one literal operand.
+    fn has_literal_operand(&self) -> bool;
+
+    /// Returns the literal operands.
+    fn literal_operands(&self) -> Vec<bool>;
+}
+
+/// Evaluates a factor (i.e. gets the corresponding attribute) for a node.
+fn eval_factor_for_node(factor: &proto::EstimatorFactor, node: &dyn Node) -> f64 {
+    let source_i32 = factor.source;
+    let source_enum = FactorSource::try_from(source_i32).unwrap();
+    match source_enum {
+        FactorSource::ResultBitCount => node.result_bit_count() as f64,
+        FactorSource::OperandBitCount => {
+            node.operand_bit_count(factor.operand_number as usize) as f64
+        }
+        FactorSource::OperandCount => node.operand_count() as f64,
+        FactorSource::OperandElementCount => node
+            .operand_element_count(factor.operand_number as usize)
+            .unwrap() as f64,
+        FactorSource::OperandElementBitCount => node
+            .operand_element_bit_count(factor.operand_number as usize)
+            .unwrap() as f64,
+        FactorSource::InvalidVariableSource => panic!("Invalid variable source"),
+    }
+}
+
+fn eval_factor_for_data_point(
+    factor: &proto::EstimatorFactor,
+    data_point: &proto::DataPoint,
+) -> f64 {
+    let source_i32 = factor.source;
+    let source_enum = FactorSource::try_from(source_i32).unwrap();
+    match source_enum {
+        FactorSource::ResultBitCount => data_point.operation.as_ref().unwrap().bit_count as f64,
+        FactorSource::OperandBitCount => {
+            let operand_number = factor.operand_number as usize;
+            let operand = data_point
+                .operation
+                .as_ref()
+                .unwrap()
+                .operands
+                .get(operand_number)
+                .unwrap();
+            operand.bit_count as f64
+        }
+        FactorSource::OperandCount => data_point.operation.as_ref().unwrap().operands.len() as f64,
+        FactorSource::OperandElementCount => todo!(),
+        FactorSource::OperandElementBitCount => todo!(),
+        FactorSource::InvalidVariableSource => panic!("Invalid variable source"),
+    }
+}
+
+fn eval_expression_for_node(expr: &proto::EstimatorExpression, node: &dyn Node) -> f64 {
+    let expr_type = expr.expression_type.as_ref().unwrap();
+    match expr_type {
+        proto::estimator_expression::ExpressionType::Factor(factor) => {
+            eval_factor_for_node(factor, node)
+        }
+        proto::estimator_expression::ExpressionType::BinOp(binary_op) => {
+            let op = proto::estimator_expression::BinaryOperation::try_from(*binary_op).unwrap();
+            let lhs_expression = expr.lhs_expression.as_ref().unwrap();
+            let rhs_expression = expr.rhs_expression.as_ref().unwrap();
+            let lhs = eval_expression_for_node(lhs_expression, node);
+            let rhs = eval_expression_for_node(rhs_expression, node);
+            match op {
+                proto::estimator_expression::BinaryOperation::Add => lhs + rhs,
+                proto::estimator_expression::BinaryOperation::Divide => lhs / rhs,
+                proto::estimator_expression::BinaryOperation::Max => lhs.max(rhs),
+                proto::estimator_expression::BinaryOperation::Min => lhs.min(rhs),
+                proto::estimator_expression::BinaryOperation::Multiply => lhs * rhs,
+                proto::estimator_expression::BinaryOperation::Power => lhs.powf(rhs),
+                proto::estimator_expression::BinaryOperation::Sub => lhs - rhs,
+                proto::estimator_expression::BinaryOperation::Invalid => {
+                    panic!("Invalid binary operation")
+                }
+            }
+        }
+        proto::estimator_expression::ExpressionType::Constant(constant) => *constant as f64,
+    }
+}
+
+fn eval_expression_for_data_point(
+    expr: &proto::EstimatorExpression,
+    data_point: &proto::DataPoint,
+) -> f64 {
+    let expr_type = expr.expression_type.as_ref().unwrap();
+    match expr_type {
+        proto::estimator_expression::ExpressionType::Factor(factor) => {
+            eval_factor_for_data_point(factor, data_point)
+        }
+        proto::estimator_expression::ExpressionType::BinOp(binary_op) => {
+            let op = proto::estimator_expression::BinaryOperation::try_from(*binary_op).unwrap();
+            let lhs_expression = expr.lhs_expression.as_ref().unwrap();
+            let rhs_expression = expr.rhs_expression.as_ref().unwrap();
+            let lhs = eval_expression_for_data_point(lhs_expression, data_point);
+            let rhs = eval_expression_for_data_point(rhs_expression, data_point);
+            match op {
+                proto::estimator_expression::BinaryOperation::Add => lhs + rhs,
+                proto::estimator_expression::BinaryOperation::Divide => lhs / rhs,
+                proto::estimator_expression::BinaryOperation::Max => lhs.max(rhs),
+                proto::estimator_expression::BinaryOperation::Min => lhs.min(rhs),
+                proto::estimator_expression::BinaryOperation::Multiply => lhs * rhs,
+                proto::estimator_expression::BinaryOperation::Power => lhs.powf(rhs),
+                proto::estimator_expression::BinaryOperation::Sub => lhs - rhs,
+                proto::estimator_expression::BinaryOperation::Invalid => {
+                    panic!("Invalid binary operation")
+                }
+            }
+        }
+        proto::estimator_expression::ExpressionType::Constant(constant) => *constant as f64,
+    }
+}
+
+/// Wraps an underlying node with a new opcode.
+struct AliasNode<'a> {
+    new_op: &'a str,
+    delegate: &'a dyn Node,
+}
+
+impl<'a> Node for AliasNode<'a> {
+    fn op(&self) -> &str {
+        self.new_op
+    }
+    fn result_bit_count(&self) -> u64 {
+        self.delegate.result_bit_count()
+    }
+    fn operand_bit_count(&self, i: usize) -> u64 {
+        self.delegate.operand_bit_count(i)
+    }
+    fn operand_count(&self) -> u64 {
+        self.delegate.operand_count()
+    }
+    fn all_operands_identical(&self) -> bool {
+        self.delegate.all_operands_identical()
+    }
+    fn has_literal_operand(&self) -> bool {
+        self.delegate.has_literal_operand()
+    }
+    fn literal_operands(&self) -> Vec<bool> {
+        self.delegate.literal_operands()
+    }
+    fn operand_element_count(&self, i: usize) -> Option<u64> {
+        self.delegate.operand_element_count(i)
+    }
+    fn operand_element_bit_count(&self, i: usize) -> Option<u64> {
+        self.delegate.operand_element_bit_count(i)
+    }
+}
+
+fn eval_estimator(
+    em: &proto::EstimatorModel,
+    estimator: &proto::Estimator,
+    node: &dyn Node,
+) -> Result<f64, String> {
+    match estimator.estimator.as_ref().unwrap() {
+        proto::estimator::Estimator::Fixed(fixed) => Ok(*fixed as f64),
+        proto::estimator::Estimator::AliasOp(alias_op) => {
+            let estimator: Option<&proto::Estimator> = find_estimator_for_op(
+                em,
+                alias_op,
+                node.all_operands_identical(),
+                node.has_literal_operand(),
+                &node.literal_operands(),
+            );
+            if let Some(estimator) = estimator {
+                eval_estimator(
+                    em,
+                    estimator,
+                    &AliasNode {
+                        new_op: alias_op,
+                        delegate: node,
+                    },
+                )
+            } else {
+                Err(format!(
+                    "No estimator found for op: {} aliased to: {}",
+                    node.op(),
+                    alias_op
+                ))
+            }
+        }
+        proto::estimator::Estimator::Regression(regression) => {
+            let data_points: &Vec<proto::DataPoint> = &em.data_points;
+            let estimator_impl = make_regression_estimator(regression, &data_points, &node.op())?;
+            Ok(estimator_impl.predict(node))
+        }
+        proto::estimator::Estimator::BoundingBox(_bounding_box) => todo!(),
+        proto::estimator::Estimator::LogicalEffort(_logical_effort) => todo!(),
+        proto::estimator::Estimator::AreaRegression(_area_regression) => todo!(),
+    }
+}
+
+/// Returns whether the node's literal operands (as given by `literal_operands`)
+/// match the literal operand details.
+///
+/// This is a predicate evaluator to determine if a node matches a given
+/// specialization.
+fn matches_literal_operand_details(
+    literal_operand_details: &proto::LiteralOperandDetails,
+    literal_operands: &[bool],
+) -> bool {
+    log::info!(
+        "checking whether literal operand vector {:?} matches operand details: {:?}",
+        literal_operands,
+        literal_operand_details
+    );
+
+    // Note: from the proto definition, it says "if none are specified, then any
+    // operand is allowed to be non-literal."
+    let allowed_nonliteral_operand: Option<HashSet<usize>> = if literal_operand_details
+        .allowed_nonliteral_operand
+        .is_empty()
+    {
+        None
+    } else {
+        Some(
+            literal_operand_details
+                .allowed_nonliteral_operand
+                .iter()
+                .map(|i| *i as usize)
+                .collect::<HashSet<_>>(),
+        )
+    };
+
+    let required_literal_operand: HashSet<usize> = literal_operand_details
+        .required_literal_operand
+        .iter()
+        .map(|i| *i as usize)
+        .collect::<HashSet<_>>();
+    for (i, is_literal) in literal_operands.iter().enumerate() {
+        // If `i` is required to be literal but is not, then we don't match.
+        if required_literal_operand.contains(&i) && !*is_literal {
+            log::info!("required literal operand {} is not literal", i);
+            return false;
+        }
+        if let Some(ref allowed_nonliteral) = allowed_nonliteral_operand {
+            // If `i` is not allowed to be a non-literal but is, then we don't match.
+            let is_allowed_nonliteral = allowed_nonliteral.contains(&i);
+            let is_nonliteral = !*is_literal;
+            if is_nonliteral && !is_allowed_nonliteral {
+                log::info!("non-literal operand {} is not allowed", i);
+                return false;
+            }
+        }
+    }
+    log::info!(
+        "literal operand vector {:?} matches operand details: {:?}",
+        literal_operands,
+        literal_operand_details
+    );
+    true
+}
+
+fn find_estimator_for_op<'a>(
+    em: &'a proto::EstimatorModel,
+    op: &str,
+    all_operands_identical: bool,
+    has_literal_operand: bool,
+    literal_operands: &[bool],
+) -> Option<&'a proto::Estimator> {
+    for op_model in em.op_models.iter() {
+        // Reminder: an `OpModel` has a "typical case" estimator and can have any number
+        // of "specializations" that match on the predicates we get. The specializations
+        // take precedence if they are matched on.
+        for specialization in op_model.specializations.iter() {
+            log::info!("checking specialization: {:?}", specialization);
+            let specialization_kind =
+                proto::SpecializationKind::try_from(specialization.kind).unwrap();
+
+            if specialization_kind == proto::SpecializationKind::OperandsIdentical
+                && all_operands_identical
+            {
+                assert!(
+                    specialization.details.is_none(),
+                    "'operands-identical' specializations should not have details"
+                );
+                return Some(&specialization.estimator.as_ref().unwrap());
+            }
+            if specialization_kind == proto::SpecializationKind::HasLiteralOperand
+                && has_literal_operand
+            {
+                // For literal operands there can also be detailed requirements.
+                let details = specialization.details.as_ref().unwrap();
+                let specialization_details: &proto::op_model::specialization::details::SpecializationDetails = details.specialization_details.as_ref().unwrap();
+                let literal_operand_details: &proto::LiteralOperandDetails = match specialization_details {
+                    proto::op_model::specialization::details::SpecializationDetails::LiteralOperandDetails(literal_operand_details) => literal_operand_details,
+                };
+                if matches_literal_operand_details(literal_operand_details, literal_operands) {
+                    return Some(&specialization.estimator.as_ref().unwrap());
+                }
+            }
+        }
+        if op_model.op == op {
+            return Some(&op_model.estimator.as_ref().unwrap());
+        }
+    }
+    None
+}
+
+pub fn eval_estimator_model(em: &proto::EstimatorModel, node: &dyn Node) -> Result<f64, String> {
+    // First we have to get the appropriate estimator for this node.
+    let estimator = find_estimator_for_op(
+        em,
+        node.op(),
+        node.all_operands_identical(),
+        node.has_literal_operand(),
+        &node.literal_operands(),
+    );
+    if let Some(estimator) = estimator {
+        eval_estimator(em, estimator, node)
+    } else {
+        Err(format!("No estimator found for op: {}", node.op()))
+    }
+}
+
+/// Augment a 2D array of factors `xdata` into a 2D matrix with a leading
+/// constant term in addition to raw and log2 terms for each factor.
+///
+/// This function returns an
+/// augmented matrix:
+/// - The first column is a constant term (1.0).
+/// - The next `n` columns are the raw values from `xdata`.
+/// - The final `n` columns are the log2-transformed values of `xdata` (with
+///   `log2(1)` for zeros).
+fn augment_xdata(xdata: &Array2<f64>) -> Array2<f64> {
+    let n = xdata.ncols();
+    let mut augmented = Array2::<f64>::zeros((xdata.nrows(), 1 + 2 * n));
+    {
+        let mut col0 = augmented.column_mut(0);
+        col0.fill(1.0);
+    }
+    for i in 0..n {
+        {
+            let mut col = augmented.column_mut(1 + i);
+            col.assign(&xdata.column(i));
+        }
+        {
+            let mut col = augmented.column_mut(1 + n + i);
+            col.assign(&xdata.column(i).map(|&x| (x.max(1.0)).log2()));
+        }
+    }
+    augmented
+}
+
+struct RegressionEstimatorImpl {
+    exprs: Vec<proto::EstimatorExpression>,
+    coeffs: Array1<f64>,
+}
+
+impl RegressionEstimatorImpl {
+    fn predict(&self, node: &dyn Node) -> f64 {
+        let xdata: Array1<f64> = self
+            .exprs
+            .iter()
+            .map(|e| eval_expression_for_node(e, node))
+            .collect::<Array1<f64>>();
+        let expr_count = xdata.len();
+        let x: Array1<f64> = augment_xdata(&xdata.into_shape((1, expr_count)).unwrap())
+            .row(0)
+            .to_owned();
+        let result: f64 = x.dot(&self.coeffs);
+        result
+    }
+}
+
+fn datapoint_is_for_op(dp: &proto::DataPoint, op: &str) -> bool {
+    let operation: &Option<proto::Operation> = &dp.operation;
+    if let Some(operation) = operation {
+        operation.op == op
+    } else {
+        log::warn!("data point has no operation: {:?}", dp);
+        false
+    }
+}
+
+/// After the characterization process we have a bunch of `y` values from our
+/// empirically observed delays and we can construct `x` variables with a vector
+/// like the following:
+///
+/// `[1, x0, log2(x0), x1, log2(x1), ...]`
+///
+/// The `x` variables are given as expressions in the op model.
+///
+/// See the `fit_curve` routine for a similar implementation in Python:
+/// https://sourcegraph.com/github.com/google/xls@5e5e2e0/-/blob/xls/estimators/estimator_model.py?L574
+fn make_regression_estimator(
+    spec: &proto::RegressionEstimator,
+    data_points: &[proto::DataPoint],
+    op: &str,
+) -> Result<RegressionEstimatorImpl, String> {
+    let data_points: Vec<&proto::DataPoint> = data_points
+        .iter()
+        .filter(|dp| datapoint_is_for_op(dp, op))
+        .collect();
+
+    if data_points.is_empty() {
+        return Err(format!("No data points found for op: {}", op));
+    }
+
+    // All the ground truth delays.
+    let y = Array1::from_vec(data_points.iter().map(|dp| dp.delay as f64).collect());
+
+    log::info!("ground truth delays: {:?}", y);
+
+    // `xdata` is the factors for each data point.
+    let mut xdata = Array2::zeros((data_points.len(), spec.expressions.len()));
+    for (i, dp) in data_points.iter().enumerate() {
+        for (j, expr) in spec.expressions.iter().enumerate() {
+            xdata[[i, j]] = eval_expression_for_data_point(expr, dp);
+        }
+    }
+    let x: Array2<f64> = augment_xdata(&xdata);
+
+    let (params, euclidian_norm) = nnls::nnls(x.view(), y.view());
+    log::info!("euclidian norm: {}", euclidian_norm);
+    Ok(RegressionEstimatorImpl {
+        exprs: spec.expressions.clone(),
+        coeffs: params,
+    })
+}
+
+pub fn parse_estimator_model_textproto(
+    textproto: &str,
+) -> Result<proto::EstimatorModel, Box<dyn std::error::Error>> {
+    // Load the descriptor set generated during build
+    let descriptor_bytes = include_bytes!(concat!(env!("OUT_DIR"), "/descriptors.bin"));
+    let pool = DescriptorPool::decode(descriptor_bytes.as_ref())?;
+
+    // Get the message descriptor for EstimatorModel
+    let message_descriptor: prost_reflect::MessageDescriptor = pool
+        .get_message_by_name("xls.estimator_model.EstimatorModel")
+        .ok_or("Message descriptor not found")?;
+
+    let dynamic_message =
+        prost_reflect::DynamicMessage::parse_text_format(message_descriptor, textproto)?;
+
+    // Encode the dynamic message and then decode it into the non-dynamic form.
+    let buf = dynamic_message.encode_to_vec();
+    let estimator_model = proto::EstimatorModel::decode(&*buf)?;
+
+    Ok(estimator_model)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeNode {
+        op: String,
+        result_bit_count: u64,
+        operand_bit_count: fn(usize) -> u64,
+        operand_count: u64,
+        operand_is_literal: fn(usize) -> bool,
+        all_operands_identical: bool,
+    }
+
+    impl Node for FakeNode {
+        fn op(&self) -> &str {
+            &self.op
+        }
+        fn result_bit_count(&self) -> u64 {
+            self.result_bit_count
+        }
+        fn operand_bit_count(&self, operand_number: usize) -> u64 {
+            (self.operand_bit_count)(operand_number)
+        }
+        fn operand_count(&self) -> u64 {
+            self.operand_count
+        }
+        fn operand_element_count(&self, _operand_number: usize) -> Option<u64> {
+            None
+        }
+        fn operand_element_bit_count(&self, _operand_number: usize) -> Option<u64> {
+            None
+        }
+        fn all_operands_identical(&self) -> bool {
+            self.all_operands_identical
+        }
+        fn has_literal_operand(&self) -> bool {
+            true
+        }
+        fn literal_operands(&self) -> Vec<bool> {
+            (0..self.operand_count)
+                .map(|i| (self.operand_is_literal)(i as usize))
+                .collect()
+        }
+    }
+
+    #[test]
+    fn test_eval_estimator_add() {
+        let textproto = r#"
+op_models {
+  op: "kAdd"
+  estimator {
+    regression {
+      expressions {
+        factor {
+          source: OPERAND_BIT_COUNT
+        }
+      }
+    }
+  }
+}
+data_points {
+  operation {
+    op: "kAdd"
+    bit_count: 5
+    operands {
+      bit_count: 5
+    }
+    operands {
+      bit_count: 5
+    }
+  }
+  delay: 240
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kAdd"
+    bit_count: 4
+    operands {
+      bit_count: 4
+    }
+    operands {
+      bit_count: 4
+    }
+  }
+  delay: 226
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kAdd"
+    bit_count: 2
+    operands {
+      bit_count: 2
+    }
+    operands {
+      bit_count: 2
+    }
+  }
+  delay: 186
+  delay_offset: 94
+}
+        "#;
+
+        let em = parse_estimator_model_textproto(textproto).unwrap();
+        let e = &em.op_models[0].estimator;
+        let spec = match &e.as_ref().unwrap().estimator {
+            Some(proto::estimator::Estimator::Regression(regression)) => regression,
+            _ => panic!("Expected regression estimator"),
+        };
+        let data_points = &em.data_points;
+
+        // Fit the regression estimator
+        let estimator = make_regression_estimator(&spec, &data_points, "kAdd").unwrap();
+
+        let node = FakeNode {
+            op: "kAdd".to_string(),
+            result_bit_count: 3,
+            operand_bit_count: |_operand_number: usize| 3,
+            operand_count: 2,
+            operand_is_literal: |_operand_number: usize| false,
+            all_operands_identical: false,
+        };
+
+        // Predict delay for operand bit count 3
+        let predicted_delay = estimator.predict(&node);
+
+        assert_eq!(format!("{:.2}", predicted_delay), "208.86");
+    }
+
+    #[test]
+    fn test_eval_estimator_alias() {
+        let textproto = r#"
+op_models {
+  op: "kShll"
+  estimator {
+    regression {
+      expressions {
+        factor {
+          source: OPERAND_BIT_COUNT
+        }
+      }
+    }
+  }
+}
+op_models {
+  op: "kShrl"
+  estimator {
+    alias_op: "kShll"
+  }
+}
+data_points {
+  operation {
+    op: "kShll"
+    bit_count: 12
+    operands {
+      bit_count: 12
+    }
+    operands {
+      bit_count: 4
+    }
+  }
+  delay: 300
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kShll"
+    bit_count: 8
+    operands {
+      bit_count: 8
+    }
+    operands {
+      bit_count: 3
+    }
+  }
+  delay: 255
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kShll"
+    bit_count: 6
+    operands {
+      bit_count: 6
+    }
+    operands {
+      bit_count: 3
+    }
+  }
+  delay: 223
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kShll"
+    bit_count: 4
+    operands {
+      bit_count: 4
+    }
+    operands {
+      bit_count: 2
+    }
+  }
+  delay: 202
+  delay_offset: 94
+}
+      "#;
+
+        let em: proto::EstimatorModel = parse_estimator_model_textproto(textproto).unwrap();
+        let node = FakeNode {
+            op: "kShrl".to_string(),
+            result_bit_count: 5,
+            operand_bit_count: |operand_number: usize| if operand_number == 0 { 5 } else { 3 },
+            operand_count: 2,
+            operand_is_literal: |_operand_number: usize| false,
+            all_operands_identical: false,
+        };
+        let predicted_delay = eval_estimator_model(&em, &node).unwrap();
+        assert_eq!(format!("{:.2}", predicted_delay), "213.91");
+    }
+
+    #[test]
+    fn test_two_factors_one_specialization() {
+        let textproto = r#"
+op_models {
+  op: "kSel"
+  estimator {
+    regression {
+      expressions {
+        factor {
+          source: RESULT_BIT_COUNT
+        }
+      }
+      expressions {
+        factor {
+          source: OPERAND_COUNT
+        }
+      }
+    }
+  }
+  specializations {
+    kind: HAS_LITERAL_OPERAND
+    estimator {
+      fixed: 0
+    }
+    details {
+      literal_operand_details {
+        required_literal_operand: 0
+      }
+    }
+  }
+}
+  data_points {
+  operation {
+    op: "kSel"
+    bit_count: 64
+    operands {
+      bit_count: 2
+    }
+    operands {
+      bit_count: 64
+    }
+    operands {
+      bit_count: 64
+    }
+    operands {
+      bit_count: 64
+    }
+    operands {
+      bit_count: 64
+    }
+  }
+  delay: 290
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kSel"
+    bit_count: 32
+    operands {
+      bit_count: 2
+    }
+    operands {
+      bit_count: 32
+    }
+    operands {
+      bit_count: 32
+    }
+    operands {
+      bit_count: 32
+    }
+    operands {
+      bit_count: 32
+    }
+  }
+  delay: 271
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kSel"
+    bit_count: 16
+    operands {
+      bit_count: 2
+    }
+    operands {
+      bit_count: 16
+    }
+    operands {
+      bit_count: 16
+    }
+    operands {
+      bit_count: 16
+    }
+    operands {
+      bit_count: 16
+    }
+  }
+  delay: 276
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kSel"
+    bit_count: 8
+    operands {
+      bit_count: 2
+    }
+    operands {
+      bit_count: 8
+    }
+    operands {
+      bit_count: 8
+    }
+    operands {
+      bit_count: 8
+    }
+    operands {
+      bit_count: 8
+    }
+  }
+  delay: 265
+  delay_offset: 94
+}
+  data_points {
+  operation {
+    op: "kSel"
+    bit_count: 1024
+    operands {
+      bit_count: 1
+    }
+    operands {
+      bit_count: 1024
+    }
+    operands {
+      bit_count: 1024
+    }
+  }
+  delay: 309
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kSel"
+    bit_count: 512
+    operands {
+      bit_count: 1
+    }
+    operands {
+      bit_count: 512
+    }
+    operands {
+      bit_count: 512
+    }
+  }
+  delay: 307
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kSel"
+    bit_count: 128
+    operands {
+      bit_count: 1
+    }
+    operands {
+      bit_count: 128
+    }
+    operands {
+      bit_count: 128
+    }
+  }
+  delay: 258
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kSel"
+    bit_count: 64
+    operands {
+      bit_count: 1
+    }
+    operands {
+      bit_count: 64
+    }
+    operands {
+      bit_count: 64
+    }
+  }
+  delay: 235
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kSel"
+    bit_count: 32
+    operands {
+      bit_count: 1
+    }
+    operands {
+      bit_count: 32
+    }
+    operands {
+      bit_count: 32
+    }
+  }
+  delay: 245
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kSel"
+    bit_count: 16
+    operands {
+      bit_count: 1
+    }
+    operands {
+      bit_count: 16
+    }
+    operands {
+      bit_count: 16
+    }
+  }
+  delay: 214
+  delay_offset: 94
+}
+data_points {
+  operation {
+    op: "kSel"
+    bit_count: 8
+    operands {
+      bit_count: 1
+    }
+    operands {
+      bit_count: 8
+    }
+    operands {
+      bit_count: 8
+    }
+  }
+  delay: 209
+  delay_offset: 94
+}
+        "#;
+
+        let _ = env_logger::builder().is_test(true).init();
+        let em = parse_estimator_model_textproto(textproto).unwrap();
+        let node = FakeNode {
+            op: "kSel".to_string(),
+            result_bit_count: 17,
+            operand_bit_count: |operand_number: usize| if operand_number == 0 { 1 } else { 17 },
+            operand_count: 3,
+            operand_is_literal: |_operand_number: usize| false,
+            all_operands_identical: false,
+        };
+        let predicted_delay = eval_estimator_model(&em, &node).unwrap();
+        assert_eq!(format!("{:.2}", predicted_delay), "222.63");
+
+        let specialized_node = FakeNode {
+            op: "kSel".to_string(),
+            result_bit_count: 17,
+            operand_bit_count: |operand_number: usize| if operand_number == 0 { 1 } else { 17 },
+            operand_count: 3,
+            operand_is_literal: |operand_number: usize| operand_number == 0,
+            all_operands_identical: false,
+        };
+        let specialized_delay = eval_estimator_model(&em, &specialized_node).unwrap();
+        assert_eq!(format!("{:.2}", specialized_delay), "0.00");
+    }
+}

--- a/xlsynth-estimator/src/main.rs
+++ b/xlsynth-estimator/src/main.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Command line tool that takes an `xls.estimator_model.EstimatorModel`
+//! textproto and a node description and emits the predicted delay for the node.
+//!
+//! ```
+//! <binary> <estimator_model_path> <node_description_str>
+//! ```
+//!
+//! Sample invocation of the command line:
+//! ```shell
+//! $ time xlsynth-estimator xls/estimators/delay_model/models/asap7.textproto \
+//!   "op: \"kAdd\" result_bit_count: 16 operand_bit_count: [16, 16] operand_count: 2"
+//! delay: 517.48
+//!
+//! real    0m0.010s
+//! ```
+
+mod estimator;
+
+use prost::Message;
+use prost_reflect::DescriptorPool;
+
+mod proto {
+    include!(concat!(env!("OUT_DIR"), "/xlsynth.estimator.rs"));
+}
+
+fn parse_sample_node_textproto(
+    textproto: &str,
+) -> Result<proto::SampleNode, Box<dyn std::error::Error>> {
+    // Load the descriptor set generated during build
+    let descriptor_bytes = include_bytes!(concat!(env!("OUT_DIR"), "/descriptors.bin"));
+    let pool = DescriptorPool::decode(descriptor_bytes.as_ref())?;
+
+    // Get the message descriptor for EstimatorModel
+    let message_descriptor: prost_reflect::MessageDescriptor = pool
+        .get_message_by_name("xlsynth.estimator.SampleNode")
+        .ok_or("Message descriptor not found")?;
+
+    let dynamic_message =
+        prost_reflect::DynamicMessage::parse_text_format(message_descriptor, textproto)?;
+
+    // Encode the dynamic message and then decode it into the non-dynamic form.
+    let buf = dynamic_message.encode_to_vec();
+    let sample_node = proto::SampleNode::decode(&*buf)?;
+
+    Ok(sample_node)
+}
+
+struct SampleNode {
+    wrapped: proto::SampleNode,
+}
+
+impl estimator::Node for SampleNode {
+    fn op(&self) -> &str {
+        &self.wrapped.op
+    }
+    fn result_bit_count(&self) -> u64 {
+        self.wrapped.result_bit_count
+    }
+    fn operand_bit_count(&self, operand_number: usize) -> u64 {
+        self.wrapped.operand_bit_count[operand_number]
+    }
+    fn operand_count(&self) -> u64 {
+        self.wrapped.operand_count
+    }
+    fn operand_element_count(&self, operand_number: usize) -> Option<u64> {
+        if self.wrapped.operand_element_count.is_empty() {
+            None
+        } else {
+            Some(self.wrapped.operand_element_count[operand_number])
+        }
+    }
+    fn operand_element_bit_count(&self, operand_number: usize) -> Option<u64> {
+        if self.wrapped.operand_element_bit_count.is_empty() {
+            None
+        } else {
+            Some(self.wrapped.operand_element_bit_count[operand_number])
+        }
+    }
+    fn all_operands_identical(&self) -> bool {
+        self.wrapped.all_operands_identical
+    }
+    fn has_literal_operand(&self) -> bool {
+        self.wrapped.has_literal_operand
+    }
+    fn literal_operands(&self) -> Vec<bool> {
+        self.wrapped.literal_operands.clone()
+    }
+}
+
+fn main() {
+    let _ = env_logger::builder().init();
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        println!("Usage: <binary> <estimator_model_path> <node_description_str>");
+        std::process::exit(1);
+    }
+
+    let estimator_model_path = std::path::PathBuf::from(&args[1]);
+    let node_description_str = &args[2];
+
+    // Read in the estimator model from the given path.
+    let estimator_model_text = std::fs::read_to_string(estimator_model_path).unwrap();
+    let estimator_model =
+        estimator::parse_estimator_model_textproto(&estimator_model_text).unwrap();
+
+    // Read in the node description from the given string.
+    let node_proto = parse_sample_node_textproto(&node_description_str).unwrap();
+    let node = SampleNode {
+        wrapped: node_proto,
+    };
+
+    match estimator::eval_estimator_model(&estimator_model, &node) {
+        Ok(delay) => println!("delay: {:.2}", delay),
+        Err(e) => {
+            eprintln!("error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
This is a first step towards a pluggable delay estimator via the C API so environments can register new delay estimators.

Uses various case studies from the asap7 EstimatorModel protobuf.