### PR TITLE
[g8r:mcmc] Add parallel multi-threaded MCMC driver

### DIFF
--- a/xlsynth-g8r/Cargo.toml
+++ b/xlsynth-g8r/Cargo.toml
@@ -14,6 +14,7 @@ xlsynth = { path = "../xlsynth", version = "0.0.147" }
 env_logger = "0.11"
 log = "0.4"
 clap = { version = "4.5.21", features = ["derive"] }
+num_cpus = "1.16"
 tempfile = "3.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary
- run multiple MCMC chains in parallel using all CPUs
- share best result across threads via new `Best` struct
- expose `Best` and hook into `mcmc` to update global best
- add `--threads` CLI flag to `mcmc-driver`
- add `num_cpus` crate for CPU count

## Testing
- `pre-commit run --all-files`