### PR TITLE
Add IR optimization equivalence fuzz target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,6 @@ jobs:
         run: |
           mkdir -p boolector_libs
           wget -O boolector_libs/libboolector.so https://github.com/xlsynth/boolector-build/releases/download/boolector-debian10-171b2783200bf9f7636f3e595587ee822a0a6d07/libboolector-debian10.so
-          if [ ! -f boolector_libs/libboolector.so ]; then
-            echo "ERROR: libboolector.so was not downloaded correctly!" >&2
-            ls -l boolector_libs/
-            exit 1
-          fi
-          echo "Boolector lib downloaded to $(pwd)/boolector_libs"
-          ls -l boolector_libs/
           sudo cp boolector_libs/libboolector.so /usr/lib/
           sudo ldconfig
           echo "Listing /usr/lib for libboolector.so:"
@@ -514,19 +507,40 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
-      - name: Install libc++ (C++ standard library)
+      - name: Download and set up Boolector
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libc++1 libc++abi1
+          mkdir -p boolector_libs
+          wget -O boolector_libs/libboolector.so https://github.com/xlsynth/boolector-build/releases/download/boolector-debian10-171b2783200bf9f7636f3e595587ee822a0a6d07/libboolector-debian10.so
+          sudo cp boolector_libs/libboolector.so /usr/lib/
+          sudo ldconfig
+
+      - name: Verify Boolector library presence
+        run: |
+          ls -l /usr/lib/libboolector.so
+          ldconfig -p | grep boolector
 
       - name: Download xlsynth tools for fuzzing
         run: |
           pip3 install -r requirements.txt
-          python3 download_release.py -p ubuntu2004 --binaries check_ir_equivalence_main -o /tmp/xlsynth_tools_smoke
+          python3 download_release.py -p rocky8 --binaries check_ir_equivalence_main -d -o /tmp/xlsynth_tools_smoke
+          sudo mv /tmp/xlsynth_tools_smoke/libxls-rocky8.so /usr/lib/libxls-rocky8.so
+          sudo ldconfig
+
+      - name: Build and run fuzz_ir_opt_equiv for 10 seconds
+        env:
+          XLSYNTH_TOOLS: /tmp/xlsynth_tools_smoke
+          XLS_DSO_PATH: /usr/lib/libxls-rocky8.so
+          DSLX_STDLIB_PATH: /tmp/xlsynth_tools_smoke/xls/dslx/stdlib
+        run: |
+          cargo install cargo-fuzz
+          cd xlsynth-g8r/fuzz
+          cargo fuzz run fuzz_ir_opt_equiv -- -max_total_time=10
 
       - name: Build and run fuzz_gatify for 10 seconds
         env:
           XLSYNTH_TOOLS: /tmp/xlsynth_tools_smoke
+          XLS_DSO_PATH: /usr/lib/libxls-rocky8.so
+          DSLX_STDLIB_PATH: /tmp/xlsynth_tools_smoke/xls/dslx/stdlib
         run: |
           cargo install cargo-fuzz
           cd xlsynth-g8r/fuzz

