### PR TITLE
[g8r] Also propose/verify *inverted* gate histories.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "sample-usage"
-version = "0.0.118"
+version = "0.0.119"
 dependencies = [
  "cargo_metadata 0.18.1",
  "env_logger",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "test-helpers"
-version = "0.0.118"
+version = "0.0.119"
 dependencies = [
  "cargo_metadata 0.18.1",
  "curl",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth"
-version = "0.0.118"
+version = "0.0.119"
 dependencies = [
  "cargo_metadata 0.18.1",
  "criterion 0.3.6",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-driver"
-version = "0.0.118"
+version = "0.0.119"
 dependencies = [
  "clap 4.5.35",
  "colored",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-estimator"
-version = "0.0.118"
+version = "0.0.119"
 dependencies = [
  "env_logger",
  "log",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-g8r"
-version = "0.0.118"
+version = "0.0.119"
 dependencies = [
  "arbitrary",
  "bitvec",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "xlsynth-sys"
-version = "0.0.118"
+version = "0.0.119"
 dependencies = [
  "flate2",
  "libc",

--- a/xlsynth-g8r/src/check_equivalence.rs
+++ b/xlsynth-g8r/src/check_equivalence.rs
@@ -3,8 +3,8 @@
 use crate::{gate, gate2ir, xls_ir::ir};
 
 pub fn check_equivalence(orig_package: &str, gate_package: &str) -> Result<(), String> {
-    log::info!("check_equivalence; orig_package:\n{}", orig_package);
-    log::info!("check_equivalence; gate_package:\n{}", gate_package);
+    log::debug!("check_equivalence; orig_package:\n{}", orig_package);
+    log::debug!("check_equivalence; gate_package:\n{}", gate_package);
     let tempdir = tempfile::tempdir().unwrap();
     let temp_path = tempdir.into_path(); // This prevents auto-deletion
     let orig_path = temp_path.join("orig.ir");

--- a/xlsynth-g8r/src/gate.rs
+++ b/xlsynth-g8r/src/gate.rs
@@ -364,6 +364,8 @@ fn ir_bits_from_bitvec(bv: BitVec) -> IrBits {
 }
 
 impl GateFn {
+    /// Collapses a sparse mapping of AigRefs to boolean values into a vector of
+    /// IrBits that can be fed to gate / IR simulation as input stimulus.
     pub fn map_to_inputs(&self, map: HashMap<AigRef, bool>) -> Vec<IrBits> {
         let mut bitvecs: Vec<BitVec> = self
             .inputs
@@ -373,9 +375,10 @@ impl GateFn {
         for (input_num, input) in self.inputs.iter().enumerate() {
             for bit_index in 0..input.get_bit_count() {
                 let aig_ref = input.bit_vector.get_lsb(bit_index).non_negated().unwrap();
-                let bit_value = map
-                    .get(&aig_ref)
-                    .expect("all input gates should be present");
+                let bit_value = map.get(&aig_ref).expect(&format!(
+                    "all input gates should be present in provided sparse map; missing: {:?}",
+                    aig_ref
+                ));
                 bitvecs[input_num].set(bit_index, *bit_value);
             }
         }

--- a/xlsynth-g8r/src/gate2ir.rs
+++ b/xlsynth-g8r/src/gate2ir.rs
@@ -198,7 +198,7 @@ pub fn gate_fn_to_xlsynth_ir(
     function_type: &ir::FunctionType,
 ) -> Result<xlsynth::IrPackage, XlsynthError> {
     assert_eq!(gate_fn.inputs.len(), function_type.param_types.len());
-    log::info!(
+    log::debug!(
         "Converting gate function `{}` to IR:\n{}",
         gate_fn.name,
         gate_fn.to_string()
@@ -359,7 +359,7 @@ top fn do_nand(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
         let package =
             gate_fn_to_xlsynth_ir(&gatify_output.gate_fn, "sample", &ir_top.get_type()).unwrap();
         let gate_fn_as_xls_ir = package.to_string();
-        log::info!("gate_fn_as_xls_ir:\n{}", gate_fn_as_xls_ir);
+        log::debug!("gate_fn_as_xls_ir:\n{}", gate_fn_as_xls_ir);
         assert_eq!(gate_fn_as_xls_ir, input_ir_text);
     }
 }

--- a/xlsynth-g8r/src/ir2gate.rs
+++ b/xlsynth-g8r/src/ir2gate.rs
@@ -1072,7 +1072,7 @@ fn gatify_internal(f: &ir::Fn, g8_builder: &mut GateBuilder, env: &mut GateEnv) 
             ir::NodePayload::Binop(ir::Binop::Ne, a, b) => {
                 let a_gate_refs = env.get_bit_vector(*a).expect("ne lhs should be present");
                 let b_gate_refs = env.get_bit_vector(*b).expect("ne rhs should be present");
-                log::info!(
+                log::debug!(
                     "ne lhs bits[{}] rhs bits[{}]",
                     a_gate_refs.get_bit_count(),
                     b_gate_refs.get_bit_count()
@@ -1366,7 +1366,7 @@ fn gatify_internal(f: &ir::Fn, g8_builder: &mut GateBuilder, env: &mut GateEnv) 
                 env.add(node_ref, GateOrVec::BitVector(bits));
             }
             ir::NodePayload::Encode { arg } => {
-                log::info!("gatifying encode; ty: {}", node.ty);
+                log::debug!("gatifying encode; ty: {}", node.ty);
                 let arg_bits = env
                     .get_bit_vector(*arg)
                     .expect("encode arg should be present");
@@ -1533,7 +1533,7 @@ pub fn gatify(f: &ir::Fn, options: GatifyOptions) -> Result<GatifyOutput, String
     let mut env = GateEnv::new();
     gatify_internal(f, &mut g8_builder, &mut env);
     let gate_fn = g8_builder.build();
-    log::info!(
+    log::debug!(
         "converted IR function to gate function:\n{}",
         gate_fn.to_string()
     );

--- a/xlsynth-g8r/src/test_utils.rs
+++ b/xlsynth-g8r/src/test_utils.rs
@@ -181,15 +181,17 @@ pub struct TestGraph {
     pub o: AigOperand,
 }
 
-/// Creates a common graph structure for testing cone extraction.
-/// Graph:
-/// i0 --\
-///       AND(a) --\
-/// i1 --|          \
-///       AND(b) -- AND(o) [output]
-/// i2 --|
-///       AND(c) [output]
-/// i3 --/
+/// Creates a common graph structure for testing e.g. cone extraction.
+/// There are no redundancies in this graph.
+/// ```text
+/// fn g(i0, i1, i2, i3) -> (o, c) {
+///     a = i0 & i1
+///     b = i1 & i2
+///     c = i2 & i3
+///     o = a & b
+///     return (o, c)
+/// }
+/// ```
 pub fn setup_simple_graph() -> TestGraph {
     let mut gb = GateBuilder::new("g".to_string(), GateBuilderOptions::no_opt());
     let i0: AigOperand = gb.add_input("i0".to_string(), 1).try_into().unwrap();
@@ -407,6 +409,30 @@ pub fn setup_graph_for_liveness_check() -> TestGraphForLivenessCheck {
         c_in,
         o1_op: o1,
         o2_op: o2,
+    }
+}
+
+pub struct TestGraphForConstantReplace {
+    pub g: GateFn,
+    pub const_true: AigOperand,
+    pub const_false: AigOperand,
+    pub and_true_true: AigOperand, // And2(true, true) node
+}
+
+pub fn setup_graph_for_constant_replace() -> TestGraphForConstantReplace {
+    let mut gb = GateBuilder::new("constant_replace".to_string(), GateBuilderOptions::no_opt());
+    let const_true = gb.get_true();
+    let const_false = gb.get_false();
+    let and_true_true = gb.add_and_binary(const_true, const_true);
+    gb.add_output("out".to_string(), and_true_true.into());
+
+    let g = gb.build();
+
+    TestGraphForConstantReplace {
+        g,
+        const_true,
+        const_false,
+        and_true_true,
     }
 }
 


### PR DESCRIPTION
This allows us to find gates that are inverse patterns of other gates and rewire them via a negated operand. Before we needed the polarities of gates to happen to match to find the substitution.

With release build on Ryzen 9 7950X:
```
bf16_mul: live nodes: 1172 -> 1147 (2.13% improvement)
bf16_mul: depth: 109 -> 105 (3.67% improvement)
bf16_mul: took 530.435484ms

bf16_add: live nodes: 1303 -> 1139 (12.59% improvement)
bf16_add: depth: 130 -> 120 (7.69% improvement)
bf16_add: took 2.402919234s
```