### PR TITLE
Add GateFn parser with round-trip testing

### DIFF
--- a/xlsynth-g8r/fuzz/Cargo.toml
+++ b/xlsynth-g8r/fuzz/Cargo.toml
@@ -38,3 +38,9 @@ name = "fuzz_ir_opt_equiv"
 path = "fuzz_targets/fuzz_ir_opt_equiv.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_gate_fn_roundtrip"
+path = "fuzz_targets/fuzz_gate_fn_roundtrip.rs"
+test = false
+doc = false

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_fn_roundtrip.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_fn_roundtrip.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use xlsynth_g8r::gate::GateFn;
+use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
+use xlsynth_g8r::gate_parser::ParseError;
+use xlsynth_g8r::test_utils::structurally_equivalent;
+use xlsynth_g8r::gate::{AigBitVector};
+
+#[derive(Debug, Clone, Arbitrary)]
+struct FuzzOp {
+    lhs: u16,
+    rhs: u16,
+    lhs_neg: bool,
+    rhs_neg: bool,
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct FuzzGraph {
+    num_inputs: u8,
+    input_width: u8,
+    num_ops: u8,
+    num_outputs: u8,
+    ops: Vec<FuzzOp>,
+    use_opt: bool,
+}
+
+fn build_graph(sample: &FuzzGraph) -> Option<GateFn> {
+    let num_inputs = sample.num_inputs.min(4);
+    let width = sample.input_width.min(4);
+    let num_ops = sample.num_ops.min(32);
+    let opts = if sample.use_opt { GateBuilderOptions::opt() } else { GateBuilderOptions::no_opt() };
+    let mut builder = GateBuilder::new("fuzz_rt".to_string(), opts);
+    let mut nodes = Vec::new();
+    for i in 0..num_inputs {
+        let bv = builder.add_input(format!("in{}", i), width as usize);
+        for j in 0..width {
+            nodes.push(*bv.get_lsb(j as usize));
+        }
+    }
+    if nodes.is_empty() {
+        nodes.push(builder.get_false());
+    }
+    for op in sample.ops.iter().take(num_ops as usize) {
+        let a = nodes[(op.lhs as usize) % nodes.len()];
+        let b = nodes[(op.rhs as usize) % nodes.len()];
+        let a = if op.lhs_neg { builder.add_not(a) } else { a };
+        let b = if op.rhs_neg { builder.add_not(b) } else { b };
+        let new_node = builder.add_and_binary(a, b);
+        nodes.push(new_node);
+        if nodes.len() > 256 { break; }
+    }
+    let outputs = nodes.len().min(sample.num_outputs as usize).max(1);
+    for i in 0..outputs {
+        builder.add_output(format!("out{}", i), AigBitVector::from_bit(nodes[i]));
+    }
+    Some(builder.build())
+}
+
+fuzz_target!(|graph: FuzzGraph| {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let Some(g) = build_graph(&graph) else { return; };
+    let text = g.to_string();
+    let parsed = match GateFn::from_str(&text) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    assert!(structurally_equivalent(&g, &parsed));
+});

--- a/xlsynth-g8r/src/gate_parser.rs
+++ b/xlsynth-g8r/src/gate_parser.rs
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::gate::{AigBitVector, AigNode, AigOperand, AigRef, GateFn, Input, Output};
+
+#[derive(Debug)]
+pub struct ParseError {
+    msg: String,
+}
+
+impl ParseError {
+    fn new(msg: String) -> Self {
+        Self { msg }
+    }
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ParseError: {}", self.msg)
+    }
+}
+
+use std::collections::HashMap;
+
+struct Parser<'a> {
+    input: &'a str,
+    pos: usize,
+    input_lookup: HashMap<(String, usize), usize>,
+}
+
+impl<'a> Parser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            input,
+            pos: 0,
+            input_lookup: HashMap::new(),
+        }
+    }
+
+    fn rest(&self) -> &'a str {
+        &self.input[self.pos..]
+    }
+
+    fn drop_ws(&mut self) {
+        while let Some(c) = self.rest().chars().next() {
+            if c.is_whitespace() {
+                self.pos += c.len_utf8();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn try_drop(&mut self, tok: &str) -> bool {
+        self.drop_ws();
+        if self.rest().starts_with(tok) {
+            self.pos += tok.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn drop_or_error(&mut self, tok: &str) -> Result<(), ParseError> {
+        if self.try_drop(tok) {
+            Ok(())
+        } else {
+            Err(ParseError::new(format!(
+                "expected '{}' got '{}...'",
+                tok,
+                &self.rest()[..self.rest().len().min(tok.len())]
+            )))
+        }
+    }
+
+    fn parse_identifier(&mut self) -> Result<String, ParseError> {
+        self.drop_ws();
+        let rest = self.rest();
+        let mut chars = rest.chars();
+        let mut result = String::new();
+        if let Some(c) = chars.next() {
+            if c.is_alphabetic() || c == '_' {
+                result.push(c);
+                self.pos += c.len_utf8();
+            } else {
+                return Err(ParseError::new(format!(
+                    "expected identifier start, got '{}'",
+                    c
+                )));
+            }
+        } else {
+            return Err(ParseError::new("unexpected eof".to_string()));
+        }
+        while let Some(c) = self.rest().chars().next() {
+            if c.is_alphanumeric() || c == '_' {
+                result.push(c);
+                self.pos += c.len_utf8();
+            } else {
+                break;
+            }
+        }
+        Ok(result)
+    }
+
+    fn parse_usize(&mut self) -> Result<usize, ParseError> {
+        self.drop_ws();
+        let rest = self.rest();
+        let mut len = 0;
+        for c in rest.chars() {
+            if c.is_ascii_digit() {
+                len += c.len_utf8();
+            } else {
+                break;
+            }
+        }
+        if len == 0 {
+            return Err(ParseError::new("expected number".to_string()));
+        }
+        let num: usize = rest[..len].parse().unwrap();
+        self.pos += len;
+        Ok(num)
+    }
+
+    fn parse_operand(&mut self) -> Result<AigOperand, ParseError> {
+        self.drop_ws();
+        let neg = if self.try_drop("not(") { true } else { false };
+        self.drop_ws();
+        let id = if self.try_drop("%") {
+            self.parse_usize()?
+        } else {
+            let name = self.parse_identifier()?;
+            self.drop_or_error("[")?;
+            let idx = self.parse_usize()?;
+            self.drop_or_error("]")?;
+            *self
+                .input_lookup
+                .get(&(name, idx))
+                .ok_or_else(|| ParseError::new("unknown input reference".into()))?
+        };
+        if neg {
+            self.drop_or_error(")")?;
+        }
+        Ok(AigOperand {
+            node: AigRef { id },
+            negated: neg,
+        })
+    }
+
+    fn parse_bit_vector(&mut self) -> Result<AigBitVector, ParseError> {
+        self.drop_ws();
+        self.drop_or_error("[")?;
+        let mut ops = Vec::new();
+        if self.try_drop("]") {
+            return Ok(AigBitVector::from_lsb_is_index_0(&ops));
+        }
+        loop {
+            let op = self.parse_operand()?;
+            ops.push(op);
+            if self.try_drop("]") {
+                break;
+            }
+            self.drop_or_error(",")?;
+        }
+        Ok(AigBitVector::from_lsb_is_index_0(&ops))
+    }
+
+    fn parse_io_list(&mut self) -> Result<Vec<(String, AigBitVector)>, ParseError> {
+        self.drop_ws();
+        self.drop_or_error("(")?;
+        if self.try_drop(")") {
+            return Ok(Vec::new());
+        }
+        let mut entries = Vec::new();
+        loop {
+            let name = self.parse_identifier()?;
+            self.drop_or_error(":")?;
+            self.drop_or_error("bits[")?;
+            let width = self.parse_usize()?;
+            self.drop_or_error("]")?;
+            self.drop_or_error("=")?;
+            let bv = self.parse_bit_vector()?;
+            if bv.get_bit_count() != width {
+                return Err(ParseError::new("bit count mismatch".to_string()));
+            }
+            entries.push((name, bv));
+            if self.try_drop(")") {
+                break;
+            }
+            self.drop_or_error(",")?;
+        }
+        Ok(entries)
+    }
+
+    fn at_eof(&mut self) -> bool {
+        self.drop_ws();
+        self.pos >= self.input.len()
+    }
+}
+
+pub fn parse_gate_fn(text: &str) -> Result<GateFn, ParseError> {
+    let mut p = Parser::new(text);
+    p.drop_or_error("fn")?;
+    let name = p.parse_identifier()?;
+    let inputs_pairs = p.parse_io_list()?;
+    p.drop_or_error("->")?;
+    let outputs_pairs = p.parse_io_list()?;
+    p.drop_or_error("{")?;
+
+    use std::collections::HashMap;
+    let mut nodes: HashMap<usize, AigNode> = HashMap::new();
+    nodes.insert(0, AigNode::Literal(false));
+
+    let mut inputs = Vec::new();
+    for (inp_name, bv) in inputs_pairs {
+        for (i, op) in bv.iter_lsb_to_msb().enumerate() {
+            nodes.insert(
+                op.node.id,
+                AigNode::Input {
+                    name: inp_name.clone(),
+                    lsb_index: i,
+                },
+            );
+            p.input_lookup.insert((inp_name.clone(), i), op.node.id);
+        }
+        inputs.push(Input {
+            name: inp_name,
+            bit_vector: bv,
+        });
+    }
+
+    while !p.at_eof() {
+        if p.try_drop("}") {
+            break;
+        }
+        p.drop_ws();
+        if p.rest().starts_with('%') {
+            p.drop_or_error("%")?;
+            let id = p.parse_usize()?;
+            p.drop_or_error("=")?;
+            if p.try_drop("and(") {
+                let a = p.parse_operand()?;
+                p.drop_or_error(",")?;
+                let b = p.parse_operand()?;
+                let tags = if p.try_drop(",") {
+                    p.drop_or_error("tags=[")?;
+                    let mut tag_vec = Vec::new();
+                    if !p.try_drop("]") {
+                        loop {
+                            let tag = p.parse_identifier()?;
+                            tag_vec.push(tag);
+                            if p.try_drop("]") {
+                                break;
+                            }
+                            p.drop_or_error(",")?;
+                        }
+                    }
+                    p.drop_or_error(")")?;
+                    Some(tag_vec)
+                } else {
+                    p.drop_or_error(")")?;
+                    None
+                };
+                nodes.insert(id, AigNode::And2 { a, b, tags });
+                continue;
+            } else if p.try_drop("literal(") {
+                let value = p.parse_usize()?;
+                p.drop_or_error(")")?;
+                nodes.insert(id, AigNode::Literal(value != 0));
+                continue;
+            } else {
+                return Err(ParseError::new("unknown node kind".to_string()));
+            }
+        } else {
+            let _name = p.parse_identifier()?;
+            p.drop_or_error("[")?;
+            p.parse_usize()?;
+            p.drop_or_error("]")?;
+            p.drop_or_error("=")?;
+            let _ = p.parse_operand()?;
+            continue;
+        }
+    }
+
+    let mut outputs = Vec::new();
+    for (name, bv) in outputs_pairs {
+        outputs.push(Output {
+            name,
+            bit_vector: bv,
+        });
+    }
+
+    let max_id = nodes.keys().copied().max().unwrap_or(0);
+    let mut gates = Vec::new();
+    for id in 0..=max_id {
+        if let Some(node) = nodes.remove(&id) {
+            gates.push(node);
+        } else {
+            return Err(ParseError::new(format!("missing node id {}", id)));
+        }
+    }
+
+    Ok(GateFn {
+        name,
+        inputs,
+        outputs,
+        gates,
+    })
+}
+
+impl GateFn {
+    pub fn from_str(text: &str) -> Result<Self, ParseError> {
+        parse_gate_fn(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{setup_simple_graph, structurally_equivalent};
+
+    #[test]
+    fn test_round_trip_simple() {
+        let g = setup_simple_graph().g;
+        let text = g.to_string();
+        let parsed = GateFn::from_str(&text).unwrap();
+        assert!(structurally_equivalent(&g, &parsed));
+    }
+}

--- a/xlsynth-g8r/src/lib.rs
+++ b/xlsynth-g8r/src/lib.rs
@@ -19,6 +19,7 @@ pub mod fuzz_utils;
 pub mod gate;
 pub mod gate2ir;
 pub mod gate_builder;
+pub mod gate_parser;
 pub mod gate_sim;
 pub mod gate_simd;
 pub mod get_summary_stats;

--- a/xlsynth-g8r/tests/test_gate_from_str.rs
+++ b/xlsynth-g8r/tests/test_gate_from_str.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use xlsynth_g8r::gate::GateFn;
+use xlsynth_g8r::gate_parser::ParseError;
+use xlsynth_g8r::test_utils::{
+    setup_graph_with_redundancies, setup_simple_graph, structurally_equivalent,
+};
+
+#[test]
+fn test_round_trip_simple() -> Result<(), ParseError> {
+    let g = setup_simple_graph().g;
+    let text = g.to_string();
+    let parsed = GateFn::from_str(&text)?;
+    assert!(structurally_equivalent(&g, &parsed));
+    Ok(())
+}
+
+#[test]
+fn test_round_trip_redundant() -> Result<(), ParseError> {
+    let g = setup_graph_with_redundancies().g;
+    let text = g.to_string();
+    let parsed = GateFn::from_str(&text)?;
+    assert!(structurally_equivalent(&g, &parsed));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement `GateFn::from_str` in new `gate_parser` module
- expose new module in library
- add integration tests for round-tripping sample graphs
- add fuzz target to stress `GateFn` parsing

## Testing
- `pre-commit run --all-files`
- `cargo test --quiet`
- `cargo fuzz run fuzz_gate_fn_roundtrip -- -max_total_time=10`