### PR TITLE
[g8r] Add first cut of equivalence class validation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -549,7 +549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
 dependencies = [
  "csv-core",
- "itoa",
+ "itoa 1.0.15",
  "ryu",
  "serde",
 ]
@@ -601,7 +601,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -628,7 +628,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -933,7 +933,7 @@ checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.15",
 ]
 
 [[package]]
@@ -978,7 +978,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "itoa",
+ "itoa 1.0.15",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -1153,7 +1153,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1240,6 +1240,12 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
@@ -1265,7 +1271,7 @@ checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1293,6 +1299,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -1396,7 +1408,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1622,7 +1634,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1641,6 +1653,35 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "partial_ref"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f728bc9b1479656e40cba507034904a8c44027c0efdbbaf6a4bdc5f2d3a910c"
+dependencies = [
+ "partial_ref_derive",
+]
+
+[[package]]
+name = "partial_ref_derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e1d2cb5b898b5a5342e994e0d0c367dbfe69cbf717cd307045ec9fb057581"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1680,7 +1721,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1791,7 +1832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1830,7 +1871,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.100",
  "tempfile",
 ]
 
@@ -1844,7 +1885,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2055,6 +2096,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,7 +2270,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2232,7 +2279,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "itoa",
+ "itoa 1.0.15",
  "memchr",
  "ryu",
  "serde",
@@ -2254,7 +2301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.15",
  "ryu",
  "serde",
 ]
@@ -2337,6 +2384,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
@@ -2357,13 +2415,25 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2435,7 +2505,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2446,7 +2516,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "test-case-core",
 ]
 
@@ -2502,7 +2572,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2513,7 +2583,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2704,6 +2774,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2739,10 +2815,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "varisat"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe609851d1e9196674ac295f656bd8601200a1077343d22b345013497807caf"
+dependencies = [
+ "anyhow",
+ "itoa 0.4.8",
+ "leb128",
+ "log",
+ "ordered-float",
+ "partial_ref",
+ "rustc-hash",
+ "serde",
+ "thiserror 1.0.69",
+ "varisat-checker",
+ "varisat-dimacs",
+ "varisat-formula",
+ "varisat-internal-macros",
+ "varisat-internal-proof",
+ "vec_mut_scan",
+]
+
+[[package]]
+name = "varisat-checker"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135c977c5913ed6e98f6b81b8e4d322211303b7d40dae773caef7ad1de6c763b"
+dependencies = [
+ "anyhow",
+ "log",
+ "partial_ref",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 1.0.69",
+ "varisat-dimacs",
+ "varisat-formula",
+ "varisat-internal-proof",
+]
+
+[[package]]
+name = "varisat-dimacs"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1dee4e21be1f04c0a939f7ae710cced47233a578de08a1b3c7d50848402636"
+dependencies = [
+ "anyhow",
+ "itoa 0.4.8",
+ "thiserror 1.0.69",
+ "varisat-formula",
+]
+
+[[package]]
+name = "varisat-formula"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395c5543b9bfd9076d6d3af49d6c34a4b91b0b355998c0a5ec6ed7265d364520"
+
+[[package]]
+name = "varisat-internal-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602ece773543d066aa7848455486c6c0422a3f214da7a2b899100f3c4f12408d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
+]
+
+[[package]]
+name = "varisat-internal-proof"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6163bb7bc9018af077b76d64f976803d141c36a27d640f1437dddc4fd527d207"
+dependencies = [
+ "anyhow",
+ "varisat-formula",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_mut_scan"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ed610a8d5e63d9c0e31300e8fdb55104c5f21e422743a9dc74848fa8317fd2"
 
 [[package]]
 name = "version_check"
@@ -2806,7 +2969,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -2841,7 +3004,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3215,6 +3378,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-case",
+ "varisat",
  "xlsynth",
 ]
 
@@ -3255,8 +3419,8 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "synstructure",
+ "syn 2.0.100",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -3276,7 +3440,7 @@ checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3296,8 +3460,8 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "synstructure",
+ "syn 2.0.100",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -3325,7 +3489,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/xlsynth-g8r/Cargo.toml
+++ b/xlsynth-g8r/Cargo.toml
@@ -23,6 +23,7 @@ blake3 = "1.5"
 once_cell = "1.19"
 bitvec = "1.0.1"
 rand = "0.8"