--- a/xlsynth-g8r/fuzz/Cargo.lock
+++ b/xlsynth-g8r/fuzz/Cargo.lock
@@ -164,6 +164,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "boolector"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5567f99e46c8f1f61624adafd2fdf4424b203d9fc5534368421725af17c5fd21"
+dependencies = [
+ "boolector-sys",
+ "libc",
+]
+
+[[package]]
+name = "boolector-sys"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f0c2f69c37174fb92110f2949c79ad87f6ab48bf45e2e3220b669c10698093"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +1664,7 @@ version = "0.0.142"
 dependencies = [
  "bitvec",
  "blake3",
+ "boolector",
  "clap",
  "env_logger",
  "flate2",

--- a/xlsynth-g8r/fuzz/Cargo.toml
+++ b/xlsynth-g8r/fuzz/Cargo.toml
@@ -15,9 +15,7 @@ env_logger = "0.11"
 xlsynth = { path = "../../xlsynth", version = "0.0.147" }
 rand = "0.8"
 xlsynth-test-helpers = { path = "../../xlsynth-test-helpers" }
-
-[dependencies.xlsynth-g8r]
-path = ".."
+xlsynth-g8r = { path = "../../xlsynth-g8r", features = ["with-boolector-system"] }
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -32,5 +30,11 @@ doc = false
 [[bin]]
 name = "fuzz_bulk_replace"
 path = "fuzz_targets/fuzz_bulk_replace.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_ir_opt_equiv"
+path = "fuzz_targets/fuzz_ir_opt_equiv.rs"
 test = false
 doc = false

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use xlsynth_g8r::check_equivalence;
+use xlsynth_g8r::ir_equiv_boolector;
+use xlsynth_g8r::xls_ir::ir_parser;
+use xlsynth_test_helpers::ir_fuzz::{generate_ir_fn, FuzzSample};
+
+fuzz_target!(|sample: FuzzSample| {
+    // Ensure XLSYNTH_TOOLS is set for equivalence checking
+    if std::env::var("XLSYNTH_TOOLS").is_err() {
+        panic!("XLSYNTH_TOOLS environment variable must be set for fuzzing.");
+    }
+
+    if sample.ops.is_empty() || sample.input_bits == 0 {
+        return;
+    }
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    // Build an XLS IR package from the fuzz sample
+    let mut pkg = xlsynth::IrPackage::new("fuzz_pkg").unwrap();
+    if let Err(e) = generate_ir_fn(sample.input_bits, sample.ops.clone(), &mut pkg) {
+        log::info!("IR generation failed: {}", e);
+        return;
+    }
+
+    let top_fn = pkg.get_function("fuzz_test").unwrap();
+
+    // Optimize the IR
+    let optimized_pkg = match xlsynth::optimize_ir(&pkg, top_fn.get_name().as_str()) {
+        Ok(p) => p,
+        Err(e) => {
+            log::error!("optimize_ir failed: {}", e);
+            return;
+        }
+    };
+
+    // Parse both packages using the xlsynth-g8r parser
+    let orig_pkg = ir_parser::Parser::new(&pkg.to_string())
+        .parse_package()
+        .unwrap();
+    let opt_pkg = ir_parser::Parser::new(&optimized_pkg.to_string())
+        .parse_package()
+        .unwrap();
+
+    let orig_fn = orig_pkg.get_top().unwrap();
+    let opt_fn = opt_pkg.get_top().unwrap();
+
+    // Check equivalence using the external tool first, specifying the top function
+    let orig_ir = pkg.to_string();
+    let opt_ir = optimized_pkg.to_string();
+    let top_fn_name = "fuzz_test";
+    let ext_equiv =
+        check_equivalence::check_equivalence_with_top(&orig_ir, &opt_ir, Some(top_fn_name));
+    match ext_equiv {
+        Ok(()) => {
+            // External tool says equivalent, Boolector should agree
+            match ir_equiv_boolector::check_equiv(orig_fn, opt_fn) {
+                ir_equiv_boolector::EquivResult::Proved => (),
+                ir_equiv_boolector::EquivResult::Disproved(cex) => {
+                    log::info!("==== IR disagreement detected ====");
+                    log::info!("Original IR:\n{}", orig_ir);
+                    log::info!("Optimized IR:\n{}", opt_ir);
+                    panic!(
+                        "Disagreement: external tool says equivalent, Boolector disproves: {:?}",
+                        cex
+                    );
+                }
+            }
+        }
+        Err(ext_err) => {
+            // External tool says not equivalent, check Boolector
+            match ir_equiv_boolector::check_equiv(orig_fn, opt_fn) {
+                ir_equiv_boolector::EquivResult::Proved => {
+                    log::info!("==== IR disagreement detected ====");
+                    log::info!("Original IR:\n{}", orig_ir);
+                    log::info!("Optimized IR:\n{}", opt_ir);
+                    panic!(
+                        "Disagreement: external tool says NOT equivalent, Boolector proves equivalence. External error: {}",
+                        ext_err
+                    );
+                }
+                ir_equiv_boolector::EquivResult::Disproved(_cex) => (), // Both agree not equivalent
+            }
+        }
+    }
+});

--- a/xlsynth-g8r/src/check_equivalence.rs
+++ b/xlsynth-g8r/src/check_equivalence.rs
@@ -5,6 +5,14 @@ use std::time::Instant;
 use crate::{gate, gate2ir, xls_ir::ir};
 
 pub fn check_equivalence(orig_package: &str, gate_package: &str) -> Result<(), String> {
+    check_equivalence_with_top(orig_package, gate_package, None)
+}
+
+pub fn check_equivalence_with_top(
+    orig_package: &str,
+    gate_package: &str,
+    top_fn_name: Option<&str>,
+) -> Result<(), String> {
     let tempdir = tempfile::tempdir().unwrap();
     let temp_path = tempdir.into_path(); // This prevents auto-deletion
     let orig_path = temp_path.join("orig.ir");
@@ -28,7 +36,11 @@ pub fn check_equivalence(orig_package: &str, gate_package: &str) -> Result<(), S
     command.arg("--alsologtostderr");
     command.arg(orig_path.to_str().unwrap());
     command.arg(gate_path.to_str().unwrap());
-    log::info!("check_equivalence; running command: {:?}", command);
+    if let Some(top) = top_fn_name {
+        command.arg("--top");
+        command.arg(top);
+    }
+    log::info!("check_equivalence_with_top; running command: {:?}", command);
     let start = Instant::now();
     let output = command.output().unwrap();
     let elapsed = start.elapsed();
@@ -40,7 +52,7 @@ pub fn check_equivalence(orig_package: &str, gate_package: &str) -> Result<(), S
             String::from_utf8_lossy(&output.stderr)
         ));
     }
