### PR TITLE
[driver] Make driver pick up xlsynth-toolchain.toml from the CWD if i…

### DIFF
--- a/xlsynth-driver/src/dslx2ir.rs
+++ b/xlsynth-driver/src/dslx2ir.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::ArgMatches;
-use xlsynth::DslxConvertOptions;
+use xlsynth::{DslxConvertOptions, IrPackage};
 
 use crate::{
     toolchain_config::{get_dslx_path, get_dslx_stdlib_path, ToolchainConfig},
-    tools::run_ir_converter_main,
+    tools::{run_ir_converter_main, run_opt_main},
 };
 
 fn dslx2ir(
@@ -16,10 +16,15 @@ fn dslx2ir(
     tool_path: Option<&str>,
     enable_warnings: Option<&[String]>,
     disable_warnings: Option<&[String]>,
+    opt: bool,
 ) {
     log::info!("dslx2ir");
+
+    let dslx_module_name = input_file.file_stem().unwrap().to_str().unwrap();
+    let ir_top = xlsynth::mangle_dslx_name(dslx_module_name, dslx_top.unwrap()).unwrap();
+
     if let Some(tool_path) = tool_path {
-        let output = run_ir_converter_main(
+        let mut output = run_ir_converter_main(
             input_file,
             dslx_top,
             dslx_stdlib_path,
@@ -28,6 +33,13 @@ fn dslx2ir(
             enable_warnings,
             disable_warnings,
         );
+        if opt {
+            // Write the output of conversion to a temp file and then pass that.
+            let temp_file = tempfile::NamedTempFile::new().unwrap();
+            let temp_file_path = temp_file.path();
+            std::fs::write(temp_file_path, output).unwrap();
+            output = run_opt_main(temp_file_path, Some(&ir_top), tool_path);
+        }
         println!("{}", output);
     } else {
         let dslx_contents = std::fs::read_to_string(input_file).expect("file read successful");
@@ -36,7 +48,7 @@ fn dslx2ir(
         let additional_search_paths: Vec<&std::path::Path> = dslx_path
             .map(|s| s.split(';').map(|p| std::path::Path::new(p)).collect())
             .unwrap_or_default();
-        let result = xlsynth::convert_dslx_to_ir_text(
+        let result: xlsynth::DslxToIrTextResult = xlsynth::convert_dslx_to_ir_text(
             &dslx_contents,
             input_file,
             &DslxConvertOptions {
@@ -54,7 +66,16 @@ fn dslx2ir(
                 warning
             );
         }
-        println!("{}", result.ir);
+
+        let result_text: String = if opt {
+            let ir_package = IrPackage::parse_ir(&result.ir, Some(&ir_top)).unwrap();
+            let optimized_ir_package = xlsynth::optimize_ir(&ir_package, &ir_top).unwrap();
+            optimized_ir_package.to_string()
+        } else {
+            result.ir
+        };
+
+        println!("{}", result_text);
     }
 }
 
@@ -79,6 +100,12 @@ pub fn handle_dslx2ir(matches: &ArgMatches, config: &Option<ToolchainConfig>) {
     let enable_warnings = config.as_ref().and_then(|c| c.enable_warnings.as_deref());
     let disable_warnings = config.as_ref().and_then(|c| c.disable_warnings.as_deref());
 
+    let opt = match matches.get_one::<String>("opt").map(|s| s.as_str()) {
+        Some("true") => true,
+        Some("false") => false,
+        _ => false,
+    };
+
     // Stub function for DSLX to IR conversion
     dslx2ir(
         input_path,
@@ -88,5 +115,6 @@ pub fn handle_dslx2ir(matches: &ArgMatches, config: &Option<ToolchainConfig>) {
         tool_path,
         enable_warnings,
         disable_warnings,
+        opt,
     );
 }

--- a/xlsynth-driver/src/ir2gates.rs
+++ b/xlsynth-driver/src/ir2gates.rs
@@ -16,7 +16,7 @@ fn ir2gates(input_file: &std::path::Path, quiet: bool) {
     }
 }
 
-pub fn handle_ir2gates(matches: &ArgMatches, config: &Option<ToolchainConfig>) {
+pub fn handle_ir2gates(matches: &ArgMatches, _config: &Option<ToolchainConfig>) {
     let input_file = matches.get_one::<String>("ir_input_file").unwrap();
     let quiet = match matches.get_one::<String>("quiet").map(|s| s.as_str()) {
         Some("true") => true,


### PR DESCRIPTION
…t is present and no explicit toolchain flag is given.

Also adds the --opt flag to the dslx2ir subcommand just for convenience of not needing to chain two commands.