### PR TITLE
Add more value APIs to avoid stringy manipulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +140,12 @@ name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -196,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +232,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags 1.3.2",
+ "textwrap",
+ "unicode-width",
+]
 
 [[package]]
 name = "clap"
@@ -278,6 +312,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+dependencies = [
+ "atty",
+ "cast",
+ "clap 2.34.0",
+ "criterion-plot",
+ "csv",
+ "itertools 0.10.5",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +380,27 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -602,6 +693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +715,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -976,7 +1082,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
@@ -1209,7 +1315,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -1229,12 +1335,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "openssl"
 version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1350,6 +1462,34 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1525,7 +1665,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -1635,7 +1775,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1694,6 +1834,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "sample-usage"
 version = "0.1.0"
 dependencies = [
@@ -1723,7 +1872,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1756,6 +1905,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -1921,7 +2080,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -2012,6 +2171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2227,16 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2223,6 +2401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,6 +2452,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2385,6 +2579,37 @@ dependencies = [
  "rustix",
  "winsafe",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-registry"
@@ -2519,7 +2744,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -2547,10 +2772,12 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.71"
+version = "0.0.72"
 dependencies = [
  "cargo_metadata",
+ "criterion",
  "env_logger",
+ "lazy_static",
  "log",
  "pretty_assertions",
  "test-helpers",
@@ -2559,9 +2786,9 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-driver"
-version = "0.0.71"
+version = "0.0.72"
 dependencies = [
- "clap",
+ "clap 4.5.29",
  "env_logger",
  "log",
  "prost-build",
@@ -2575,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-estimator"
-version = "0.0.71"
+version = "0.0.72"
 dependencies = [
  "env_logger",
  "log",
@@ -2589,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-sys"
-version = "0.0.71"
+version = "0.0.72"
 dependencies = [
  "flate2",
  "libc",

--- a/sample-usage/build.rs
+++ b/sample-usage/build.rs
@@ -21,7 +21,7 @@ fn make_readme_snippet_file() {
     println!("cargo:rerun-if-changed=README.md");
 
     // Read entire README
-    let readme_contents = std::fs::read_to_string("README.md").expect("Failed to read README.md");
+    let readme_contents = std::fs::read_to_string("README.md").unwrap();
 
     // Extract the snippet between ```rust and ``` lines
     let snippet = extract_rust_fence(&readme_contents)
@@ -51,7 +51,7 @@ mod readme_snippet {{
     // Now write that out:
     let out_dir = std::env::var("OUT_DIR").unwrap();
     let test_file = std::path::Path::new(&out_dir).join("readme_snippet_test.rs");
-    std::fs::write(&test_file, test_code).expect("Failed to write readme_snippet_test.rs");
+    std::fs::write(&test_file, test_code).expect("write readme_snippet_test.rs should succeed");
 }
 
 fn main() {

--- a/sample-usage/src/main.rs
+++ b/sample-usage/src/main.rs
@@ -79,7 +79,7 @@ fn validate_fail() -> Result<(), Box<dyn std::error::Error>> {
     let result = load_and_invoke(file, "always_fail");
     match result {
         Ok(_) => Err(Box::new(xlsynth::XlsynthError(
-            "expected function to fail".to_string(),
+            "expected function call to fail".to_string(),
         ))),
         Err(e) => {
             if e.to_string()

--- a/sample-usage/src/multithread.rs
+++ b/sample-usage/src/multithread.rs
@@ -9,9 +9,9 @@ use xlsynth::IrValue;
 
 fn load_package(cargo_relpath: &str) -> IrPackage {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(cargo_relpath);
-    let dslx = std::fs::read_to_string(&path).expect("read_to_string failed");
-    let result = xlsynth::convert_dslx_to_ir(&dslx, path.as_path(), &DslxConvertOptions::default())
-        .expect("convert_dslx_to_ir failed");
+    let dslx = std::fs::read_to_string(&path).unwrap();
+    let result =
+        xlsynth::convert_dslx_to_ir(&dslx, path.as_path(), &DslxConvertOptions::default()).unwrap();
     for warning in result.warnings {
         log::warn!("DSLX warning for {}: {}", path.to_str().unwrap(), warning);
     }
@@ -24,8 +24,8 @@ lazy_static! {
     // interpreter.
     static ref ADD1_FUNCTION: xlsynth::IrFunction = {
         let package = load_package("src/sample.x");
-        let mangled = xlsynth::mangle_dslx_name("sample", "add1").expect("mangle_dslx_name failed");
-        let function = package.get_function(&mangled).expect("get_function failed");
+        let mangled = xlsynth::mangle_dslx_name("sample", "add1").unwrap();
+        let function = package.get_function(&mangled).unwrap();
         assert_eq!(function.get_name(), mangled);
         function
     };
@@ -33,9 +33,7 @@ lazy_static! {
 
 fn run_dslx_add1(x: u32) -> u32 {
     let x_ir = IrValue::u32(x);
-    let result = ADD1_FUNCTION
-        .interpret(&[x_ir])
-        .expect("interpretation success");
+    let result = ADD1_FUNCTION.interpret(&[x_ir]).unwrap();
     result.to_u32().unwrap()
 }
 

--- a/xlsynth-driver/Cargo.toml
+++ b/xlsynth-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-driver"
-version = "0.0.71"
+version = "0.0.72"
 edition = "2021"
 
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/xlsynth"
 homepage = "https://github.com/xlsynth/xlsynth-crate"
 
 [dependencies]
-xlsynth = { path = "../xlsynth", version = "0.0.71" }
+xlsynth = { path = "../xlsynth", version = "0.0.72" }
 clap = "4.5.21"
 tempfile = "3.13"
 toml = "0.8.19"

--- a/xlsynth-driver/src/ir2delayinfo.rs
+++ b/xlsynth-driver/src/ir2delayinfo.rs
@@ -26,7 +26,7 @@ fn run_delay_info_main(
         command.arg("--top").arg(top.unwrap());
     }
 
-    let output = command.output().expect("Failed to execute delay_info_main");
+    let output = command.output().expect("delay_info_main should succeed");
 
     if !output.status.success() {
         eprintln!("Delay info failed with status: {}", output.status);

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -279,14 +279,15 @@ fn main() {
     let toml_path = matches.get_one::<String>("toolchain");
     let toml_value: Option<toml::Value> = toml_path.map(|path| {
         // If we got a toolchain toml file, read/parse it.
-        let toml_str = std::fs::read_to_string(path).expect("Failed to read toolchain toml file");
-        toml::from_str(&toml_str).expect("Failed to parse toolchain toml file")
+        let toml_str =
+            std::fs::read_to_string(path).expect("read toolchain toml file should succeed");
+        toml::from_str(&toml_str).expect("parse toolchain toml file should succeed")
     });
     let config = toml_value.map(|v| {
-        let toolchain_config = v
-            .clone()
-            .try_into::<XlsynthToolchain>()
-            .expect(&format!("Failed to parse toolchain config; value: {}", v));
+        let toolchain_config = v.clone().try_into::<XlsynthToolchain>().expect(&format!(
+            "parse toolchain config should succeed; value: {}",
+            v
+        ));
         toolchain_config.toolchain
     });
 

--- a/xlsynth-driver/src/tools.rs
+++ b/xlsynth-driver/src/tools.rs
@@ -40,7 +40,7 @@ pub fn run_codegen_pipeline(
     log::info!("Running command: {:?}", command);
 
     // We run the codegen_main tool on the given input file.
-    let output = command.output().expect("Failed to execute codegen_main");
+    let output = command.output().expect("codegen_main should succeed");
 
     if !output.status.success() {
         eprintln!("Pipeline generation failed with status: {}", output.status);
@@ -66,7 +66,7 @@ pub fn run_opt_main(input_file: &std::path::Path, ir_top: Option<&str>, tool_pat
         command.arg("--top").arg(ir_top.unwrap());
     }
 
-    let output = command.output().expect("Failed to execute IR optimization");
+    let output = command.output().expect("opt_main should succeed");
 
     if !output.status.success() {
         eprintln!("IR optimization failed with status: {}", output.status);
@@ -126,7 +126,7 @@ pub fn run_ir_converter_main(
     }
 
     log::info!("command: {:?}", command);
-    let output = command.output().expect("Failed to execute ir_convert");
+    let output = command.output().expect("ir_converter_main should succeed");
 
     if !output.status.success() {
         eprintln!("IR conversion failed with status: {}", output.status);

--- a/xlsynth-driver/tests/invoke_test.rs
+++ b/xlsynth-driver/tests/invoke_test.rs
@@ -43,7 +43,7 @@ fn test_dslx2sv_types_subcommand(use_tool_path: bool) {
         .arg("--dslx_input_file")
         .arg(dslx_path.to_str().unwrap())
         .output()
-        .expect("Failed to run xlsynth-driver");
+        .unwrap();
 
     assert!(
         output.status.success(),
@@ -84,7 +84,7 @@ struct MyStruct {
         .arg("--dslx_input_file")
         .arg(dslx_path.to_str().unwrap())
         .output()
-        .expect("Failed to run xlsynth-driver");
+        .unwrap();
 
     assert!(
         output.status.success(),
@@ -156,7 +156,7 @@ dslx_stdlib_path = "{}"
         .arg("--dslx_top")
         .arg("main")
         .output()
-        .expect("Failed to run xlsynth-driver");
+        .unwrap();
 
     assert!(
         output.status.success(),
@@ -208,7 +208,7 @@ fn main(x: MyStruct[4]) -> MyStruct[4] {
         .arg("--dslx_top")
         .arg("main")
         .output()
-        .expect("Failed to run xlsynth-driver");
+        .unwrap();
 
     assert!(
         output.status.success(),
@@ -276,7 +276,7 @@ enable_warnings = ["already_exhaustive_match"]
         .arg("main")
         .env("RUST_LOG", rust_log)
         .output()
-        .expect("Failed to run xlsynth-driver");
+        .unwrap();
 
     // Check that the output shows the warning and that the return code is
     // non-success because we have warnings-as-errors on.
@@ -338,7 +338,7 @@ fn test_dslx2pipeline_with_unused_binding(use_tool_path: bool) {
         .arg("main")
         .env("RUST_LOG", &rust_log)
         .output()
-        .expect("Failed to run xlsynth-driver");
+        .unwrap();
 
     assert!(
         !output.status.success(),
@@ -385,7 +385,7 @@ disable_warnings = ["unused_definition", "empty_range_literal"]
         .arg("main")
         .env("RUST_LOG", &rust_log)
         .output()
-        .expect("Failed to run xlsynth-driver");
+        .unwrap();
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/xlsynth-estimator/Cargo.toml
+++ b/xlsynth-estimator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-estimator"
-version = "0.0.71"
+version = "0.0.72"
 edition = "2021"
 
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]

--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-sys"
-version = "0.0.71"
+version = "0.0.72"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust (Native Library)"

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.0.143";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.0.144";
 
 struct DsoInfo {
     extension: &'static str,
@@ -56,7 +56,7 @@ fn high_integrity_download(
 
     let tmp_dir = env_tmp_dir.join(format!("xlsynth-sys-tmp-{}", std::process::id()));
     // Make the temp dir.
-    std::fs::create_dir_all(&tmp_dir).expect("Failed to create temp directory");
+    std::fs::create_dir_all(&tmp_dir).expect("create temp directory should succeed");
 
     // Download the sha256 checksum file to the temp directory.
     let checksum_url = format!("{}.sha256", url);
@@ -238,7 +238,7 @@ fn download_dso_if_dne(url_base: &str, out_dir: &str) -> DsoInfo {
     );
 
     // Download the DSO
-    high_integrity_download(&dso_url, &dso_path).expect("Failed to download DSO");
+    high_integrity_download(&dso_url, &dso_path).expect("download of DSO should succeed");
 
     if cfg!(target_os = "macos") {
         let dso_filename = dso_info.get_dso_filename();
@@ -249,7 +249,7 @@ fn download_dso_if_dne(url_base: &str, out_dir: &str) -> DsoInfo {
             .arg(format!("@rpath/{}", &dso_filename))
             .arg(&dso_path)
             .status()
-            .expect("Failed to fix DSO id");
+            .expect("fixing DSO id should succeed");
 
         if !status.success() {
             panic!("Fixing DSO id failed with status: {:?}", status);
@@ -272,7 +272,7 @@ fn download_stdlib_if_dne(url_base: &str, out_dir: &str) -> PathBuf {
     let tarball_path = PathBuf::from(&out_dir).join("dslx_stdlib.tar.gz");
     let tarball_url = format!("{url_base}/dslx_stdlib.tar.gz");
     high_integrity_download(&tarball_url, &tarball_path)
-        .expect("Failed to download stdlib tarball");
+        .expect("download of stdlib tarball should succeed");
 
     let tar_gz = std::fs::File::open(tarball_path).unwrap();
     let tar = flate2::read::GzDecoder::new(tar_gz);

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -247,13 +247,68 @@ extern "C" {
     ) -> bool;
     pub fn xls_value_free(value: *mut CIrValue);
 
+    pub fn xls_value_clone(value: *const CIrValue) -> *mut CIrValue;
+
+    // Extracts a bits value from a (boxed) value or gives an error.
     pub fn xls_value_get_bits(
         value: *const CIrValue,
         error_out: *mut *mut std::os::raw::c_char,
         bits_out: *mut *mut CIrBits,
     ) -> bool;
 
+    // Turns a span of IR values into a tuple value.
+    pub fn xls_value_make_tuple(
+        value_count: libc::size_t,
+        values: *const *mut CIrValue,
+    ) -> *mut CIrValue;
+
+    // Extracts an element from a tuple/array value or gives an error (e.g. if this
+    // value is not a tuple/array or the index is out of bounds).
+    pub fn xls_value_get_element(
+        tuple: *const CIrValue,
+        index: libc::size_t,
+        error_out: *mut *mut std::os::raw::c_char,
+        element_out: *mut *mut CIrValue,
+    ) -> bool;
+
+    pub fn xls_value_get_element_count(
+        value: *const CIrValue,
+        error_out: *mut *mut std::os::raw::c_char,
+        count_out: *mut i64,
+    ) -> bool;
+
+    // Creates a bits value (via an unsigned integer) that is boxed in an IrValue.
+    pub fn xls_value_make_ubits(
+        bit_count: i64,
+        value: u64,
+        error_out: *mut *mut std::os::raw::c_char,
+        result_out: *mut *mut CIrValue,
+    ) -> bool;
+
+    // Creates a bits value (via a signed integer) that is boxed in an IrValue.
+    pub fn xls_value_make_sbits(
+        bit_count: i64,
+        value: i64,
+        error_out: *mut *mut std::os::raw::c_char,
+        result_out: *mut *mut CIrValue,
+    ) -> bool;
+
+    // Boxes an IR bits object into an IR value.
     pub fn xls_value_from_bits(bits: *const CIrBits) -> *mut CIrValue;
+
+    pub fn xls_bits_make_ubits(
+        bit_count: i64,
+        value: u64,
+        error_out: *mut *mut std::os::raw::c_char,
+        bits_out: *mut *mut CIrBits,
+    ) -> bool;
+
+    pub fn xls_bits_make_sbits(
+        bit_count: i64,
+        value: i64,
+        error_out: *mut *mut std::os::raw::c_char,
+        bits_out: *mut *mut CIrBits,
+    ) -> bool;
 
     pub fn xls_bits_free(bits: *mut CIrBits);
     pub fn xls_bits_get_bit_count(bits: *const CIrBits) -> i64;

--- a/xlsynth/Cargo.toml
+++ b/xlsynth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth"
-version = "0.0.71"
+version = "0.0.72"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust"
@@ -13,7 +13,7 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 readme = "../README.md"
 
 [dependencies]
-xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.71"}
+xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.72"}
 cargo_metadata = "0.18"
 log = "0.4"
 
@@ -21,3 +21,17 @@ log = "0.4"
 env_logger = "0.11"
 pretty_assertions = "1.3"
 test-helpers = { path = "../test-helpers" }
+lazy_static = "1.4"
+criterion = "0.3"
+
+[[bench]]
+name = "call_dslx"
+harness = false
+
+[[bench]]
+name = "build_f32_tuple"
+harness = false
+
+[[bench]]
+name = "bits_ops"
+harness = false

--- a/xlsynth/benches/bits_ops.rs
+++ b/xlsynth/benches/bits_ops.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use xlsynth::{IrBits, IrValue};
+
+/// Benchmarks creating a single boolean `false` value via the Bits creation
+/// machinery.
+fn bench_make_bits(c: &mut Criterion) {
+    c.bench_function("make_bits", |b| {
+        b.iter(|| {
+            let bits = IrBits::make_ubits(1, 0).unwrap();
+            black_box(bits);
+        });
+    });
+}
+
+/// Benchmarks getting the bit count of a bits value.
+fn bench_get_bit_count(c: &mut Criterion) {
+    let bits = IrBits::make_ubits(1, 0).unwrap();
+    c.bench_function("get_bit_count", |b| {
+        b.iter(|| {
+            black_box(bits.get_bit_count());
+        });
+    });
+}
+
+/// Benchmarks getting the bit count of an IrValue that holds bits.
+fn bench_get_bit_count_of_value(c: &mut Criterion) {
+    let value = IrValue::make_ubits(1, 0).unwrap();
+    c.bench_function("get_bit_count_of_value", |b| {
+        b.iter(|| {
+            let bit_count: usize = value.bit_count().unwrap();
+            black_box(bit_count);
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_make_bits,
+    bench_get_bit_count,
+    bench_get_bit_count_of_value
+);
+criterion_main!(benches);

--- a/xlsynth/benches/build_f32_tuple.rs
+++ b/xlsynth/benches/build_f32_tuple.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use xlsynth::IrValue;
+
+/// Benchmarks making 3 bits values and packing them into a tuple (in the shape
+/// of a DSLX `float32::F32`).
+fn bench_build_f32_tuple(c: &mut Criterion) {
+    c.bench_function("build_f32_tuple", |b| {
+        b.iter(|| {
+            let sign = IrValue::make_ubits(1, 0).unwrap();
+            let bexp = IrValue::make_ubits(8, 127).unwrap();
+            let frac = IrValue::make_ubits(23, 0).unwrap();
+            let f32_tuple = IrValue::make_tuple(&[sign, bexp, frac]);
+            black_box(f32_tuple);
+        });
+    });
+}
+
+/// Benchmarks unpacking a tuple into 3 bits values (in the shape of a DSLX
+/// `float32::F32`).
+fn bench_unpack_f32_tuple(c: &mut Criterion) {
+    let _ = env_logger::builder().is_test(true).try_init();
+    c.bench_function("unpack_f32_tuple", |b| {
+        let orig = IrValue::make_tuple(&[
+            IrValue::make_ubits(1, 0).unwrap(),
+            IrValue::make_ubits(8, 127).unwrap(),
+            IrValue::make_ubits(23, 0).unwrap(),
+        ]);
+        b.iter(|| {
+            let elements = orig.get_elements().unwrap();
+            let [sign, bexp, frac] = elements.as_slice() else {
+                panic!("expected 3 elements");
+            };
+            black_box((sign, bexp, frac));
+        });
+    });
+}
+
+fn bench_clone_f32_tuple(c: &mut Criterion) {
+    c.bench_function("clone_f32_tuple", |b| {
+        let orig = IrValue::make_tuple(&[
+            IrValue::make_ubits(1, 0).unwrap(),
+            IrValue::make_ubits(8, 127).unwrap(),
+            IrValue::make_ubits(23, 0).unwrap(),
+        ]);
+        b.iter(|| {
+            let clone = orig.clone();
+            black_box(clone);
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_build_f32_tuple,
+    bench_unpack_f32_tuple,
+    bench_clone_f32_tuple
+);
+criterion_main!(benches);

--- a/xlsynth/benches/call_dslx.rs
+++ b/xlsynth/benches/call_dslx.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use lazy_static::lazy_static;
+
+use xlsynth::IrValue;
+
+const DSLX_CODE: &str = "import float32;
+
+fn make_f32(sign: bool, bexp: u8, fraction: u23) -> float32::F32 {
+    float32::F32 { sign, bexp, fraction }
+}
+";
+
+lazy_static! {
+    static ref MAKE_F32: xlsynth::IrFunction = {
+        let convert_result: xlsynth::DslxToIrPackageResult = xlsynth::convert_dslx_to_ir(
+            DSLX_CODE,
+            std::path::Path::new("/memfile/make_f32.x"),
+            &xlsynth::DslxConvertOptions::default(),
+        )
+        .unwrap();
+        let package: xlsynth::IrPackage = convert_result.ir;
+        let mangled = xlsynth::mangle_dslx_name("make_f32", "make_f32").unwrap();
+        let function = package.get_function(&mangled).unwrap();
+        function
+    };
+}
+
+// Benchmarks calling the DSLX function with pre-created values.
+//
+// Notably this still creates a result value that we are then deallocating in
+// each trip.
+fn bench_call_dslx(c: &mut Criterion) {
+    c.bench_function("call_dslx", |b| {
+        let s = IrValue::make_ubits(1, 0).unwrap();
+        let bexp = IrValue::make_ubits(8, 127).unwrap();
+        let frac = IrValue::make_ubits(23, 0).unwrap();
+        let args = vec![s, bexp, frac];
+        b.iter(|| {
+            let result: IrValue = MAKE_F32.interpret(&args).unwrap();
+            black_box(result);
+        });
+    });
+}
+
+criterion_group!(benches, bench_call_dslx);
+criterion_main!(benches);

--- a/xlsynth/src/ir_package.rs
+++ b/xlsynth/src/ir_package.rs
@@ -62,7 +62,7 @@ impl IrPackagePtr {
 impl Drop for IrPackagePtr {
     fn drop(&mut self) {
         if !self.0.is_null() {
-            xls_package_free(self.0).expect("dealloc success");
+            xls_package_free(self.0);
             self.0 = std::ptr::null_mut();
         }
     }

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -717,4 +717,17 @@ mod tests {
         assert_eq!(elements[2].to_string(), "bits[3]:2");
         assert_eq!(elements[2], b3_v2);
     }
+
+    #[test]
+    fn test_make_ir_value_bits_that_does_not_fit() {
+        let result = IrValue::make_ubits(1, 2);
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(error.to_string().contains("0x2 requires 2 bits to fit in an unsigned datatype, but attempting to fit in 1 bit"), "got: {}", error);
+
+        let result = IrValue::make_sbits(1, -2);
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(error.to_string().contains("0xfffffffffffffffe requires 2 bits to fit in an signed datatype, but attempting to fit in 1 bit"), "got: {}", error);
+    }
 }

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -355,7 +355,7 @@ impl IrValue {
 
     pub fn get_elements(&self) -> Result<Vec<IrValue>, XlsynthError> {
         let count = self.get_element_count()?;
-        let mut elements = Vec::new();
+        let mut elements = Vec::with_capacity(count);
         for i in 0..count {
             let element = self.get_element(i)?;
             elements.push(element);

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -4,8 +4,10 @@ use xlsynth_sys::{CIrBits, CIrValue};
 
 use crate::{
     lib_support::{
-        xls_bits_to_debug_str, xls_bits_to_string, xls_format_preference_from_string, xls_value_eq,
-        xls_value_free, xls_value_get_bits, xls_value_to_string,
+        xls_bits_make_sbits, xls_bits_make_ubits, xls_bits_to_debug_str, xls_bits_to_string,
+        xls_format_preference_from_string, xls_value_eq, xls_value_free, xls_value_get_bits,
+        xls_value_get_element, xls_value_get_element_count, xls_value_make_sbits,
+        xls_value_make_tuple, xls_value_make_ubits, xls_value_to_string,
         xls_value_to_string_format_preference,
     },
     xls_parse_typed_value,
@@ -18,9 +20,12 @@ pub struct IrBits {
 }
 
 impl IrBits {
-    pub fn new(bit_count: usize, value: u64) -> Result<Self, XlsynthError> {
-        let value = IrValue::make_bits(bit_count, value)?;
-        Ok(value.to_bits()?)
+    pub fn make_ubits(bit_count: usize, value: u64) -> Result<Self, XlsynthError> {
+        xls_bits_make_ubits(bit_count, value)
+    }
+
+    pub fn make_sbits(bit_count: usize, value: i64) -> Result<Self, XlsynthError> {
+        xls_bits_make_sbits(bit_count, value)
     }
 
     pub fn get_bit_count(&self) -> usize {
@@ -195,6 +200,8 @@ impl std::ops::Not for IrBits {
     }
 }
 
+// --
+
 pub enum IrFormatPreference {
     Default,
     Binary,
@@ -228,6 +235,10 @@ pub struct IrValue {
 }
 
 impl IrValue {
+    pub fn make_tuple(elements: &[IrValue]) -> Self {
+        xls_value_make_tuple(elements)
+    }
+
     pub fn from_bits(bits: &IrBits) -> Self {
         let ptr = unsafe { xlsynth_sys::xls_value_from_bits(bits.ptr) };
         Self { ptr }
@@ -238,36 +249,27 @@ impl IrValue {
     }
 
     pub fn u32(value: u32) -> Self {
-        // TODO(cdleary): 2024-06-23 Expose a more efficient API for this.
-        Self::parse_typed(std::format!("bits[32]:{}", value).as_str()).unwrap()
+        // Unwrap should be ok since the u32 always fits.
+        xls_value_make_ubits(value as u64, 32).unwrap()
     }
 
     pub fn u64(value: u64) -> Self {
-        // TODO(cdleary): 2024-06-23 Expose a more efficient API for this.
-        Self::parse_typed(std::format!("bits[64]:{}", value).as_str()).unwrap()
+        // Unwrap should be ok since the u64 always fits.
+        xls_value_make_ubits(value as u64, 64).unwrap()
     }
 
-    pub fn make_bits(bit_count: usize, value: u64) -> Result<Self, XlsynthError> {
-        // TODO(cdleary): 2024-10-06 Expose a more efficient API for this.
-        Self::parse_typed(std::format!("bits[{}]:{}", bit_count, value).as_str())
+    pub fn make_ubits(bit_count: usize, value: u64) -> Result<Self, XlsynthError> {
+        xls_value_make_ubits(value as u64, bit_count)
     }
 
-    pub fn bit_count(&self) -> usize {
-        // TODO(cdleary): 2024-06-23 Expose a more efficient API for this.
-        let s = self
-            .to_string_fmt(IrFormatPreference::Default)
-            .expect("fmt success");
-        // Look at the decimal value in the formatted result; e.g. `bits[7]:42` => `7`
-        let parts: Vec<&str> = s
-            .split(':')
-            .nth(0)
-            .expect("split success")
-            .split('[')
-            .nth(1)
-            .expect("split success")
-            .split(']')
-            .collect();
-        return parts[0].parse::<usize>().expect("parse success");
+    pub fn make_sbits(bit_count: usize, value: i64) -> Result<Self, XlsynthError> {
+        xls_value_make_sbits(value, bit_count)
+    }
+
+    pub fn bit_count(&self) -> Result<usize, XlsynthError> {
+        // TODO(cdleary): 2024-06-23 Expose a more efficient API for this from libxls.so
+        let bits = self.to_bits()?;
+        Ok(bits.get_bit_count())
     }
 
     pub fn to_string_fmt(&self, format: IrFormatPreference) -> Result<String, XlsynthError> {
@@ -290,20 +292,14 @@ impl IrValue {
     }
 
     pub fn to_bool(&self) -> Result<bool, XlsynthError> {
-        if self.bit_count() != 1 {
+        let bits = self.to_bits()?;
+        if bits.get_bit_count() != 1 {
             return Err(XlsynthError(format!(
                 "IrValue {} is not single-bit; must be bits[1] to convert to bool",
                 self.to_string()
             )));
         }
-        // TODO(cdleary): 2024-06-23 Expose a more efficient API for this.
-        let s = self.to_string_fmt(IrFormatPreference::PlainBinary)?;
-        let v = s.split(':').nth(1).expect("split success");
-        match v {
-            "0" => return Ok(false),
-            "1" => return Ok(true),
-            _ => panic!("Unexpected stringified value for single-bit IrValue: {}", s),
-        }
+        bits.get_bit(0)
     }
 
     pub fn to_i64(&self) -> Result<i64, XlsynthError> {
@@ -348,6 +344,24 @@ impl IrValue {
     pub fn to_bits(&self) -> Result<IrBits, XlsynthError> {
         xls_value_get_bits(self.ptr)
     }
+
+    pub fn get_element(&self, index: usize) -> Result<IrValue, XlsynthError> {
+        xls_value_get_element(self.ptr, index)
+    }
+
+    pub fn get_element_count(&self) -> Result<usize, XlsynthError> {
+        xls_value_get_element_count(self.ptr)
+    }
+
+    pub fn get_elements(&self) -> Result<Vec<IrValue>, XlsynthError> {
+        let count = self.get_element_count()?;
+        let mut elements = Vec::new();
+        for i in 0..count {
+            let element = self.get_element(i)?;
+            elements.push(element);
+        }
+        Ok(elements)
+    }
 }
 
 unsafe impl Send for IrValue {}
@@ -387,10 +401,8 @@ impl Drop for IrValue {
 
 impl Clone for IrValue {
     fn clone(&self) -> Self {
-        // TODO(cdleary): 2024-12-14 We should either add a C API for cloning IR values
-        // more efficiently than this text serdes, or implement refcounted CIrValue
-        // pointers on the Rust side of the fence.
-        IrValue::parse_typed(&self.to_string()).unwrap()
+        let ptr = unsafe { xlsynth_sys::xls_value_clone(self.ptr) };
+        Self { ptr }
     }
 }
 
@@ -527,10 +539,11 @@ mod tests {
             "bits[64]:42"
         );
         // Check the bit count is as we specified.
-        assert_eq!(v.bit_count(), 64);
+        assert_eq!(v.bit_count().unwrap(), 64);
 
         // Check we can't convert a 64-bit value to a bool.
-        v.to_bool().expect_err("bool conversion fail for u64");
+        v.to_bool()
+            .expect_err("bool conversion should error for u64");
 
         let v_i64 = v.to_i64().expect("i64 conversion success");
         assert_eq!(v_i64, 42);
@@ -548,7 +561,7 @@ mod tests {
         let bits = v.to_bits().expect("to_bits success");
 
         // Equality comparison.
-        let v2 = IrValue::make_bits(32, 42).expect("make_bits success");
+        let v2 = IrValue::make_ubits(32, 42).expect("make_ubits success");
         assert_eq!(v, v2);
 
         // Getting at bit values; 42 = 0b101010.
@@ -578,7 +591,7 @@ mod tests {
 
     #[test]
     fn test_ir_value_make_bits() {
-        let zero_u2 = IrValue::make_bits(2, 0).expect("make_bits success");
+        let zero_u2 = IrValue::make_ubits(2, 0).expect("make_ubits success");
         assert_eq!(
             zero_u2
                 .to_string_fmt(IrFormatPreference::Default)
@@ -586,7 +599,7 @@ mod tests {
             "bits[2]:0"
         );
 
-        let three_u2 = IrValue::make_bits(2, 3).expect("make_bits success");
+        let three_u2 = IrValue::make_ubits(2, 3).expect("make_ubits success");
         assert_eq!(
             three_u2
                 .to_string_fmt(IrFormatPreference::Default)
@@ -611,24 +624,26 @@ mod tests {
 
     #[test]
     fn test_ir_bits_add_two_plus_three() {
-        let two = IrBits::new(32, 2).expect("make_bits success");
-        let three = IrBits::new(32, 3).expect("make_bits success");
+        let two = IrBits::make_ubits(32, 2).expect("make_ubits success");
+        let three = IrBits::make_ubits(32, 3).expect("make_ubits success");
         let sum = two + three;
         assert_eq!(sum.to_string(), "bits[32]:5");
     }
 
     #[test]
     fn test_ir_bits_umul_two_times_three() {
-        let two = IrBits::new(32, 2).expect("make_bits success");
-        let three = IrBits::new(32, 3).expect("make_bits success");
+        let two = IrBits::make_ubits(32, 2).expect("make_ubits success");
+        let three = IrBits::make_ubits(32, 3).expect("make_ubits success");
         let product = two.umul(&three);
         assert_eq!(product.to_string(), "bits[64]:6");
     }
 
     #[test]
     fn test_ir_bits_smul_two_times_neg_three() {
-        let two = IrBits::new(32, 2).expect("make_bits success");
-        let neg_three = IrBits::new(32, 3).expect("make_bits success").negate();
+        let two = IrBits::make_ubits(32, 2).expect("make_ubits success");
+        let neg_three = IrBits::make_ubits(32, 3)
+            .expect("make_ubits success")
+            .negate();
         let product = two.smul(&neg_three);
         assert_eq!(product.msb(), true);
         assert_eq!(product.abs().to_string(), "bits[64]:6");
@@ -636,53 +651,70 @@ mod tests {
 
     #[test]
     fn test_ir_bits_width_slice() {
-        let bits = IrBits::new(32, 0x12345678).expect("make_bits success");
+        let bits = IrBits::make_ubits(32, 0x12345678).expect("make_ubits success");
         let slice = bits.width_slice(8, 16);
         assert_eq!(slice.to_hex_string(), "bits[16]:0x3456");
     }
 
     #[test]
     fn test_ir_bits_shll() {
-        let bits = IrBits::new(32, 0x12345678).expect("make_bits success");
+        let bits = IrBits::make_ubits(32, 0x12345678).expect("make_ubits success");
         let shifted = bits.shll(8);
         assert_eq!(shifted.to_hex_string(), "bits[32]:0x3456_7800");
     }
 
     #[test]
     fn test_ir_bits_shrl() {
-        let bits = IrBits::new(32, 0x12345678).expect("make_bits success");
+        let bits = IrBits::make_ubits(32, 0x12345678).expect("make_ubits success");
         let shifted = bits.shrl(8);
         assert_eq!(shifted.to_hex_string(), "bits[32]:0x12_3456");
     }
 
     #[test]
     fn test_ir_bits_shra() {
-        let bits = IrBits::new(32, 0x92345678).expect("make_bits success");
+        let bits = IrBits::make_ubits(32, 0x92345678).expect("make_ubits success");
         let shifted = bits.shra(8);
         assert_eq!(shifted.to_hex_string(), "bits[32]:0xff92_3456");
     }
 
     #[test]
     fn test_ir_bits_and() {
-        let lhs = IrBits::new(32, 0x5a5a5a5a).expect("make_bits success");
-        let rhs = IrBits::new(32, 0xa5a5a5a5).expect("make_bits success");
+        let lhs = IrBits::make_ubits(32, 0x5a5a5a5a).expect("make_ubits success");
+        let rhs = IrBits::make_ubits(32, 0xa5a5a5a5).expect("make_ubits success");
         assert_eq!(lhs.and(&rhs).to_hex_string(), "bits[32]:0x0");
         assert_eq!(lhs.and(&rhs.not()).to_hex_string(), "bits[32]:0x5a5a_5a5a");
     }
 
     #[test]
     fn test_ir_bits_or() {
-        let lhs = IrBits::new(32, 0x5a5a5a5a).expect("make_bits success");
-        let rhs = IrBits::new(32, 0xa5a5a5a5).expect("make_bits success");
+        let lhs = IrBits::make_ubits(32, 0x5a5a5a5a).expect("make_ubits success");
+        let rhs = IrBits::make_ubits(32, 0xa5a5a5a5).expect("make_ubits success");
         assert_eq!(lhs.or(&rhs).to_hex_string(), "bits[32]:0xffff_ffff");
         assert_eq!(lhs.or(&rhs.not()).to_hex_string(), "bits[32]:0x5a5a_5a5a");
     }
 
     #[test]
     fn test_ir_bits_xor() {
-        let lhs = IrBits::new(32, 0x5a5a5a5a).expect("make_bits success");
-        let rhs = IrBits::new(32, 0xa5a5a5a5).expect("make_bits success");
+        let lhs = IrBits::make_ubits(32, 0x5a5a5a5a).expect("make_ubits success");
+        let rhs = IrBits::make_ubits(32, 0xa5a5a5a5).expect("make_ubits success");
         assert_eq!(lhs.xor(&rhs).to_hex_string(), "bits[32]:0xffff_ffff");
         assert_eq!(lhs.xor(&rhs.not()).to_hex_string(), "bits[32]:0x0");
+    }
+
+    #[test]
+    fn test_make_tuple_and_get_elements() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let b1_v0 = IrValue::make_ubits(1, 0).expect("make_ubits success");
+        let b2_v1 = IrValue::make_ubits(2, 1).expect("make_ubits success");
+        let b3_v2 = IrValue::make_ubits(3, 2).expect("make_ubits success");
+        let tuple = IrValue::make_tuple(&[b1_v0.clone(), b2_v1.clone(), b3_v2.clone()]);
+        let elements = tuple.get_elements().expect("get_elements success");
+        assert_eq!(elements.len(), 3);
+        assert_eq!(elements[0].to_string(), "bits[1]:0");
+        assert_eq!(elements[0], b1_v0);
+        assert_eq!(elements[1].to_string(), "bits[2]:1");
+        assert_eq!(elements[1], b2_v1);
+        assert_eq!(elements[2].to_string(), "bits[3]:2");
+        assert_eq!(elements[2], b3_v2);
     }
 }

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -395,7 +395,7 @@ impl std::fmt::Debug for IrValue {
 
 impl Drop for IrValue {
     fn drop(&mut self) {
-        xls_value_free(self.ptr).expect("dealloc success");
+        xls_value_free(self.ptr)
     }
 }
 

--- a/xlsynth/src/lib_support.rs
+++ b/xlsynth/src/lib_support.rs
@@ -86,10 +86,117 @@ pub(crate) fn xls_value_to_string(p: *mut CIrValue) -> Result<String, XlsynthErr
     }
 }
 
+pub(crate) fn xls_value_get_element(
+    p: *mut CIrValue,
+    index: usize,
+) -> Result<IrValue, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut element_out: *mut CIrValue = std::ptr::null_mut();
+        let success =
+            xlsynth_sys::xls_value_get_element(p, index, &mut error_out, &mut element_out);
+        if success {
+            return Ok(IrValue { ptr: element_out });
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+pub(crate) fn xls_value_get_element_count(p: *const CIrValue) -> Result<usize, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut count: i64 = 0;
+        let success = xlsynth_sys::xls_value_get_element_count(p, &mut error_out, &mut count);
+        if success {
+            return Ok(count as usize);
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+pub(crate) fn xls_value_make_ubits(value: u64, bit_count: usize) -> Result<IrValue, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut result: *mut CIrValue = std::ptr::null_mut();
+        let success =
+            xlsynth_sys::xls_value_make_ubits(bit_count as i64, value, &mut error_out, &mut result);
+        if success {
+            return Ok(IrValue { ptr: result });
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+pub(crate) fn xls_value_make_sbits(value: i64, bit_count: usize) -> Result<IrValue, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut result: *mut CIrValue = std::ptr::null_mut();
+        let success =
+            xlsynth_sys::xls_value_make_sbits(bit_count as i64, value, &mut error_out, &mut result);
+        if success {
+            return Ok(IrValue { ptr: result });
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+pub(crate) fn xls_value_make_tuple(elements: &[IrValue]) -> IrValue {
+    unsafe {
+        // The C API call takes ownership of the elements that are in the array.
+        let elements_ptrs: Vec<*mut CIrValue> = elements
+            .iter()
+            .map(|v| -> *mut CIrValue { xlsynth_sys::xls_value_clone(v.ptr) })
+            .collect();
+        let result = xlsynth_sys::xls_value_make_tuple(elements_ptrs.len(), elements_ptrs.as_ptr());
+        assert!(!result.is_null());
+        IrValue { ptr: result }
+    }
+}
+
 pub(crate) fn xls_bits_to_debug_str(p: *const CIrBits) -> String {
     unsafe {
         let c_str_out = xlsynth_sys::xls_bits_to_debug_string(p);
         return c_str_to_rust(c_str_out);
+    }
+}
+
+pub(crate) fn xls_bits_make_ubits(bit_count: usize, value: u64) -> Result<IrBits, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut bits_out: *mut CIrBits = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_bits_make_ubits(
+            bit_count as i64,
+            value,
+            &mut error_out,
+            &mut bits_out,
+        );
+        if success {
+            return Ok(IrBits { ptr: bits_out });
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
+    }
+}
+
+pub(crate) fn xls_bits_make_sbits(bit_count: usize, value: i64) -> Result<IrBits, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut bits_out: *mut CIrBits = std::ptr::null_mut();
+        let success = xlsynth_sys::xls_bits_make_sbits(
+            bit_count as i64,
+            value,
+            &mut error_out,
+            &mut bits_out,
+        );
+        if success {
+            return Ok(IrBits { ptr: bits_out });
+        }
+        let error_out_str: String = c_str_to_rust(error_out);
+        return Err(XlsynthError(error_out_str));
     }
 }
 

--- a/xlsynth/src/lib_support.rs
+++ b/xlsynth/src/lib_support.rs
@@ -487,7 +487,8 @@ pub(crate) fn xls_interpret_function(
     args: &[IrValue],
 ) -> Result<IrValue, XlsynthError> {
     unsafe {
-        let args_ptrs: Vec<*const CIrValue> = args.iter().map(|v| v.ptr).collect();
+        let args_ptrs: Vec<*const CIrValue> =
+            args.iter().map(|v| -> *const CIrValue { v.ptr }).collect();
         let argc = args_ptrs.len();
         let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
         let mut result_out: *mut CIrValue = std::ptr::null_mut();

--- a/xlsynth/src/lib_support.rs
+++ b/xlsynth/src/lib_support.rs
@@ -21,10 +21,34 @@ use crate::{
     IrBits, IrValue, XlsynthError,
 };
 
-/// Binding for the C API function:
-/// ```c
-/// bool xls_package_to_string(const struct xls_package* p, char** string_out) {
+/// Macro for performing FFI calls to fallible functions with a trailing output
+/// parameter.
+///
+/// You call it by passing in the FFI function, its regular arguments,
+/// then a semicolon and the identifier to populate with the output.
+/// It returns a Result<(), XlsynthError>.
+///
+/// For instance, calling:
+/// ```rust-snippet
+/// let mut ir_out: *mut c_char = std::ptr::null_mut();
+/// xls_call!(xlsynth_sys::xls_optimize_ir, ir.as_ptr(), top.as_ptr(); ir_out)?;
 /// ```
+/// will call the FFI function with the arguments and automatically convert the
+/// error if it occurs.
+macro_rules! xls_ffi_call {
+    ($func:path $(, $arg:expr )* ; $out:ident) => {{
+        unsafe {
+            let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+            let success = $func($($arg,)* &mut error_out, &mut $out);
+            if success {
+                Ok(())
+            } else {
+                Err(XlsynthError(c_str_to_rust(error_out)))
+            }
+        }
+    }};
+}
+
 pub(crate) fn xls_package_to_string(p: *const CIrPackage) -> Result<String, XlsynthError> {
     unsafe {
         let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
@@ -87,62 +111,27 @@ pub(crate) fn xls_value_get_element(
     p: *mut CIrValue,
     index: usize,
 ) -> Result<IrValue, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut element_out: *mut CIrValue = std::ptr::null_mut();
-        let success =
-            xlsynth_sys::xls_value_get_element(p, index, &mut error_out, &mut element_out);
-        if success {
-            Ok(IrValue { ptr: element_out })
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut element_out: *mut CIrValue = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_value_get_element, p, index; element_out)?;
+    Ok(IrValue { ptr: element_out })
 }
 
 pub(crate) fn xls_value_get_element_count(p: *const CIrValue) -> Result<usize, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut count: i64 = 0;
-        let success = xlsynth_sys::xls_value_get_element_count(p, &mut error_out, &mut count);
-        if success {
-            Ok(count as usize)
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut count: i64 = 0;
+    xls_ffi_call!(xlsynth_sys::xls_value_get_element_count, p; count)?;
+    Ok(count as usize)
 }
 
 pub(crate) fn xls_value_make_ubits(value: u64, bit_count: usize) -> Result<IrValue, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result: *mut CIrValue = std::ptr::null_mut();
-        let success =
-            xlsynth_sys::xls_value_make_ubits(bit_count as i64, value, &mut error_out, &mut result);
-        if success {
-            Ok(IrValue { ptr: result })
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut result: *mut CIrValue = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_value_make_ubits, bit_count as i64, value; result)?;
+    Ok(IrValue { ptr: result })
 }
 
 pub(crate) fn xls_value_make_sbits(value: i64, bit_count: usize) -> Result<IrValue, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result: *mut CIrValue = std::ptr::null_mut();
-        let success =
-            xlsynth_sys::xls_value_make_sbits(bit_count as i64, value, &mut error_out, &mut result);
-        if success {
-            Ok(IrValue { ptr: result })
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut result: *mut CIrValue = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_value_make_sbits, bit_count as i64, value; result)?;
+    Ok(IrValue { ptr: result })
 }
 
 pub(crate) fn xls_value_make_tuple(elements: &[IrValue]) -> IrValue {
@@ -166,99 +155,39 @@ pub(crate) fn xls_bits_to_debug_str(p: *const CIrBits) -> String {
 }
 
 pub(crate) fn xls_bits_make_ubits(bit_count: usize, value: u64) -> Result<IrBits, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut bits_out: *mut CIrBits = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_bits_make_ubits(
-            bit_count as i64,
-            value,
-            &mut error_out,
-            &mut bits_out,
-        );
-        if success {
-            Ok(IrBits { ptr: bits_out })
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut result: *mut CIrBits = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_bits_make_ubits, bit_count as i64, value; result)?;
+    Ok(IrBits { ptr: result })
 }
 
 pub(crate) fn xls_bits_make_sbits(bit_count: usize, value: i64) -> Result<IrBits, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut bits_out: *mut CIrBits = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_bits_make_sbits(
-            bit_count as i64,
-            value,
-            &mut error_out,
-            &mut bits_out,
-        );
-        if success {
-            Ok(IrBits { ptr: bits_out })
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut result: *mut CIrBits = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_bits_make_sbits, bit_count as i64, value; result)?;
+    Ok(IrBits { ptr: result })
 }
 
 pub(crate) fn xls_value_get_bits(p: *const CIrValue) -> Result<IrBits, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut bits_out: *mut CIrBits = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_value_get_bits(p, &mut error_out, &mut bits_out);
-        if success {
-            Ok(IrBits { ptr: bits_out })
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut result: *mut CIrBits = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_value_get_bits, p; result)?;
+    Ok(IrBits { ptr: result })
 }
 
 pub(crate) fn xls_format_preference_from_string(
     s: &str,
 ) -> Result<XlsFormatPreference, XlsynthError> {
-    unsafe {
-        let c_str = CString::new(s).unwrap();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result_out: XlsFormatPreference = -1;
-        let success = xlsynth_sys::xls_format_preference_from_string(
-            c_str.as_ptr(),
-            &mut error_out,
-            &mut result_out,
-        );
-        if success {
-            Ok(result_out)
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let c_str = CString::new(s).unwrap();
+    let mut result_out: XlsFormatPreference = -1;
+    xls_ffi_call!(xlsynth_sys::xls_format_preference_from_string, c_str.as_ptr(); result_out)?;
+    Ok(result_out)
 }
 
 pub(crate) fn xls_value_to_string_format_preference(
     p: *mut CIrValue,
     fmt: XlsFormatPreference,
 ) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_value_to_string_format_preference(
-            p,
-            fmt,
-            &mut error_out,
-            &mut c_str_out,
-        );
-        if success {
-            Ok(c_str_to_rust(c_str_out))
-        } else {
-            Err(XlsynthError(
-                "Failed to convert XLS value to string via C API".to_string(),
-            ))
-        }
-    }
+    let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_value_to_string_format_preference, p, fmt; c_str_out)?;
+    Ok(unsafe { c_str_to_rust(c_str_out) })
 }
 
 pub(crate) fn xls_bits_to_string(
@@ -266,23 +195,9 @@ pub(crate) fn xls_bits_to_string(
     fmt: XlsFormatPreference,
     include_bit_count: bool,
 ) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_bits_to_string(
-            p,
-            fmt,
-            include_bit_count,
-            &mut error_out,
-            &mut c_str_out,
-        );
-        if success {
-            Ok(c_str_to_rust(c_str_out))
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_bits_to_string, p, fmt, include_bit_count; c_str_out)?;
+    Ok(unsafe { c_str_to_rust(c_str_out) })
 }
 
 pub(crate) fn xls_value_eq(
@@ -292,271 +207,109 @@ pub(crate) fn xls_value_eq(
     unsafe { Ok(xlsynth_sys::xls_value_eq(lhs, rhs)) }
 }
 
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_parse_ir_package(
-///     const char* ir, const char* filename,
-///     char** error_out,
-///     struct xls_package** xls_package_out);
-/// ```
 pub(crate) fn xls_parse_ir_package(
     ir: &str,
     filename: Option<&str>,
 ) -> Result<crate::ir_package::IrPackage, XlsynthError> {
-    unsafe {
-        let ir = CString::new(ir).unwrap();
-        // The filename is allowed to be a null pointer if there is no filename.
-        let filename_ptr = filename
-            .map(|s| CString::new(s).unwrap())
-            .map(|s| s.as_ptr())
-            .unwrap_or(std::ptr::null());
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut xls_package_out: *mut CIrPackage = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_parse_ir_package(
-            ir.as_ptr(),
-            filename_ptr,
-            &mut error_out,
-            &mut xls_package_out,
-        );
-        if success {
-            let package = crate::ir_package::IrPackage {
-                ptr: Arc::new(RwLock::new(IrPackagePtr(xls_package_out))),
-                filename: filename.map(|s| s.to_string()),
-            };
-            Ok(package)
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let ir_cstring = CString::new(ir).unwrap();
+    let filename_ptr = filename
+        .map(|s| CString::new(s).unwrap())
+        .map(|s| s.as_ptr())
+        .unwrap_or(std::ptr::null());
+    let mut xls_package_out: *mut CIrPackage = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_parse_ir_package, ir_cstring.as_ptr(), filename_ptr; xls_package_out)?;
+    let package = crate::ir_package::IrPackage {
+        ptr: Arc::new(RwLock::new(IrPackagePtr(xls_package_out))),
+        filename: filename.map(|s| s.to_string()),
+    };
+    Ok(package)
 }
 
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_type_to_string(struct xls_type* type, char** error_out,
-/// char** result_out);
-/// ```
 pub(crate) fn xls_type_to_string(t: *const CIrType) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_type_to_string(t, &mut error_out, &mut c_str_out);
-        if success {
-            Ok(c_str_to_rust(c_str_out))
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_type_to_string, t; c_str_out)?;
+    Ok(unsafe { c_str_to_rust(c_str_out) })
 }
 
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_package_get_type_for_value(struct xls_package* package,
-// struct xls_value* value, char** error_out,
-/// struct xls_type** result_out);
-/// ```
 pub(crate) fn xls_package_get_type_for_value(
     package: *const CIrPackage,
     value: *const CIrValue,
 ) -> Result<IrType, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result_out: *mut CIrType = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_package_get_type_for_value(
-            package,
-            value,
-            &mut error_out,
-            &mut result_out,
-        );
-        if success {
-            let ir_type = IrType { ptr: result_out };
-            Ok(ir_type)
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut result_out: *mut CIrType = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_package_get_type_for_value, package, value; result_out)?;
+    Ok(IrType { ptr: result_out })
 }
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_package_get_function(
-///    struct xls_package* package,
-///    const char* function_name, char** error_out,
-///    struct xls_function** result_out);
-/// ```
+
 pub(crate) fn xls_package_get_function(
     package: &Arc<RwLock<IrPackagePtr>>,
     guard: RwLockReadGuard<IrPackagePtr>,
     function_name: &str,
 ) -> Result<crate::ir_package::IrFunction, XlsynthError> {
-    unsafe {
-        let function_name = CString::new(function_name).unwrap();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result_out: *mut CIrFunction = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_package_get_function(
-            guard.const_c_ptr(),
-            function_name.as_ptr(),
-            &mut error_out,
-            &mut result_out,
-        );
-        if success {
-            let function = crate::ir_package::IrFunction {
-                parent: package.clone(),
-                ptr: result_out,
-            };
-            Ok(function)
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let function_name = CString::new(function_name).unwrap();
+    let mut result_out: *mut CIrFunction = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_package_get_function, guard.const_c_ptr(), function_name.as_ptr(); result_out)?;
+    Ok(crate::ir_package::IrFunction {
+        parent: package.clone(),
+        ptr: result_out,
+    })
 }
 
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_function_get_type(struct xls_function* function, char** error_out,
-/// struct xls_function_type** xls_fn_type_out);
-/// ```
 pub(crate) fn xls_function_get_type(
     _package_write_guard: &RwLockWriteGuard<IrPackagePtr>,
     function: *const CIrFunction,
 ) -> Result<IrFunctionType, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut xls_fn_type_out: *mut CIrFunctionType = std::ptr::null_mut();
-        let success =
-            xlsynth_sys::xls_function_get_type(function, &mut error_out, &mut xls_fn_type_out);
-        if success {
-            let ir_type = IrFunctionType {
-                ptr: xls_fn_type_out,
-            };
-            Ok(ir_type)
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut xls_fn_type_out: *mut CIrFunctionType = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_function_get_type, function; xls_fn_type_out)?;
+    Ok(IrFunctionType {
+        ptr: xls_fn_type_out,
+    })
 }
 
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_function_type_to_string(struct xls_function_type* xls_function_type,
-/// char** error_out, char** string_out);
-/// ```
 pub(crate) fn xls_function_type_to_string(
     t: *const CIrFunctionType,
 ) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_function_type_to_string(t, &mut error_out, &mut c_str_out);
-        if success {
-            Ok(c_str_to_rust(c_str_out))
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_function_type_to_string, t; c_str_out)?;
+    Ok(unsafe { c_str_to_rust(c_str_out) })
 }
 
 pub(crate) fn xls_function_get_name(function: *const CIrFunction) -> Result<String, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_function_get_name(function, &mut error_out, &mut c_str_out);
-        if success {
-            Ok(c_str_to_rust(c_str_out))
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let mut c_str_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_function_get_name, function; c_str_out)?;
+    Ok(unsafe { c_str_to_rust(c_str_out) })
 }
 
-/// Bindings for the C API function:
-/// ```c
-/// bool xls_interpret_function(
-///     struct xls_function* function, size_t argc,
-///     const struct xls_value** args, char** error_out,
-///     struct xls_value** result_out);
-/// ```
 pub(crate) fn xls_interpret_function(
     _package_guard: &RwLockReadGuard<IrPackagePtr>,
     function: *const CIrFunction,
     args: &[IrValue],
 ) -> Result<IrValue, XlsynthError> {
-    unsafe {
-        let args_ptrs: Vec<*const CIrValue> =
-            args.iter().map(|v| -> *const CIrValue { v.ptr }).collect();
-        let argc = args_ptrs.len();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result_out: *mut CIrValue = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_interpret_function(
-            function,
-            argc,
-            args_ptrs.as_ptr(),
-            &mut error_out,
-            &mut result_out,
-        );
-        if success {
-            Ok(IrValue { ptr: result_out })
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let args_ptrs: Vec<*const CIrValue> =
+        args.iter().map(|v| -> *const CIrValue { v.ptr }).collect();
+    let argc = args_ptrs.len();
+    let mut result_out: *mut CIrValue = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_interpret_function, function, argc, args_ptrs.as_ptr(); result_out)?;
+    Ok(IrValue { ptr: result_out })
 }
 
-/// Binding for the C API function:
-/// ```c
-/// bool xls_optimize_ir(const char* ir, const char* top, char** error_out,
-/// char** ir_out);
-/// ```
 pub(crate) fn xls_optimize_ir(ir: &str, top: &str) -> Result<String, XlsynthError> {
-    unsafe {
-        let ir = CString::new(ir).unwrap();
-        let top = CString::new(top).unwrap();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut ir_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success =
-            xlsynth_sys::xls_optimize_ir(ir.as_ptr(), top.as_ptr(), &mut error_out, &mut ir_out);
-        if success {
-            Ok(c_str_to_rust(ir_out))
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let ir = CString::new(ir).unwrap();
+    let top = CString::new(top).unwrap();
+    let mut ir_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_optimize_ir, ir.as_ptr(), top.as_ptr(); ir_out)?;
+    let ir_str = unsafe { c_str_to_rust(ir_out) };
+    Ok(ir_str)
 }
 
-/// Binding for the C API function:
-/// ```c
-/// bool xls_mangle_dslx_name(const char* module_name, const char* function_name,
-/// char** error_out, char** mangled_out);
-/// ```
 pub(crate) fn xls_mangle_dslx_name(
     module_name: &str,
     function_name: &str,
 ) -> Result<String, XlsynthError> {
-    unsafe {
-        let module_name = CString::new(module_name).unwrap();
-        let function_name = CString::new(function_name).unwrap();
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut mangled_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let success = xlsynth_sys::xls_mangle_dslx_name(
-            module_name.as_ptr(),
-            function_name.as_ptr(),
-            &mut error_out,
-            &mut mangled_out,
-        );
-        if success {
-            Ok(c_str_to_rust(mangled_out))
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let module_name = CString::new(module_name).unwrap();
+    let function_name = CString::new(function_name).unwrap();
+    let mut mangled_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_mangle_dslx_name, module_name.as_ptr(), function_name.as_ptr(); mangled_out)?;
+    Ok(unsafe { c_str_to_rust(mangled_out) })
 }
 
 pub(crate) fn xls_schedule_and_codegen_package(
@@ -566,27 +319,16 @@ pub(crate) fn xls_schedule_and_codegen_package(
     codegen_flags_proto_str: &str,
     with_delay_model: bool,
 ) -> Result<ScheduleAndCodegenResult, XlsynthError> {
-    unsafe {
-        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
-        let mut result_out: *mut CScheduleAndCodegenResult = std::ptr::null_mut();
-        let scheduling_options_flags_proto =
-            CString::new(scheduling_options_flags_proto_str).unwrap();
-        let codegen_flags_proto = CString::new(codegen_flags_proto_str).unwrap();
-        let success = xlsynth_sys::xls_schedule_and_codegen_package(
-            guard.mut_c_ptr(),
-            scheduling_options_flags_proto.as_ptr(),
-            codegen_flags_proto.as_ptr(),
-            with_delay_model,
-            &mut error_out,
-            &mut result_out,
-        );
-        if success {
-            assert!(!result_out.is_null());
-            let result = ScheduleAndCodegenResult { ptr: result_out };
-            Ok(result)
-        } else {
-            let error_out_str: String = c_str_to_rust(error_out);
-            Err(XlsynthError(error_out_str))
-        }
-    }
+    let scheduling_options_flags_proto = CString::new(scheduling_options_flags_proto_str).unwrap();
+    let codegen_flags_proto = CString::new(codegen_flags_proto_str).unwrap();
+    let mut result_out: *mut CScheduleAndCodegenResult = std::ptr::null_mut();
+    xls_ffi_call!(xlsynth_sys::xls_schedule_and_codegen_package,
+        guard.mut_c_ptr(),
+        scheduling_options_flags_proto.as_ptr(),
+        codegen_flags_proto.as_ptr(),
+        with_delay_model;
+        result_out
+    )?;
+    assert!(!result_out.is_null());
+    Ok(ScheduleAndCodegenResult { ptr: result_out })
 }

--- a/xlsynth/src/rust_bridge_builder.rs
+++ b/xlsynth/src/rust_bridge_builder.rs
@@ -97,10 +97,11 @@ impl BridgeBuilder for RustBridgeBuilder {
         for (member_name, value) in members.iter() {
             let value_str = value_to_string(value)?;
             self.lines.push(format!(
-                "            {}::{} => IrValue::make_bits({}, {}).unwrap(),",
+                "            {}::{} => IrValue::make_{}bits({}, {}).unwrap(),",
                 dslx_name,
                 member_name,
-                value.bit_count(),
+                if is_signed { "s" } else { "u" },
+                value.bit_count()?,
                 value_str
             ));
         }
@@ -180,8 +181,8 @@ pub enum MyEnum {
 impl Into<IrValue> for MyEnum {
     fn into(self) -> IrValue {
         match self {
-            MyEnum::A => IrValue::make_bits(2, 0).unwrap(),
-            MyEnum::B => IrValue::make_bits(2, 3).unwrap(),
+            MyEnum::A => IrValue::make_ubits(2, 0).unwrap(),
+            MyEnum::B => IrValue::make_ubits(2, 3).unwrap(),
         }
     }
 }
@@ -246,8 +247,8 @@ pub enum MyEnum {
 impl Into<IrValue> for MyEnum {
     fn into(self) -> IrValue {
         match self {
-            MyEnum::A => IrValue::make_bits(2, 0).unwrap(),
-            MyEnum::B => IrValue::make_bits(2, 3).unwrap(),
+            MyEnum::A => IrValue::make_ubits(2, 0).unwrap(),
+            MyEnum::B => IrValue::make_ubits(2, 3).unwrap(),
         }
     }
 }


### PR DESCRIPTION
Adds a few benchmarks for calling IR for interpretation and packing / unpacking a float 3-tuple.

Also makes use of `expect()` with an associated message more consistently worded in the crate.

Fixes #101