### PR TITLE
[g8r] parser fix for identifiers starting with ret

### DIFF
--- a/xlsynth-g8r/src/fraig.rs
+++ b/xlsynth-g8r/src/fraig.rs
@@ -131,8 +131,10 @@ pub fn fraig_optimize(
                     let node_ref = equiv_node.aig_ref();
                     let is_inverted = equiv_node.is_inverted();
                     (stats.ref_to_depth[&node_ref], is_inverted, node_ref.id)
-                })
-                .unwrap();
+                });
+            let Some(min_depth_node) = min_depth_node else {
+                continue;
+            };
             for equiv_node in proven_equiv_set.iter() {
                 // if this is the "minimum depth" one in the equivalence class, we don't replace
                 // it with anything

--- a/xlsynth-g8r/src/fuzz_utils.rs
+++ b/xlsynth-g8r/src/fuzz_utils.rs
@@ -1,21 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use xlsynth::ir_value::IrBits;
+use xlsynth::ir_value::{IrBits, IrValue};
 use xlsynth::xlsynth_error::XlsynthError;
 
 /// Generates an arbitrary IrBits value of the given width using the provided
 /// random number generator. The width must be <= 64.
 pub fn arbitrary_irbits<R: rand::Rng>(rng: &mut R, width: usize) -> Result<IrBits, XlsynthError> {
     assert!(width > 0, "width must be positive, got {}", width);
-    assert!(
-        width <= 64,
-        "arbitrary_irbits only supports width <= 64 for now, got {}",
-        width
-    );
-    let value = if width == 64 {
-        rng.gen::<u64>()
-    } else {
-        rng.gen_range(0..(1u64 << width))
-    };
-    IrBits::make_ubits(width, value)
+    if width > 64 {
+        // We build a string and then parse that. Inefficient, replace with better APIs
+        // when they're available.
+        let mut s = String::new();
+        for _bit_index in 0..width {
+            s.push(if rng.gen_bool(0.5) { '1' } else { '0' });
+        }
+        let value = IrValue::parse_typed(&format!("bits[{}]:0b{}", width, s))?;
+        return value.to_bits();
+    }
+    let value = rng.gen::<u64>();
+    let value_masked = value & ((1u64 << width) - 1);
+    IrBits::make_ubits(width, value_masked)
 }

--- a/xlsynth-g8r/src/propose_equiv.rs
+++ b/xlsynth-g8r/src/propose_equiv.rs
@@ -2,6 +2,7 @@
 
 //! Functionality for proposing equivalence classes via concrete simulation.
 
+use crate::fuzz_utils::arbitrary_irbits;
 use crate::gate::{AigNode, AigRef, GateFn};
 use crate::gate_sim::{self, Collect, GateSimResult};
 use bitvec::vec::BitVec;
@@ -54,17 +55,11 @@ impl Ord for EquivNode {
     }
 }
 
-fn gen_random_input_bits(bit_count: usize, rng: &mut impl Rng) -> IrBits {
-    let value = rng.gen::<u64>();
-    let value_masked = value & ((1 << bit_count) - 1);
-    IrBits::make_ubits(bit_count, value_masked).unwrap()
-}
-
 fn gen_random_inputs(gate_fn: &GateFn, rng: &mut impl Rng) -> Vec<IrBits> {
     gate_fn
         .inputs
         .iter()
-        .map(|input| gen_random_input_bits(input.bit_vector.get_bit_count(), rng))
+        .map(|input| arbitrary_irbits(rng, input.bit_vector.get_bit_count()).unwrap())
         .collect()
 }
 

--- a/xlsynth-g8r/src/xls_ir/ir_node_env.rs
+++ b/xlsynth-g8r/src/xls_ir/ir_node_env.rs
@@ -49,6 +49,10 @@ impl IrNodeEnv {
             NameOrId::Name(name) => self.name_to_node.get(name.as_str()),
         }
     }
+
+    pub fn keys(&self) -> Vec<&String> {
+        self.name_to_node.keys().collect::<Vec<&String>>()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Plumbs context all around for better error message reporting.

Also make arbitrary bitstring generation work in a fallback slow way if it's more than 64 bits.