### PR TITLE
[g8r] Gatify everything needed for apfloat::mul

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Download xlsynth binaries
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           pip3 install requests
           python3 download_release.py -p ubuntu2004 -o xlsynth_tools
@@ -139,6 +141,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Download xlsynth binaries
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           pip3 install requests
           python3 download_release.py -p ubuntu2004 -o xlsynth_tools
@@ -265,6 +269,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Download xlsynth binaries
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           dnf install -y python3 python3-pip
           python3 -V  # Print the python3 version.
@@ -353,6 +359,8 @@ jobs:
           sudo apt-get install -y valgrind
 
       - name: Download xlsynth binaries
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           pip3 install requests termcolor
           python3 download_release.py -p ubuntu2004 -o xlsynth_tools
@@ -388,6 +396,8 @@ jobs:
           override: true
 
       - name: Pre-download artifacts using download_release.py
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           # Note we download rocky8 version just because they have the fewest/oldest system
           # requirements.

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 target/
 .vscode
 xlsynth-g8r/fuzz/corpus/
+xlsynth-g8r/fuzz/artifacts/
 __pycache__
 .pytest_cache

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -122,6 +122,13 @@
    ...
 }
 {
+   dslx_sized_type_keywords
+   Memcheck:Leak
+   ...
+   fun:_ZN3xls4dslx28GetSizedTypeKeywordsMetadataEv
+   ...
+}
+{
    dslx_scanner_keywords
    Memcheck:Leak
    match-leak-kinds: possible

--- a/xlsynth-g8r/fuzz/Cargo.lock
+++ b/xlsynth-g8r/fuzz/Cargo.lock
@@ -389,6 +389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -889,6 +890,15 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1976,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.102"
+version = "0.0.103"
 dependencies = [
  "cargo_metadata",
  "log",
@@ -1985,10 +1995,11 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-g8r"
-version = "0.0.102"
+version = "0.0.103"
 dependencies = [
  "clap",
  "env_logger",
+ "flate2",
  "log",
  "serde",
  "serde_json",
@@ -2010,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-sys"
-version = "0.0.102"
+version = "0.0.103"
 dependencies = [
  "flate2",
  "libc",
@@ -2091,3 +2102,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"

--- a/xlsynth-g8r/src/gate.rs
+++ b/xlsynth-g8r/src/gate.rs
@@ -872,6 +872,14 @@ impl GateBuilder {
         args: &[AigOperand],
         reduction_kind: ReductionKind,
     ) -> AigOperand {
+        assert!(
+            args.len() > 0,
+            "add_or_nary; attempted to reduce an empty list of operands; reduction_kind: {:?}",
+            reduction_kind
+        );
+        if args.len() == 1 {
+            return args[0];
+        }
         if self.fold {
             if args.iter().any(|arg| self.is_known_true(*arg)) {
                 return self.get_true();

--- a/xlsynth-g8r/src/ir2gate.rs
+++ b/xlsynth-g8r/src/ir2gate.rs
@@ -204,6 +204,17 @@ fn gatify_umul(
     output_bit_count: usize,
     gb: &mut GateBuilder,
 ) -> AigBitVector {
+    let lhs_bit_count = lhs_bits.get_bit_count();
+    let rhs_bit_count = rhs_bits.get_bit_count();
+
+    if lhs_bit_count == 0 || rhs_bit_count == 0 {
+        assert_eq!(
+            output_bit_count, 0,
+            "output_bit_count must be 0 if lhs_bits or rhs_bits have no bits"
+        );
+        return AigBitVector::zeros(0);
+    }
+
     let mut partial_products = Vec::new();
 
     // For each bit in the multiplier (rhs), generate a scaled partial product

--- a/xlsynth-g8r/src/xls_ir/ir.rs
+++ b/xlsynth-g8r/src/xls_ir/ir.rs
@@ -127,13 +127,19 @@ pub enum Binop {
     Ult,
     Ule,
 
+    // signed comparisons
     Sgt,
     Sge,
     Slt,
     Sle,
+
     Umul,
-    Gate,
+    Smul,
+
     Sdiv,
+    Udiv,
+
+    Gate,
 }
 
 pub fn operator_to_binop(operator: &str) -> Option<Binop> {
@@ -143,10 +149,10 @@ pub fn operator_to_binop(operator: &str) -> Option<Binop> {
         "shrl" => Some(Binop::Shrl),
         "shra" => Some(Binop::Shra),
 
-        "add" => Some(Binop::Add),
         "array_concat" => Some(Binop::ArrayConcat),
         "smulp" => Some(Binop::Smulp),
         "umulp" => Some(Binop::Umulp),
+
         "eq" => Some(Binop::Eq),
         "ne" => Some(Binop::Ne),
         // signed comparisons
@@ -160,9 +166,12 @@ pub fn operator_to_binop(operator: &str) -> Option<Binop> {
         "ult" => Some(Binop::Ult),
         "ule" => Some(Binop::Ule),
         // arithmetic
+        "add" => Some(Binop::Add),
         "sub" => Some(Binop::Sub),
         "umul" => Some(Binop::Umul),
+        "smul" => Some(Binop::Smul),
         "sdiv" => Some(Binop::Sdiv),
+        "udiv" => Some(Binop::Udiv),
 
         // "special" operations
         "gate" => Some(Binop::Gate),
@@ -191,8 +200,10 @@ pub fn binop_to_operator(binop: Binop) -> &'static str {
         Binop::Sle => "sle",
         Binop::Sub => "sub",
         Binop::Umul => "umul",
+        Binop::Smul => "smul",
         Binop::Gate => "gate",
         Binop::Sdiv => "sdiv",
+        Binop::Udiv => "udiv",
     }
 }
 

--- a/xlsynth-g8r/src/xls_ir/ir.rs
+++ b/xlsynth-g8r/src/xls_ir/ir.rs
@@ -113,6 +113,7 @@ pub enum Binop {
 
     Shll,
     Shrl,
+    Shra,
 
     ArrayConcat,
     Smulp,
@@ -137,8 +138,11 @@ pub enum Binop {
 
 pub fn operator_to_binop(operator: &str) -> Option<Binop> {
     match operator {
+        // Shifts
         "shll" => Some(Binop::Shll),
         "shrl" => Some(Binop::Shrl),
+        "shra" => Some(Binop::Shra),
+
         "add" => Some(Binop::Add),
         "array_concat" => Some(Binop::ArrayConcat),
         "smulp" => Some(Binop::Smulp),
@@ -171,6 +175,7 @@ pub fn binop_to_operator(binop: Binop) -> &'static str {
         Binop::Add => "add",
         Binop::Shll => "shll",
         Binop::Shrl => "shrl",
+        Binop::Shra => "shra",
         Binop::ArrayConcat => "array_concat",
         Binop::Smulp => "smulp",
         Binop::Umulp => "umulp",
@@ -870,6 +875,10 @@ impl Package {
             Some(name) => self.fns.iter_mut().find(|f| f.name == *name),
             None => self.fns.first_mut(),
         }
+    }
+
+    pub fn get_fn(&self, name: &str) -> Option<&Fn> {
+        self.fns.iter().find(|f| f.name == name)
     }
 }
 

--- a/xlsynth-g8r/src/xls_ir/ir_parser.rs
+++ b/xlsynth-g8r/src/xls_ir/ir_parser.rs
@@ -884,9 +884,9 @@ impl Parser {
                 self.maybe_drop_pos_attribute()?;
                 (ir::NodePayload::Literal(value), maybe_id.unwrap())
             }
-            "shll" | "shrl" | "add" | "sub" | "array_concat" | "smulp" | "umulp" | "umul"
-            | "sdiv" | "eq" | "ne" | "ugt" | "ult" | "uge" | "ule" | "sgt" | "slt" | "sge"
-            | "sle" | "gate" => {
+            "shll" | "shrl" | "shra" | "add" | "sub" | "array_concat" | "smulp" | "umulp"
+            | "umul" | "sdiv" | "eq" | "ne" | "ugt" | "ult" | "uge" | "ule" | "sgt" | "slt"
+            | "sge" | "sle" | "gate" => {
                 let binop = ir::operator_to_binop(operator.as_str())
                     .expect(format!("operator {:?} should be known binop", operator).as_str());
                 let lhs = self.parse_node_ref(&node_env)?;

--- a/xlsynth-g8r/src/xls_ir/ir_parser.rs
+++ b/xlsynth-g8r/src/xls_ir/ir_parser.rs
@@ -885,8 +885,8 @@ impl Parser {
                 (ir::NodePayload::Literal(value), maybe_id.unwrap())
             }
             "shll" | "shrl" | "shra" | "add" | "sub" | "array_concat" | "smulp" | "umulp"
-            | "umul" | "sdiv" | "eq" | "ne" | "ugt" | "ult" | "uge" | "ule" | "sgt" | "slt"
-            | "sge" | "sle" | "gate" => {
+            | "umul" | "smul" | "sdiv" | "eq" | "ne" | "ugt" | "ult" | "uge" | "ule" | "sgt"
+            | "slt" | "sge" | "sle" | "gate" => {
                 let binop = ir::operator_to_binop(operator.as_str())
                     .expect(format!("operator {:?} should be known binop", operator).as_str());
                 let lhs = self.parse_node_ref(&node_env)?;

--- a/xlsynth-g8r/tests/gatify_tests.rs
+++ b/xlsynth-g8r/tests/gatify_tests.rs
@@ -566,6 +566,24 @@ fn do_umul(lhs: bits[{lhs_bits}], rhs: bits[{rhs_bits}]) -> bits[{output_bits}] 
     );
 }
 
+#[test_matrix(
+    1..3,
+    1..3,
+    1..7,
+    [false, true]
+)]
+fn test_smul_ir_to_gates(lhs_bits: u32, rhs_bits: u32, output_bits: u32, fold: bool) {
+    do_test_ir_conversion(
+        &format!(
+            "package sample
+fn do_smul(lhs: bits[{lhs_bits}], rhs: bits[{rhs_bits}]) -> bits[{output_bits}] {{
+    ret result: bits[{output_bits}] = smul(lhs, rhs, id=3)
+}}",
+        ),
+        fold,
+    );
+}
+
 fn gather_stats_for_widths(
     widths: &[usize],
     builder_fn: impl Fn(&mut GateBuilder, usize) -> (),

--- a/xlsynth-g8r/tests/gatify_tests.rs
+++ b/xlsynth-g8r/tests/gatify_tests.rs
@@ -368,6 +368,16 @@ bit_count_test_cases!(test_shra_dslx_to_gates, |input_bits: u32,
     );
 });
 
+bit_count_test_cases!(test_shra_by_u32_dslx_to_gates, |input_bits: u32,
+                                                       fold: bool|
+ -> () {
+    do_test_dslx_conversion(
+        input_bits,
+        fold,
+        "fn do_shra_by_u32(x: sN[N], amount: u32) -> sN[N] { x >> amount }",
+    );
+});
+
 bit_count_test_cases!(test_shrl_to_gates, |input_bits: u32, fold: bool| -> () {
     do_test_dslx_conversion(
         input_bits,


### PR DESCRIPTION
Adds support for signed comparisons, umul/smul, shra (which was borked before).

Proves equivalence of the gate mappings for these ops vs XLS IR versions for bit counts up to 8 generally.

Multiplier gate mapping is a simple array multiplier with ripple carry adders for now.

Makes sure fuzzer can select among every op in the IR structure via a flat type we can more easily do `u.arbitrary<>` on.