### PR TITLE
[sv_bridge] Fixes issue seen where type alias is not named same as original.

### DIFF
--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.0.120";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.0.121";
 
 struct DsoInfo {
     extension: &'static str,

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -608,6 +608,9 @@ extern "C" {
     pub fn xls_dslx_type_definition_get_colon_ref(
         type_definition: *const CDslxTypeDefinition,
     ) -> *mut CDslxColonRef;
+    pub fn xls_dslx_type_definition_get_type_alias(
+        type_definition: *const CDslxTypeDefinition,
+    ) -> *mut CDslxTypeAlias;
 
     // -- TypeRefTypeAnnotation
 

--- a/xlsynth/src/dslx.rs
+++ b/xlsynth/src/dslx.rs
@@ -468,6 +468,17 @@ impl TypeDefinition {
             ptr: casted,
         })
     }
+
+    pub fn to_type_alias(&self) -> Option<TypeAlias> {
+        let casted = unsafe { sys::xls_dslx_type_definition_get_type_alias(self.ptr) };
+        if casted.is_null() {
+            return None;
+        }
+        Some(TypeAlias {
+            parent: self.parent.clone(),
+            ptr: casted,
+        })
+    }
 }
 
 // -- TypeRef

--- a/xlsynth/src/sv_bridge_builder.rs
+++ b/xlsynth/src/sv_bridge_builder.rs
@@ -366,7 +366,9 @@ impl BridgeBuilder for SvBridgeBuilder {
 
             // If the member_annotated_ty is a local alias, we want to emit the type via
             // its local identifier.
-            if let Some(type_ref_type_annotation) = member_annotated_ty.to_type_ref_type_annotation() {
+            if let Some(type_ref_type_annotation) =
+                member_annotated_ty.to_type_ref_type_annotation()
+            {
                 let type_ref = type_ref_type_annotation.get_type_ref();
                 let type_def = type_ref.get_type_definition();
                 if let Some(type_alias) = type_def.to_type_alias() {

--- a/xlsynth/src/sv_bridge_builder.rs
+++ b/xlsynth/src/sv_bridge_builder.rs
@@ -110,7 +110,7 @@ fn get_extern_type_ref(
 
         // Inspect whether the type definition is a colon-reference where the subject is
         // another module.
-        let type_definition = type_ref.get_type_definition();
+        let type_definition: dslx::TypeDefinition = type_ref.get_type_definition();
         if let Some(colon_ref) = type_definition.to_colon_ref() {
             if let Some(import) = colon_ref.resolve_import_subject() {
                 // It is a reference to a type defined in another module -- refer to its in
@@ -359,9 +359,26 @@ impl BridgeBuilder for SvBridgeBuilder {
 
             let member_annotated_ty = &member.type_annotation;
 
+            log::info!(
+                "member_name: {member_name} concrete_ty: {}",
+                member_concrete_ty
+            );
+
             if let Some(extern_ref) = get_extern_type_ref(member_annotated_ty, member_concrete_ty) {
                 lines.push(format!("    {} {};", extern_ref, member_name));
                 continue;
+            }
+
+            // If the member_annotated_ty is a local alias, we want to emit the type via
+            // its local identifier.
+            if let Some(type_ref_type_annotation) = member_annotated_ty.to_type_ref_type_annotation() {
+                let type_ref = type_ref_type_annotation.get_type_ref();
+                let type_def = type_ref.get_type_definition();
+                if let Some(type_alias) = type_def.to_type_alias() {
+                    let sv_type_name = struct_name_to_sv(&type_alias.get_identifier());
+                    lines.push(format!("    {} {};", sv_type_name, member_name));
+                    continue;
+                }
             }
 
             let member_sv_ty = convert_type(member_concrete_ty, None)?;

--- a/xlsynth/src/sv_bridge_builder.rs
+++ b/xlsynth/src/sv_bridge_builder.rs
@@ -359,11 +359,6 @@ impl BridgeBuilder for SvBridgeBuilder {
 
             let member_annotated_ty = &member.type_annotation;
 
-            log::info!(
-                "member_name: {member_name} concrete_ty: {}",
-                member_concrete_ty
-            );
-
             if let Some(extern_ref) = get_extern_type_ref(member_annotated_ty, member_concrete_ty) {
                 lines.push(format!("    {} {};", extern_ref, member_name));
                 continue;

--- a/xlsynth/tests/structure_zoo.x
+++ b/xlsynth/tests/structure_zoo.x
@@ -114,8 +114,8 @@ struct HasExternalStruct {
 }
 
 /// Struct that refers to an external struct type through a local alias.
-type Point = common_zoo::Point;
+type MyPoint = common_zoo::Point;
 
 struct HasExternalStructThroughLocalAlias {
-    point: Point,
+    point: MyPoint,
 }

--- a/xlsynth/tests/want_structure_zoo.golden.sv
+++ b/xlsynth/tests/want_structure_zoo.golden.sv
@@ -83,15 +83,15 @@ typedef struct packed {
 typedef common_zoo_sv_pkg::my_u8_t my_u8_t;
 
 typedef struct packed {
-    logic [7:0] data;
+    my_u8_t data;
 } external_alias_through_local_alias_struct_t;
 
 typedef struct packed {
     common_zoo_sv_pkg::point_t point;
 } has_external_struct_t;
 
-typedef common_zoo_sv_pkg::point_t point_t;
+typedef common_zoo_sv_pkg::point_t my_point_t;
 
 typedef struct packed {
-    point_t point;
+    my_point_t point;
 } has_external_struct_through_local_alias_t;


### PR DESCRIPTION
Note: this should pass once the `v0.0.121` release of xlsynth is done: https://github.com/xlsynth/xlsynth/actions/runs/12383539921