### PR TITLE
[g8r] Implement SAT-based GateFn equivalence

### DIFF
--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
@@ -3,7 +3,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use xlsynth_g8r::check_equivalence;
+use xlsynth_g8r::validate_equiv::{check_equiv as check_gate_equiv, Ctx, EquivResult as GateEquivResult};
 use xlsynth_g8r::ir_equiv_boolector;
+use xlsynth_g8r::ir2gate::{gatify, GatifyOptions};
 use xlsynth_g8r::xls_ir::ir_parser;
 use xlsynth_test_helpers::ir_fuzz::{generate_ir_fn, FuzzSample};
 
@@ -48,6 +50,28 @@ fuzz_target!(|sample: FuzzSample| {
     let orig_fn = orig_pkg.get_top().unwrap();
     let opt_fn = opt_pkg.get_top().unwrap();
 
+    let orig_gate = gatify(
+        &orig_fn,
+        GatifyOptions {
+            fold: true,
+            check_equivalence: false,
+            hash: true,
+        },
+    )
+    .unwrap()
+    .gate_fn;
+    let opt_gate = gatify(
+        &opt_fn,
+        GatifyOptions {
+            fold: true,
+            check_equivalence: false,
+            hash: true,
+        },
+    )
+    .unwrap()
+    .gate_fn;
+    let mut gate_ctx = Ctx::new();
+
     // Check equivalence using the external tool first, specifying the top function
     let orig_ir = pkg.to_string();
     let opt_ir = optimized_pkg.to_string();
@@ -56,7 +80,7 @@ fuzz_target!(|sample: FuzzSample| {
         check_equivalence::check_equivalence_with_top(&orig_ir, &opt_ir, Some(top_fn_name));
     match ext_equiv {
         Ok(()) => {
-            // External tool says equivalent, Boolector should agree
+            // External tool says equivalent, Boolector and gate-level checks should agree
             match ir_equiv_boolector::check_equiv(orig_fn, opt_fn) {
                 ir_equiv_boolector::EquivResult::Proved => (),
                 ir_equiv_boolector::EquivResult::Disproved(cex) => {
@@ -65,6 +89,18 @@ fuzz_target!(|sample: FuzzSample| {
                     log::info!("Optimized IR:\n{}", opt_ir);
                     panic!(
                         "Disagreement: external tool says equivalent, Boolector disproves: {:?}",
+                        cex
+                    );
+                }
+            }
+            match check_gate_equiv(&orig_gate, &opt_gate, &mut gate_ctx) {
+                GateEquivResult::Proved => (),
+                GateEquivResult::Disproved(cex) => {
+                    log::info!("==== Gate disagreement detected ====");
+                    log::info!("Original IR:\n{}", orig_ir);
+                    log::info!("Optimized IR:\n{}", opt_ir);
+                    panic!(
+                        "Disagreement: external tool says equivalent, gate-level solver disproves: {:?}",
                         cex
                     );
                 }
@@ -83,6 +119,18 @@ fuzz_target!(|sample: FuzzSample| {
                     );
                 }
                 ir_equiv_boolector::EquivResult::Disproved(_cex) => (), // Both agree not equivalent
+            }
+            match check_gate_equiv(&orig_gate, &opt_gate, &mut gate_ctx) {
+                GateEquivResult::Proved => {
+                    log::info!("==== Gate disagreement detected ====");
+                    log::info!("Original IR:\n{}", orig_ir);
+                    log::info!("Optimized IR:\n{}", opt_ir);
+                    panic!(
+                        "Disagreement: external tool says NOT equivalent, gate-level solver proves equivalence. External error: {}",
+                        ext_err
+                    );
+                }
+                GateEquivResult::Disproved(_) => (),
             }
         }
     }

--- a/xlsynth-g8r/tests/test_gate_equiv_varisat.rs
+++ b/xlsynth-g8r/tests/test_gate_equiv_varisat.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
+use xlsynth_g8r::validate_equiv::{check_equiv, Ctx, EquivResult};
+
+#[test]
+fn test_simple_equivalence() {
+    let mut gb = GateBuilder::new("xor".to_string(), GateBuilderOptions::opt());
+    let a = gb.add_input("a".to_string(), 1).get_lsb(0).clone();
+    let b = gb.add_input("b".to_string(), 1).get_lsb(0).clone();
+    let x = gb.add_xor_binary(a, b);
+    gb.add_output("out".to_string(), x.into());
+    let g1 = gb.build();
+
+    let mut ctx = Ctx::new();
+    assert_eq!(check_equiv(&g1, &g1, &mut ctx), EquivResult::Proved);
+}
+
+#[test]
+fn test_simple_inequivalence() {
+    let mut gb1 = GateBuilder::new("xor".to_string(), GateBuilderOptions::opt());
+    let a1 = gb1.add_input("a".to_string(), 1).get_lsb(0).clone();
+    let b1 = gb1.add_input("b".to_string(), 1).get_lsb(0).clone();
+    let x1 = gb1.add_xor_binary(a1, b1);
+    gb1.add_output("out".to_string(), x1.into());
+    let g1 = gb1.build();
+
+    let mut gb2 = GateBuilder::new("and".to_string(), GateBuilderOptions::opt());
+    let a2 = gb2.add_input("a".to_string(), 1).get_lsb(0).clone();
+    let b2 = gb2.add_input("b".to_string(), 1).get_lsb(0).clone();
+    let y = gb2.add_and_binary(a2, b2);
+    gb2.add_output("out".to_string(), y.into());
+    let g2 = gb2.build();
+
+    let mut ctx = Ctx::new();
+    match check_equiv(&g1, &g2, &mut ctx) {
+        EquivResult::Proved => panic!("Expected inequivalent"),
+        EquivResult::Disproved(_) => (),
+    }
+}


### PR DESCRIPTION
## Summary
- move SAT-based gate equivalence into existing validate_equiv module
- reuse add_tseitsin* helpers to avoid duplication
- wire new API into fuzzing harness and tests

## Testing
- `pre-commit run --all-files`
- `cargo test --test test_gate_equiv_varisat`