### PR TITLE
[g8r] Add gatesim benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +259,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half 2.6.0",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,7 +395,7 @@ dependencies = [
  "atty",
  "cast",
  "clap 2.34.0",
- "criterion-plot",
+ "criterion-plot 0.4.5",
  "csv",
  "itertools 0.10.5",
  "lazy_static",
@@ -380,10 +413,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.5.35",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
@@ -802,6 +871,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1153,17 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.0",
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2993,7 +3079,7 @@ name = "xlsynth"
 version = "0.0.116"
 dependencies = [
  "cargo_metadata 0.18.1",
- "criterion",
+ "criterion 0.3.6",
  "env_logger",
  "lazy_static",
  "log",
@@ -3043,6 +3129,7 @@ dependencies = [
  "arbitrary",
  "cargo_metadata 0.19.2",
  "clap 4.5.35",
+ "criterion 0.5.1",
  "env_logger",
  "flate2",
  "half 2.6.0",

--- a/xlsynth-g8r/Cargo.toml
+++ b/xlsynth-g8r/Cargo.toml
@@ -18,6 +18,7 @@ tempfile = "3.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 flate2 = { version = "1.1", features = ["zlib-rs"], default-features = false }
+half = "2.6"
 
 [dev-dependencies]
 test-case = "3.3.1"
@@ -26,8 +27,8 @@ libfuzzer-sys = "0.4"
 pretty_assertions = "1.4.1"
 regex = "1.5"
 cargo_metadata = "0.19.2"
-half = "2.6"
 rand = "0.8"
+criterion = "0.5"
 
 [lib]
 name = "xlsynth_g8r"
@@ -40,3 +41,7 @@ path = "src/main.rs"
 [[bin]]
 name = "try-parse-liberty"
 path = "src/liberty/try_parse.rs"
+
+[[bench]]
+name = "bf16_mul_gatesim_bench"
+harness = false

--- a/xlsynth-g8r/benches/bf16_mul_gatesim_bench.rs
+++ b/xlsynth-g8r/benches/bf16_mul_gatesim_bench.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use xlsynth::IrBits;
+use xlsynth_g8r::gate_sim;
+use xlsynth_g8r::test_utils::{load_bf16_mul_sample, BF16_TOTAL_BITS};
+
+/// Benchmarks the gate simulation of bf16 multiplication using fixed zero
+/// inputs.
+fn bf16_mul_gatesim_benchmark(c: &mut Criterion) {
+    let loaded_sample = load_bf16_mul_sample();
+    let gate_fn = loaded_sample.gate_fn;
+
+    // Using fixed inputs helps reduce benchmark variance.
+    let num_samples: u64 = 100; // Number of samples per benchmark iteration batch (use u64 for Throughput)
+
+    // Prepare *one* owned input slice for eval *before* the benchmark loop
+    // since the input is constant (zeros).
+    let zero_arg_bits = IrBits::make_ubits(BF16_TOTAL_BITS, 0).unwrap();
+    let prepared_eval_input: [IrBits; 2] = [zero_arg_bits.clone(), zero_arg_bits.clone()];
+
+    let mut group = c.benchmark_group("bf16_mul_gatesim_zero_input");
+
+    // Configure throughput measurement: specify the number of samples processed per
+    // iteration Even though b.iter runs once, it represents processing
+    // `num_samples` items conceptually.
+    group.throughput(Throughput::Elements(num_samples));
+
+    // Define the benchmark using the group
+    // Pass the single prepared slice to the benchmark
+    group.bench_function(BenchmarkId::from_parameter(num_samples), |b| {
+        b.iter(|| {
+            // Call eval once per iteration with the prepared constant input
+            black_box(gate_sim::eval(&gate_fn, &prepared_eval_input, false));
+        });
+    });
+
+    group.finish();
+}
+
+// Register the benchmark function with criterion
+criterion_group!(benches, bf16_mul_gatesim_benchmark);
+criterion_main!(benches);

--- a/xlsynth-g8r/src/test_utils.rs
+++ b/xlsynth-g8r/src/test_utils.rs
@@ -3,13 +3,66 @@
 use crate::gate::GateFn;
 use crate::ir2gate;
 use crate::xls_ir::ir_parser;
+use half::bf16;
 use std::path::Path;
-use xlsynth::{mangle_dslx_name, IrFunction, IrPackage};
+use xlsynth::{mangle_dslx_name, IrBits, IrFunction, IrPackage, IrValue};
+
+// BF16 Constants
+pub const BF16_EXPONENT_BITS: usize = 8;
+pub const BF16_EXPONENT_MASK: usize = (1 << BF16_EXPONENT_BITS) - 1;
+pub const BF16_FRACTION_BITS: usize = 7;
+pub const BF16_FRACTION_MASK: usize = (1 << BF16_FRACTION_BITS) - 1;
+pub const BF16_TOTAL_BITS: usize = 16;
 
 pub struct LoadedSample {
     pub ir_package: IrPackage,
     pub ir_fn: IrFunction,
     pub gate_fn: GateFn,
+}
+
+// BF16 Helper Functions
+pub fn make_bf16(value: bf16) -> IrValue {
+    let bits = value.to_bits();
+    let sign_val = (bits >> (BF16_EXPONENT_BITS + BF16_FRACTION_BITS)) & 1;
+    let exponent_val = (bits >> BF16_FRACTION_BITS) & (BF16_EXPONENT_MASK as u16);
+    let fraction_val = bits & (BF16_FRACTION_MASK as u16);
+
+    let sign = IrValue::bool(sign_val == 1);
+    let exponent = IrValue::make_ubits(BF16_EXPONENT_BITS as usize, exponent_val as u64).unwrap();
+    let fraction = IrValue::make_ubits(BF16_FRACTION_BITS as usize, fraction_val as u64).unwrap();
+    IrValue::make_tuple(&[sign, exponent, fraction])
+}
+
+pub fn ir_value_bf16_to_flat_ir_bits(value: &IrValue) -> IrBits {
+    let tuple_elements = value.get_elements().unwrap();
+    let sign = tuple_elements[0].to_bool().unwrap();
+    let exponent = tuple_elements[1].to_u64().unwrap();
+    let fraction = tuple_elements[2].to_u64().unwrap();
+
+    let mut bits: u16 = 0;
+    if sign {
+        bits |= 1 << (BF16_EXPONENT_BITS + BF16_FRACTION_BITS);
+    }
+    bits |= (exponent as u16) << BF16_FRACTION_BITS;
+    bits |= fraction as u16;
+
+    IrBits::make_ubits(BF16_TOTAL_BITS as usize, bits as u64).unwrap()
+}
+
+pub fn flat_ir_bits_to_ir_value_bf16(bits_value: &IrBits) -> IrValue {
+    assert_eq!(bits_value.get_bit_count(), BF16_TOTAL_BITS as usize);
+    let temp_value = IrValue::from_bits(bits_value);
+    let bits = temp_value.to_u64().unwrap() as u16;
+
+    let sign_bit = (bits >> (BF16_EXPONENT_BITS + BF16_FRACTION_BITS)) & 1;
+    let exponent_bits = (bits >> BF16_FRACTION_BITS) & (BF16_EXPONENT_MASK as u16);
+    let fraction_bits = bits & (BF16_FRACTION_MASK as u16);
+
+    let sign = IrValue::bool(sign_bit == 1);
+    let exponent = IrValue::make_ubits(BF16_EXPONENT_BITS as usize, exponent_bits as u64).unwrap();
+    let fraction = IrValue::make_ubits(BF16_FRACTION_BITS as usize, fraction_bits as u64).unwrap();
+
+    IrValue::make_tuple(&[sign, exponent, fraction])
 }
 
 pub fn load_bf16_mul_sample() -> LoadedSample {
@@ -55,5 +108,24 @@ fn mul_bf16_bf16(x: bfloat16::BF16, y: bfloat16::BF16) -> bfloat16::BF16 {
         ir_package: opt_ir,
         ir_fn,
         gate_fn,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_bf16_one() {
+        let one = bf16::from_f32(1.0);
+        let ir_value = make_bf16(one);
+        assert_eq!(
+            ir_value,
+            IrValue::make_tuple(&[
+                IrValue::bool(false),                                  // sign
+                IrValue::make_ubits(BF16_EXPONENT_BITS, 127).unwrap(), // biased exponent
+                IrValue::make_ubits(BF16_FRACTION_BITS, 0).unwrap(),   // fraction
+            ])
+        );
     }
 }

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -130,6 +130,16 @@ impl IrBits {
     }
 }
 
+impl Clone for IrBits {
+    fn clone(&self) -> Self {
+        // TODO(cdleary): 2025-04-14 Right now we don't have a direct clone API for
+        // IrBits. Adding one would make this more efficient.
+        let value = IrValue::from_bits(self);
+        let clone = value.clone();
+        clone.to_bits().unwrap()
+    }
+}
+
 impl Drop for IrBits {
     fn drop(&mut self) {
         unsafe { xlsynth_sys::xls_bits_free(self.ptr) }


### PR DESCRIPTION
Non-scientific datapoint, for my M2 macbook running `cargo bench --bench bf16_mul_gatesim_bench` on battery gives:

```
bf16_mul_gatesim_zero_input/100
                        time:   [639.21 µs 642.12 µs 645.15 µs]
                        thrpt:  [155.00 Kelem/s 155.73 Kelem/s 156.44 Kelem/s]
                 change:
                        time:   [-6.4281% -5.8619% -5.3051%] (p = 0.00 < 0.05)
                        thrpt:  [+5.6023% +6.2269% +6.8697%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```

