### PR TITLE
[xlsynth:ir_builder] Expose mul operations.

### DIFF
--- a/xlsynth/src/lib_support.rs
+++ b/xlsynth/src/lib_support.rs
@@ -836,3 +836,31 @@ pub(crate) fn xls_schedule_and_codegen_package(
     assert!(!result_out.is_null());
     Ok(ScheduleAndCodegenResult { ptr: result_out })
 }
+
+pub(crate) fn xls_function_builder_add_umul(
+    builder: RwLockWriteGuard<IrFnBuilderPtr>,
+    a: RwLockReadGuard<BValuePtr>,
+    b: RwLockReadGuard<BValuePtr>,
+    name: Option<&str>,
+) -> Arc<RwLock<BValuePtr>> {
+    let name_cstr = name.map(|s| CString::new(s).unwrap());
+    let name_ptr = name_cstr.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
+    let builder_base = unsafe { xlsynth_sys::xls_function_builder_as_builder_base(builder.ptr) };
+    let bvalue_raw =
+        unsafe { xlsynth_sys::xls_builder_base_add_umul(builder_base, a.ptr, b.ptr, name_ptr) };
+    Arc::new(RwLock::new(BValuePtr { ptr: bvalue_raw }))
+}
+
+pub(crate) fn xls_function_builder_add_smul(
+    builder: RwLockWriteGuard<IrFnBuilderPtr>,
+    a: RwLockReadGuard<BValuePtr>,
+    b: RwLockReadGuard<BValuePtr>,
+    name: Option<&str>,
+) -> Arc<RwLock<BValuePtr>> {
+    let name_cstr = name.map(|s| CString::new(s).unwrap());
+    let name_ptr = name_cstr.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
+    let builder_base = unsafe { xlsynth_sys::xls_function_builder_as_builder_base(builder.ptr) };
+    let bvalue_raw =
+        unsafe { xlsynth_sys::xls_builder_base_add_smul(builder_base, a.ptr, b.ptr, name_ptr) };
+    Arc::new(RwLock::new(BValuePtr { ptr: bvalue_raw }))
+}


### PR DESCRIPTION
But the umul and smul operations cannot currently be distinguished because we only exposed the same-bit-width operations from the C API so far. When we add the ones that can produce an extended result we'll update these APIs.