### PR TITLE
[build] Make build.rs pull the DSO via reqwest that does not take a dep on native SSL libraries

### DIFF
--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -14,7 +14,7 @@ links = "xlsynth"
 libc = "0.2"
 
 [build-dependencies]
-reqwest = { version = "0.12", features = ["blocking"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 flate2 = "1.0"
 tar = "0.4"
 sha2 = "0.10"


### PR DESCRIPTION
Using rustls should be totally fine I believe since we don't care about performance here, and makes the build-dependencies easier to deal with.