-    log::info!("check_equivalence; successful in {:?}", elapsed);
+    log::info!("check_equivalence_with_top; successful in {:?}", elapsed);
     Ok(())
 }
 

--- a/xlsynth-g8r/src/transforms/toggle_output.rs
+++ b/xlsynth-g8r/src/transforms/toggle_output.rs
@@ -3,7 +3,7 @@
 use rand::seq::SliceRandom;
 use rand::Rng;
 
-use crate::gate::{AigOperand, GateFn};
+use crate::gate::GateFn;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct OutputBitLoc {

--- a/xlsynth-test-helpers/src/ir_fuzz.rs
+++ b/xlsynth-test-helpers/src/ir_fuzz.rs
@@ -262,7 +262,10 @@ pub fn generate_ir_fn(
             } => {
                 assert!(new_bit_count > 0, "zero extend has new bit count of 0");
                 let operand = &available_nodes[(operand.index as usize) % available_nodes.len()];
-                let node = fn_builder.zero_extend(operand, new_bit_count as u64, None);
+                let operand_width =
+                    fn_builder.get_type(operand).unwrap().get_flat_bit_count() as u8;
+                let clamped_new_bit_count = std::cmp::max(new_bit_count, operand_width);
+                let node = fn_builder.zero_extend(operand, clamped_new_bit_count as u64, None);
                 available_nodes.push(node);
             }
             FuzzOp::SignExt {
@@ -271,7 +274,10 @@ pub fn generate_ir_fn(
             } => {
                 assert!(new_bit_count > 0, "sign extend has new bit count of 0");
                 let operand = &available_nodes[(operand.index as usize) % available_nodes.len()];
-                let node = fn_builder.sign_extend(operand, new_bit_count as u64, None);
+                let operand_width =
+                    fn_builder.get_type(operand).unwrap().get_flat_bit_count() as u8;
+                let clamped_new_bit_count = std::cmp::max(new_bit_count, operand_width);
+                let node = fn_builder.sign_extend(operand, clamped_new_bit_count as u64, None);
                 available_nodes.push(node);
             }
             FuzzOp::BitSlice {


### PR DESCRIPTION
## Summary
- create a new fuzz target checking optimized IR equivalence via Boolector
- include target in fuzz workspace
- run the target for 10s in CI

## Testing
- `cargo fmt --all`
- `cargo check --workspace`