### PR TITLE
[xlsynth:ir_builder] Fix lifetime for CStrings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.84"
+version = "0.0.85"
 dependencies = [
  "cargo_metadata",
  "criterion",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-driver"
-version = "0.0.84"
+version = "0.0.85"
 dependencies = [
  "clap 4.5.29",
  "env_logger",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-estimator"
-version = "0.0.84"
+version = "0.0.85"
 dependencies = [
  "env_logger",
  "log",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-sys"
-version = "0.0.84"
+version = "0.0.85"
 dependencies = [
  "flate2",
  "libc",

--- a/xlsynth-driver/Cargo.toml
+++ b/xlsynth-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-driver"
-version = "0.0.84"
+version = "0.0.85"
 edition = "2021"
 
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/xlsynth"
 homepage = "https://github.com/xlsynth/xlsynth-crate"
 
 [dependencies]
-xlsynth = { path = "../xlsynth", version = "0.0.84" }
+xlsynth = { path = "../xlsynth", version = "0.0.85" }
 clap = "4.5.21"
 tempfile = "3.13"
 toml = "0.8.19"

--- a/xlsynth-estimator/Cargo.toml
+++ b/xlsynth-estimator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-estimator"
-version = "0.0.84"
+version = "0.0.85"
 edition = "2021"
 
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]

--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-sys"
-version = "0.0.84"
+version = "0.0.85"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust (Native Library)"

--- a/xlsynth/Cargo.toml
+++ b/xlsynth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth"
-version = "0.0.84"
+version = "0.0.85"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust"
@@ -13,7 +13,7 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 readme = "../README.md"
 
 [dependencies]
-xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.84"}
+xlsynth-sys = {path = "../xlsynth-sys", version = "0.0.85"}
 cargo_metadata = "0.18"
 log = "0.4"
 

--- a/xlsynth/src/ir_builder.rs
+++ b/xlsynth/src/ir_builder.rs
@@ -320,11 +320,11 @@ fn tuple_and_then_index(a: bits[2] id=1, b: bits[2] id=2) -> (bits[2], bits[2]) 
             "package sample_package
 
 fn f(x: bits[32] id=1, y: bits[32] id=2) -> (bits[32], bits[32]) {
-  and.3: bits[32] = and(x, y, id=3)
-  or.4: bits[32] = or(x, y, id=4)
-  or.5: bits[32] = or(x, and.3, id=5)
-  or.6: bits[32] = or(y, or.4, id=6)
-  ret tuple.7: (bits[32], bits[32]) = tuple(or.5, or.6, id=7)
+  x_mul_y: bits[32] = and(x, y, id=3)
+  x_plus_y: bits[32] = or(x, y, id=4)
+  a: bits[32] = or(x, x_mul_y, id=5)
+  b: bits[32] = or(y, x_plus_y, id=6)
+  ret result: (bits[32], bits[32]) = tuple(a, b, id=7)
 }
 "
         );

--- a/xlsynth/src/ir_builder.rs
+++ b/xlsynth/src/ir_builder.rs
@@ -308,11 +308,11 @@ fn tuple_and_then_index(a: bits[2] id=1, b: bits[2] id=2) -> (bits[2], bits[2]) 
         let mut builder = FnBuilder::new(&mut package, "f", true);
         let x = builder.param("x", &package.get_bits_type(32));
         let y = builder.param("y", &package.get_bits_type(32));
-        let x_mul_y = builder.and(&x, &y, None);
-        let x_plus_y = builder.or(&x, &y, None);
-        let a = builder.or(&x, &x_mul_y, None);
-        let b = builder.or(&y, &x_plus_y, None);
-        let result = builder.tuple(&[&a, &b], None);
+        let x_mul_y = builder.and(&x, &y, Some("x_mul_y"));
+        let x_plus_y = builder.or(&x, &y, Some("x_plus_y"));
+        let a = builder.or(&x, &x_mul_y, Some("a"));
+        let b = builder.or(&y, &x_plus_y, Some("b"));
+        let result = builder.tuple(&[&a, &b], Some("result"));
         let _f = builder.build_with_return_value(&result).unwrap();
 
         assert_eq!(

--- a/xlsynth/src/lib_support.rs
+++ b/xlsynth/src/lib_support.rs
@@ -40,7 +40,7 @@ impl Drop for IrFnBuilderPtr {
 // Wrapper around the raw pointer that frees (i.e. when the wrapping refcount
 // drops to zero).
 pub(crate) struct BValuePtr {
-    ptr: *mut CIrBValue,
+    pub(crate) ptr: *mut CIrBValue,
 }
 
 impl Drop for BValuePtr {
@@ -318,11 +318,7 @@ pub(crate) fn xls_function_builder_add_and(
     name: Option<&str>,
 ) -> Arc<RwLock<BValuePtr>> {
     let name_cstr = name.map(|s| CString::new(s).unwrap());
-    let name_ptr = if let Some(name_cstr) = name_cstr {
-        name_cstr.as_ptr()
-    } else {
-        std::ptr::null()
-    };
+    let name_ptr = name_cstr.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
     let builder_base = unsafe { xlsynth_sys::xls_function_builder_as_builder_base(builder.ptr) };
     let bvalue_raw =
         unsafe { xlsynth_sys::xls_builder_base_add_and(builder_base, a.ptr, b.ptr, name_ptr) };
@@ -336,11 +332,7 @@ pub(crate) fn xls_function_builder_add_or(
     name: Option<&str>,
 ) -> Arc<RwLock<BValuePtr>> {
     let name_cstr = name.map(|s| CString::new(s).unwrap());
-    let name_ptr = if let Some(name_cstr) = name_cstr {
-        name_cstr.as_ptr()
-    } else {
-        std::ptr::null()
-    };
+    let name_ptr = name_cstr.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
     let builder_base = unsafe { xlsynth_sys::xls_function_builder_as_builder_base(builder.ptr) };
     let bvalue_raw =
         unsafe { xlsynth_sys::xls_builder_base_add_or(builder_base, a.ptr, b.ptr, name_ptr) };
@@ -353,11 +345,7 @@ pub(crate) fn xls_function_builder_add_not(
     name: Option<&str>,
 ) -> Arc<RwLock<BValuePtr>> {
     let name_cstr = name.map(|s| CString::new(s).unwrap());
-    let name_ptr = if let Some(name_cstr) = name_cstr {
-        name_cstr.as_ptr()
-    } else {
-        std::ptr::null()
-    };
+    let name_ptr = name_cstr.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
     let builder_base = unsafe { xlsynth_sys::xls_function_builder_as_builder_base(builder.ptr) };
     let bvalue_raw =
         unsafe { xlsynth_sys::xls_builder_base_add_not(builder_base, a.ptr, name_ptr) };
@@ -372,11 +360,7 @@ pub(crate) fn xls_function_builder_add_bit_slice(
     name: Option<&str>,
 ) -> Arc<RwLock<BValuePtr>> {
     let name_cstr = name.map(|s| CString::new(s).unwrap());
-    let name_ptr = if let Some(name_cstr) = name_cstr {
-        name_cstr.as_ptr()
-    } else {
-        std::ptr::null()
-    };
+    let name_ptr = name_cstr.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
     let builder_base = unsafe { xlsynth_sys::xls_function_builder_as_builder_base(builder.ptr) };
     let bvalue_raw = unsafe {
         xlsynth_sys::xls_builder_base_add_bit_slice(
@@ -396,11 +380,7 @@ pub(crate) fn xls_function_builder_add_concat(
     name: Option<&str>,
 ) -> Arc<RwLock<BValuePtr>> {
     let name_cstr = name.map(|s| CString::new(s).unwrap());
-    let name_ptr = if let Some(name_cstr) = name_cstr {
-        name_cstr.as_ptr()
-    } else {
-        std::ptr::null()
-    };
+    let name_ptr = name_cstr.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
     let values_ptrs: Vec<*mut CIrBValue> = values.iter().map(|v| v.ptr).collect();
     let builder_base = unsafe { xlsynth_sys::xls_function_builder_as_builder_base(builder.ptr) };
     let bvalue_raw = unsafe {
@@ -420,11 +400,7 @@ pub(crate) fn xls_function_builder_add_literal(
     name: Option<&str>,
 ) -> Arc<RwLock<BValuePtr>> {
     let name_cstr = name.map(|s| CString::new(s).unwrap());
-    let name_ptr = if let Some(name_cstr) = name_cstr {
-        name_cstr.as_ptr()
-    } else {
-        std::ptr::null()
-    };
+    let name_ptr = name_cstr.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
     let builder_base = unsafe { xlsynth_sys::xls_function_builder_as_builder_base(builder.ptr) };
     let bvalue_raw =
         unsafe { xlsynth_sys::xls_builder_base_add_literal(builder_base, value.ptr, name_ptr) };
@@ -437,11 +413,7 @@ pub(crate) fn xls_function_builder_add_tuple(
     name: Option<&str>,
 ) -> Arc<RwLock<BValuePtr>> {
     let name_cstr = name.map(|s| CString::new(s).unwrap());
-    let name_ptr = if let Some(name_cstr) = name_cstr {
-        name_cstr.as_ptr()
-    } else {
-        std::ptr::null()
-    };
+    let name_ptr = name_cstr.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
     let builder_base = unsafe { xlsynth_sys::xls_function_builder_as_builder_base(builder.ptr) };
     let mut elements_ptrs: Vec<*mut CIrBValue> = elements.iter().map(|v| v.ptr).collect();
     let bvalue_raw = unsafe {


### PR DESCRIPTION
Previous pattern used was:

```rust
    let name_cstr = name.map(|s| CString::new(s).unwrap());
    let name_ptr = if let Some(name_cstr) = name_cstr {
        name_cstr.as_ptr()
    } else {
        std::ptr::null()
    };
```

But that is _moving_ the cstring into the let binding and then we take a pointer to a thing that goes out of scope. We now use the as_ref to make sure we take a pointer without moving the owner:

```rust
    let name_cstr = name.map(|s| CString::new(s).unwrap());
    let name_ptr = name_cstr.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
```