### PR TITLE
[g8r] Optimize equivalence checking in MCMC

### DIFF
--- a/xlsynth-g8r/src/transforms/double_negate.rs
+++ b/xlsynth-g8r/src/transforms/double_negate.rs
@@ -173,6 +173,10 @@ impl Transform for DoubleNegateTransform {
             )),
         }
     }
+
+    fn always_equivalent(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/xlsynth-g8r/src/transforms/duplicate.rs
+++ b/xlsynth-g8r/src/transforms/duplicate.rs
@@ -197,6 +197,10 @@ impl Transform for DuplicateGateTransform {
             ))
         }
     }
+
+    fn always_equivalent(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug)]
@@ -330,6 +334,10 @@ impl Transform for UnduplicateGateTransform {
                 "Backward direction not supported for UnduplicateGateTransform"
             ))
         }
+    }
+
+    fn always_equivalent(&self) -> bool {
+        true
     }
 }
 

--- a/xlsynth-g8r/src/transforms/false_and.rs
+++ b/xlsynth-g8r/src/transforms/false_and.rs
@@ -128,6 +128,10 @@ impl Transform for InsertFalseAndTransform {
             )),
         }
     }
+
+    fn always_equivalent(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug)]
@@ -185,12 +189,16 @@ impl Transform for RemoveFalseAndTransform {
             )),
         }
     }
+
+    fn always_equivalent(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::gate::{AigNode, AigOperand};
+    use crate::gate::AigNode;
     use crate::gate_builder::{GateBuilder, GateBuilderOptions};
     use crate::test_utils::setup_simple_graph;
 

--- a/xlsynth-g8r/src/transforms/redundant_and.rs
+++ b/xlsynth-g8r/src/transforms/redundant_and.rs
@@ -197,6 +197,10 @@ impl Transform for InsertRedundantAndTransform {
             )),
         }
     }
+
+    fn always_equivalent(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug)]
@@ -255,6 +259,10 @@ impl Transform for RemoveRedundantAndTransform {
                 candidate_location
             )),
         }
+    }
+
+    fn always_equivalent(&self) -> bool {
+        true
     }
 }
 

--- a/xlsynth-g8r/src/transforms/rotate_and.rs
+++ b/xlsynth-g8r/src/transforms/rotate_and.rs
@@ -175,6 +175,10 @@ impl Transform for RotateAndRightTransform {
             )),
         }
     }
+
+    fn always_equivalent(&self) -> bool {
+        true
+    }
 }
 
 // --- RotateAndLeftTransform ---
@@ -241,6 +245,10 @@ impl Transform for RotateAndLeftTransform {
                 candidate_location
             )),
         }
+    }
+
+    fn always_equivalent(&self) -> bool {
+        true
     }
 }
 

--- a/xlsynth-g8r/src/transforms/swap_operands.rs
+++ b/xlsynth-g8r/src/transforms/swap_operands.rs
@@ -73,6 +73,10 @@ impl Transform for SwapOperandsTransform {
             )),
         }
     }
+
+    fn always_equivalent(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/xlsynth-g8r/src/transforms/toggle_output.rs
+++ b/xlsynth-g8r/src/transforms/toggle_output.rs
@@ -90,6 +90,10 @@ impl Transform for ToggleOutputBitTransform {
             )),
         }
     }
+
+    fn always_equivalent(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/xlsynth-g8r/src/transforms/transform_trait.rs
+++ b/xlsynth-g8r/src/transforms/transform_trait.rs
@@ -90,4 +90,9 @@ pub trait Transform: Debug + Send + Sync {
         candidate_location: &TransformLocation,
         direction: TransformDirection,
     ) -> Result<()>;
+
+    /// Indicates whether this transform is always semantics preserving.
+    /// When `true`, applying the transform cannot change the functional
+    /// behaviour of the circuit, so equivalence checks can be skipped.
+    fn always_equivalent(&self) -> bool;
 }

--- a/xlsynth-g8r/src/transforms/true_and.rs
+++ b/xlsynth-g8r/src/transforms/true_and.rs
@@ -445,7 +445,7 @@ mod tests {
         gb.add_output("o".to_string(), and_gate_op.into());
         let mut g = gb.build();
 
-        let mut transform = InsertTrueAndTransform::new();
+        let transform = InsertTrueAndTransform::new();
         // Candidate should be Operand(and_gate_ref, is_rhs=true) which refers to
         // const_false_ref
         let candidate_loc = TransformLocation::Operand(and_gate_op.node, true);

--- a/xlsynth-g8r/src/transforms/true_and.rs
+++ b/xlsynth-g8r/src/transforms/true_and.rs
@@ -227,6 +227,10 @@ impl Transform for InsertTrueAndTransform {
             )),
         }
     }
+
+    fn always_equivalent(&self) -> bool {
+        true
+    }
 }
 
 // --- RemoveTrueAnd Transform ---
@@ -290,6 +294,10 @@ impl Transform for RemoveTrueAndTransform {
                 candidate_location
             )),
         }
+    }
+
+    fn always_equivalent(&self) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
## Summary
- require `always_equivalent` to be implemented by each transform
- mark all transforms accordingly with `ToggleOutputBitTransform` returning `false`
- skip equivalence checks in MCMC when transforms are always equivalent

## Testing
- `pre-commit run --all-files`