+varisat = "0.2.2"
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/xlsynth-g8r/benches/bf16_mul_gatesim_bench.rs
+++ b/xlsynth-g8r/benches/bf16_mul_gatesim_bench.rs
@@ -3,12 +3,12 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use xlsynth::IrBits;
 use xlsynth_g8r::gate_sim::{self, Collect};
-use xlsynth_g8r::test_utils::{load_bf16_mul_sample, BF16_TOTAL_BITS};
+use xlsynth_g8r::test_utils::{load_bf16_mul_sample, Opt, BF16_TOTAL_BITS};
 
 /// Benchmarks the gate simulation of bf16 multiplication using fixed zero
 /// inputs.
 fn bf16_mul_gatesim_benchmark(c: &mut Criterion) {
-    let loaded_sample = load_bf16_mul_sample();
+    let loaded_sample = load_bf16_mul_sample(Opt::Yes);
     let gate_fn = loaded_sample.gate_fn;
 
     // Using fixed inputs helps reduce benchmark variance.

--- a/xlsynth-g8r/benches/gatify_bench.rs
+++ b/xlsynth-g8r/benches/gatify_bench.rs
@@ -7,11 +7,11 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use xlsynth_g8r::{
     gate_builder::GateBuilderOptions,
     ir2gate,
-    test_utils::{load_bf16_add_sample, load_bf16_mul_sample},
+    test_utils::{load_bf16_add_sample, load_bf16_mul_sample, Opt},
 };
 
 fn gatify_bf16_mul_benchmark(c: &mut Criterion) {
-    let sample = load_bf16_mul_sample();
+    let sample = load_bf16_mul_sample(Opt::Yes);
     let ir_fn = sample.g8r_pkg.get_fn(&sample.mangled_fn_name).unwrap();
 
     let mut group = c.benchmark_group("gatify_bf16_mul");
@@ -65,7 +65,7 @@ fn gatify_bf16_mul_benchmark(c: &mut Criterion) {
 }
 
 fn gatify_bf16_add_benchmark(c: &mut Criterion) {
-    let sample = load_bf16_add_sample();
+    let sample = load_bf16_add_sample(Opt::Yes);
     let ir_fn = sample.g8r_pkg.get_fn(&sample.mangled_fn_name).unwrap();
 
     let mut group = c.benchmark_group("gatify_bf16_add");

--- a/xlsynth-g8r/src/ir2gate_utils.rs
+++ b/xlsynth-g8r/src/ir2gate_utils.rs
@@ -319,13 +319,8 @@ mod tests {
     use test_case::test_case;
 
     fn make_ripple_carry(bits: usize) -> gate::GateFn {
-        let mut ripple_builder = GateBuilder::new(
-            "ripple_carry".to_string(),
-            GateBuilderOptions {
-                fold: false,
-                hash: false,
-            },
-        );
+        let mut ripple_builder =
+            GateBuilder::new("ripple_carry".to_string(), GateBuilderOptions::no_opt());
         let lhs = ripple_builder.add_input("lhs".to_string(), bits);
         let rhs = ripple_builder.add_input("rhs".to_string(), bits);
         let c_in = ripple_builder
@@ -340,13 +335,8 @@ mod tests {
     }
 
     fn make_carry_select(bits: usize, partitions: &[usize]) -> gate::GateFn {
-        let mut carry_select_builder = GateBuilder::new(
-            "carry_select".to_string(),
-            GateBuilderOptions {
-                fold: false,
-                hash: false,
-            },
-        );
+        let mut carry_select_builder =
+            GateBuilder::new("carry_select".to_string(), GateBuilderOptions::no_opt());
         let lhs = carry_select_builder.add_input("lhs".to_string(), bits);
         let rhs = carry_select_builder.add_input("rhs".to_string(), bits);
         let c_in = carry_select_builder
@@ -390,13 +380,8 @@ mod tests {
     #[test_case(8)]
     fn test_gatify_ule(bits: usize) {
         let via_adder = {
-            let mut builder = GateBuilder::new(
-                "ule_via_adder".to_string(),
-                GateBuilderOptions {
-                    fold: false,
-                    hash: false,
-                },
-            );
+            let mut builder =
+                GateBuilder::new("ule_via_adder".to_string(), GateBuilderOptions::no_opt());
             let lhs = builder.add_input("lhs".to_string(), bits);
             let rhs = builder.add_input("rhs".to_string(), bits);
             let result = gatify_ule_via_adder(&mut builder, 3, &lhs, &rhs);
@@ -406,10 +391,7 @@ mod tests {
         let via_bit_tests = {
             let mut builder = GateBuilder::new(
                 "ule_via_bit_tests".to_string(),
-                GateBuilderOptions {
-                    fold: false,
-                    hash: false,
-                },
+                GateBuilderOptions::no_opt(),
             );
             let lhs = builder.add_input("lhs".to_string(), bits);
             let rhs = builder.add_input("rhs".to_string(), bits);

--- a/xlsynth-g8r/src/lib.rs
+++ b/xlsynth-g8r/src/lib.rs
@@ -21,4 +21,5 @@ pub mod process_ir_path;
 pub mod propose_equiv;
 pub mod test_utils;
 pub mod use_count;
+pub mod validate_equiv;
 pub mod xls_ir;

--- a/xlsynth-g8r/src/propose_equiv.rs
+++ b/xlsynth-g8r/src/propose_equiv.rs
@@ -84,7 +84,7 @@ pub fn propose_equiv(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::setup_simple_graph;
+    use crate::test_utils::{setup_graph_with_redundancies, setup_simple_graph};
     use rand::SeedableRng;
 
     #[test]
@@ -105,6 +105,26 @@ mod tests {
                 &vec![graph.b.node],
                 &vec![graph.c.node],
                 &vec![graph.o.node],
+            ]
+        );
+    }
+
+    #[test]
+    fn test_propose_equiv_graph_with_redundancies() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let graph = setup_graph_with_redundancies();
+        let mut seeded_rng = rand::rngs::StdRng::seed_from_u64(0);
+        let equiv_classes = propose_equiv(&graph.g, 4096, &mut seeded_rng);
+        log::info!("equiv_classes: {:?}", equiv_classes);
+        assert_eq!(equiv_classes.len(), 2);
+        let mut values = equiv_classes.values().collect::<Vec<_>>();
+        // Sort them so we can do stable tests.
+        values.sort();
+        assert_eq!(
+            *values,
+            vec![
+                &vec![graph.inner0.node, graph.inner1.node],
+                &vec![graph.outer0.node, graph.outer1.node],
             ]
         );
     }

--- a/xlsynth-g8r/src/test_utils.rs
+++ b/xlsynth-g8r/src/test_utils.rs
@@ -124,7 +124,7 @@ fn mul_bf16_bf16(x: bfloat16::BF16, y: bfloat16::BF16) -> bfloat16::BF16 {
     }
 }
 
-pub fn load_bf16_add_sample() -> LoadedSample {
+pub fn load_bf16_add_sample(opt: Opt) -> LoadedSample {
     let dslx_text = "import bfloat16;\n\nfn add_bf16_bf16(x: bfloat16::BF16, y: bfloat16::BF16) -> bfloat16::BF16 {\n        bfloat16::add(x, y)\n}";
     let fake_path = Path::new("test_utils.x");
     let ir_result = xlsynth::convert_dslx_to_ir(
@@ -149,8 +149,8 @@ pub fn load_bf16_add_sample() -> LoadedSample {
     let gatify_output = ir2gate::gatify(
         &g8r_ir_fn,
         ir2gate::GatifyOptions {
-            fold: true,
-            hash: true,
+            fold: if opt == Opt::Yes { true } else { false },
+            hash: if opt == Opt::Yes { true } else { false },
             check_equivalence: false,
         },
     )
@@ -250,6 +250,50 @@ pub fn setup_graph_with_redundancies() -> TestGraphWithRedundancies {
         inner1,
         outer0,
         outer1,
+    }
+}
+
+pub struct TestPartiallyEquivGraph {
+    pub g: GateFn,
+    pub i0: AigOperand,
+    pub i1: AigOperand,
+    pub i2: AigOperand,
+    pub a: AigOperand,
+    pub b: AigOperand,
+    pub c: AigOperand,
+}
+
+/// Creates a graph where 'a' and 'b' are equivalent, but 'c' is not.
+/// Graph:
+/// i0 --\\ AND(a) [output]
+/// i1 --/
+/// i0 --\\ AND(b) [output]
+/// i1 --/
+/// i0 --\\ AND(c) [output]
+/// i2 --/
+pub fn setup_partially_equiv_graph() -> TestPartiallyEquivGraph {
+    let mut gb = GateBuilder::new("partial_equiv".to_string(), GateBuilderOptions::no_opt());
+    let i0 = gb.add_input("i0".to_string(), 1).try_into().unwrap();
+    let i1 = gb.add_input("i1".to_string(), 1).try_into().unwrap();
+    let i2 = gb.add_input("i2".to_string(), 1).try_into().unwrap();
+
+    let a = gb.add_and_binary(i0, i1);
+    let b = gb.add_and_binary(i0, i1); // Identical to 'a'
+    let c = gb.add_and_binary(i0, i2); // Different from 'a' and 'b'
+
+    gb.add_output("a".to_string(), a.into());
+    gb.add_output("b".to_string(), b.into());
+    gb.add_output("c".to_string(), c.into());
+
+    let g = gb.build();
+    TestPartiallyEquivGraph {
+        g,
+        i0,
+        i1,
+        i2,
+        a,
+        b,
+        c,
     }
 }
 

--- a/xlsynth-g8r/src/validate_equiv.rs
+++ b/xlsynth-g8r/src/validate_equiv.rs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Validates equivalence classes proposed by `propose_equiv`.
+//!
+//! For a given equivalence class we will either get confirmation that they are
+//! all equivalent or a counterexample that demonstrates a case in which they
+//! are not equivalent.
+//!
+//! We use varisat for this because it supports incrementality via assume/solve
+//! and add_clause.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::gate::{extract_cone, AigNode, AigRef, GateFn};
+use xlsynth::IrBits;
+
+pub struct ValidationResult {
+    /// Sets that were proven equivalent, i.e. any value in set i can be
+    /// substituted for any other value in set i.
+    pub proven_equiv_sets: Vec<Vec<AigRef>>,
+
+    /// Input values that showed counterexamples in the equivalence sets, so
+    /// that these can be used as concrete stimulus for distinguishing proposals
+    /// in subsequent iterations.
+    pub cex_inputs: Vec<Vec<IrBits>>,
+}
+
+#[derive(Debug)]
+pub enum ValidationError {
+    SolverError(varisat::solver::SolverError),
+}
+
+// Tseitin clauses for: output_lit <=> lit_a AND lit_b
+// The Tseitsin clauses are a way of encoding the result of the AND gate in
+// terms of a fresh literal, which in our case is the `output_literal`.
+// The expansion is that `x ↔ A ∧ B` becomes:
+// (x ∨ ¬A ∨ ¬B)
+// (¬x ∨ A)
+// (¬x ∨ B)
+fn add_tseitsin_and(
+    solver: &mut impl varisat::ExtendFormula,
+    a: varisat::Lit,
+    b: varisat::Lit,
+    output: varisat::Lit,
+) {
+    solver.add_clause(&[!a, !b, output]);
+    solver.add_clause(&[a, !output]);
+    solver.add_clause(&[b, !output]);
+}
+
+// Clauses for m = a XOR b are:
+// (!a | !b | !m) & (a | b | !m) & (a | !b | m) & (!a | b | m)
+fn add_tseitsin_xor(
+    solver: &mut impl varisat::ExtendFormula,
+    a: varisat::Lit,
+    b: varisat::Lit,
+    output: varisat::Lit,
+) {
+    solver.add_clause(&[!a, !b, !output]);
+    solver.add_clause(&[a, b, !output]);
+    solver.add_clause(&[a, !b, output]);
+    solver.add_clause(&[!a, b, output]);
+}
+
+/// Returns a mapping from each AigRef in the cone to its corresponding SAT
+/// literal.
+fn build_sat_clauses(
+    solver: &mut impl varisat::ExtendFormula,
+    cone_gates: &[AigRef],
+    cone_inputs: &HashSet<AigRef>,
+    gates: &[AigNode],
+) -> HashMap<AigRef, varisat::Lit> {
+    let mut aig_ref_to_lit: HashMap<AigRef, varisat::Lit> = HashMap::new();
+
+    // Create literals for all gates in the cone.
+    for aig_ref in cone_gates {
+        let lit = solver.new_lit();
+        aig_ref_to_lit.insert(*aig_ref, lit);
+    }
+
+    // Create literals for all inputs to the cone.
+    for input in cone_inputs {
+        let lit = solver.new_lit();
+        aig_ref_to_lit.insert(*input, lit);
+    }
+
+    // For each gate add correpsonding structural clauses.
+    for aig_ref in cone_gates {
+        let output_lit = aig_ref_to_lit[aig_ref];
+        let gate = &gates[aig_ref.id];
+        match gate {
+            AigNode::Literal(value) => {
+                if *value {
+                    solver.add_clause(&[output_lit]);
+                } else {
+                    solver.add_clause(&[!output_lit]);
+                }
+            }
+            AigNode::And2 { a, b, .. } => {
+                let a_node_lit = aig_ref_to_lit[&a.node];
+                let b_node_lit = aig_ref_to_lit[&b.node];
+                let a_lit = if a.negated { !a_node_lit } else { a_node_lit };
+                let b_lit = if b.negated { !b_node_lit } else { b_node_lit };
+                add_tseitsin_and(solver, a_lit, b_lit, output_lit);
+            }
+            AigNode::Input { .. } => {
+                // Nothing to do for this.
+            }
+        }
+    }
+
+    aig_ref_to_lit
+}
+
+fn add_miters(
+    solver: &mut impl varisat::ExtendFormula,
+    aig_ref_to_lit: &HashMap<AigRef, varisat::Lit>,
+    known_equiv: &[AigRef],
+    candidate: AigRef,
+) -> Vec<varisat::Lit> {
+    let mut miters: Vec<varisat::Lit> = Vec::with_capacity(known_equiv.len());
+    for lhs in known_equiv {
+        let xor_miter = solver.new_lit();
+        let a = aig_ref_to_lit[lhs];
+        let b = aig_ref_to_lit[&candidate];
+        add_tseitsin_xor(solver, a, b, xor_miter);
+        miters.push(xor_miter);
+    }
+    miters
+}
+
+fn solver_model_to_cex(
+    model: &[varisat::Lit],
+    cone_inputs: &HashSet<AigRef>,
+    aig_ref_to_lit: &HashMap<AigRef, varisat::Lit>,
+    gate_fn: &GateFn,
+) -> Vec<IrBits> {
+    let model_set: HashSet<varisat::Lit> = model.iter().cloned().collect();
+
+    // We could really collect this as a tristate value and then flatten it with
+    // some X policy, but to keep it simple we just emit zero.
+    let mut inputs_map: HashMap<AigRef, bool> = HashMap::new();
+    for input_aig_ref in cone_inputs.iter() {
+        let input_lit: varisat::Lit = aig_ref_to_lit[&input_aig_ref];
+        let not_input_lit: varisat::Lit = !input_lit;
+        if model_set.contains(&input_lit) {
+            inputs_map.insert(*input_aig_ref, true);
+        } else if model_set.contains(&not_input_lit) {
+            inputs_map.insert(*input_aig_ref, false);
+        } else {
+            inputs_map.insert(*input_aig_ref, false);
+        }
+    }
+    let cex = gate_fn.map_to_inputs(inputs_map);
+    cex
+}
+
+pub fn validate_equiv(
+    gate_fn: &GateFn,
+    equiv_classes: &[&[AigRef]],
+) -> Result<ValidationResult, ValidationError> {
+    // Extract the combined cone for all of the references we're trying to determine
+    // equivalence for.
+    let mut frontier: Vec<AigRef> = vec![];
+    for equiv_class in equiv_classes {
+        for aig_ref in equiv_class.iter() {
+            frontier.push(*aig_ref);
+        }
+    }
+
+    let (cone_gates, cone_inputs) = extract_cone(&frontier, &gate_fn.gates);
+
+    let mut solver = varisat::Solver::new();
+
+    // Build the SAT clauses for the cone -- we're going to add miters on top of
+    // this structure.
+    let aig_ref_to_lit = build_sat_clauses(&mut solver, &cone_gates, &cone_inputs, &gate_fn.gates);
+
+    let mut validation_result = ValidationResult {
+        proven_equiv_sets: Vec::new(),
+        cex_inputs: Vec::new(),
+    };
+
+    // Now iterate through the equivalence classes -- for each equivalence class
+    // we'll advance a miter that checks whether the next value in the
+    // equivalence class is equivalent to the previous value(s) which are
+    // determined to be equivalent. By using multiple miters I'm suspecting we can
+    // potentially find counterexamples faster.
+    for equiv_class in equiv_classes {
+        let mut known_equiv = vec![equiv_class[0]];
+        for &candidate in &equiv_class[1..] {
+            // Create a miter between this candidate and all known equivalent values.
+            let miters = add_miters(&mut solver, &aig_ref_to_lit, &known_equiv, candidate);
+
+            // Assume the miters outputs are true, which is stating "the candidate is
+            // unequal to the known_equiv values".
+            solver.assume(&miters);
+            let solve_result = solver.solve();
+            match solve_result {
+                Ok(false) => {
+                    // No counterexample found, expand the known equivalent set.
+                    known_equiv.push(candidate);
+                }
+                Ok(true) => {
+                    // Counterexample found, extract it from the model.
+                    let model = solver.model();
+                    assert!(
+                        model.is_some(),
+                        "counterexample found, should be able to extract model"
+                    );
+                    let cex = solver_model_to_cex(
+                        &model.unwrap(),
+                        &cone_inputs,
+                        &aig_ref_to_lit,
+                        gate_fn,
+                    );
+                    validation_result.cex_inputs.push(cex);
+                    break;
+                }
+                Err(e) => {
+                    return Err(ValidationError::SolverError(e));
+                }
+            }
+        }
+        if known_equiv.len() > 1 {
+            validation_result
+                .proven_equiv_sets
+                .push(equiv_class.to_vec())
+        }
+    }
+
+    Ok(validation_result)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use rand::SeedableRng;
+
+    use crate::{
+        gate::AigRef,
+        propose_equiv::propose_equiv,
+        test_utils::{load_bf16_mul_sample, setup_graph_with_redundancies, Opt},
+    };
+
+    use super::validate_equiv;
+
+    #[test]
+    fn test_validate_equiv_graph_with_redundancies() {
+        let setup = setup_graph_with_redundancies();
+        let mut seeded_rng = rand::rngs::StdRng::seed_from_u64(0);
+        let equiv_classes = propose_equiv(&setup.g, 16, &mut seeded_rng);
+        let classes: Vec<&[AigRef]> = equiv_classes
+            .values()
+            .map(|nodes| nodes.as_slice())
+            .collect();
+        let validation_result = validate_equiv(&setup.g, &classes).unwrap();
+        assert_eq!(validation_result.proven_equiv_sets.len(), 2);
+    }
+
+    #[test]
+    fn test_validate_equiv_bf16_mul() {
+        let setup = load_bf16_mul_sample(Opt::Yes);
+        let mut seeded_rng = rand::rngs::StdRng::seed_from_u64(0);
+        let propose_start = Instant::now();
+        let equiv_classes = propose_equiv(&setup.gate_fn, 256, &mut seeded_rng);
+        let propose_end = Instant::now();
+        let propose_duration = propose_end - propose_start;
+        eprintln!(
+            "Proposed {} equiv classes in {:?}",
+            equiv_classes.len(),
+            propose_duration
+        );
+        assert_eq!(equiv_classes.len(), 1036);
+
+        let classes: Vec<&[AigRef]> = equiv_classes
+            .values()
+            .map(|nodes| nodes.as_slice())
+            .collect();
+        let validate_start = Instant::now();
+        let validation_result = validate_equiv(&setup.gate_fn, &classes).unwrap();
+        let validate_end = Instant::now();
+        let validate_duration = validate_end - validate_start;
+        eprintln!(
+            "Validated to {} proven sets {} counterexamples in {:?}",
+            validation_result.proven_equiv_sets.len(),
+            validation_result.cex_inputs.len(),
+            validate_duration
+        );
+        assert_eq!(validation_result.proven_equiv_sets.len(), 19);
+    }
+}

--- a/xlsynth-g8r/tests/gate_sim_vs_ir_interp.rs
+++ b/xlsynth-g8r/tests/gate_sim_vs_ir_interp.rs
@@ -14,13 +14,14 @@ use xlsynth_g8r::gate_sim::{self, Collect};
 use xlsynth_g8r::get_summary_stats::get_gate_depth;
 use xlsynth_g8r::test_utils::{
     flat_ir_bits_to_ir_value_bf16, ir_value_bf16_to_flat_ir_bits, load_bf16_mul_sample, make_bf16,
+    Opt,
 };
 use xlsynth_g8r::use_count::get_id_to_use_count;
 
 #[test]
 fn test_bf16_mul_zero_zero() {
     let _ = env_logger::builder().is_test(true).try_init();
-    let loaded_sample = load_bf16_mul_sample();
+    let loaded_sample = load_bf16_mul_sample(Opt::Yes);
     let ir_fn = loaded_sample.ir_fn;
     let gate_fn = loaded_sample.gate_fn;
 
@@ -47,7 +48,7 @@ fn test_bf16_mul_zero_zero() {
 #[test]
 fn test_bf16_mul_random() {
     let _ = env_logger::builder().is_test(true).try_init();
-    let loaded_sample = load_bf16_mul_sample();
+    let loaded_sample = load_bf16_mul_sample(Opt::Yes);
     let ir_fn = loaded_sample.ir_fn;
     let gate_fn = loaded_sample.gate_fn;
 
@@ -95,7 +96,7 @@ fn test_bf16_mul_random() {
 fn test_bf16_mul_g8r_stats() {
     let _ = env_logger::builder().is_test(true).try_init();
     log::info!("loading bf16 mul sample");
-    let loaded_sample = load_bf16_mul_sample();
+    let loaded_sample = load_bf16_mul_sample(Opt::Yes);
     let gate_fn = &loaded_sample.gate_fn;
 
     log::info!("getting id to use count");

--- a/xlsynth-g8r/tests/gate_sim_vs_ir_interp.rs
+++ b/xlsynth-g8r/tests/gate_sim_vs_ir_interp.rs
@@ -42,6 +42,8 @@ fn test_bf16_mul_zero_zero() {
     assert_eq!(ir_result, gate_result);
 }
 
+/// Pushes concrete random input vectors through both the IR function and the
+/// g8r mapped version and checks they are equivalent.
 #[test]
 fn test_bf16_mul_random() {
     let _ = env_logger::builder().is_test(true).try_init();

--- a/xlsynth-g8r/tests/gatify_tests.rs
+++ b/xlsynth-g8r/tests/gatify_tests.rs
@@ -8,13 +8,8 @@ use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
 use xlsynth_g8r::get_summary_stats::{get_summary_stats, SummaryStats};
 use xlsynth_g8r::ir2gate::{gatify, gatify_ule_via_bit_tests, GatifyOptions};
 use xlsynth_g8r::ir2gate_utils::gatify_one_hot;
+use xlsynth_g8r::test_utils::Opt;
 use xlsynth_g8r::xls_ir::ir_parser;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Opt {
-    Yes,
-    No,
-}
 
 /// Proves that the gate-mapped version fo the top function in `ir_package_text`
 /// is equivalent to the IR version.


### PR DESCRIPTION
Done via `varisat` due to its support for incremental clause addition and `assume`, super useful!

On my M2 macbook air on battery:
```
$ cargo test -p xlsynth-g8r --lib test_validate_equiv_bf16_mul --release -- --nocapture
Proposed 1036 equiv classes in 168.872917ms
Validated to 19 proven sets 46 counterexamples in 14.683458ms
test validate_equiv::tests::test_validate_equiv_bf16_mul ... ok
```