### PR TITLE
Add fuzz transform equivalence test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,3 +551,23 @@ jobs:
           cargo install cargo-fuzz
           cd xlsynth-g8r/fuzz
           cargo fuzz run fuzz_gatify -- -max_total_time=10
+
+      - name: Build and run fuzz_gate_fn_roundtrip for 10 seconds
+        env:
+          XLSYNTH_TOOLS: /tmp/xlsynth_tools_smoke
+          XLS_DSO_PATH: /usr/lib/libxls-rocky8.so
+          DSLX_STDLIB_PATH: /tmp/xlsynth_tools_smoke/xls/dslx/stdlib
+        run: |
+          cargo install cargo-fuzz
+          cd xlsynth-g8r/fuzz
+          cargo fuzz run fuzz_gate_fn_roundtrip -- -max_total_time=10
+
+      - name: Build and run fuzz_gate_transform_equiv for 10 seconds
+        env:
+          XLSYNTH_TOOLS: /tmp/xlsynth_tools_smoke
+          XLS_DSO_PATH: /usr/lib/libxls-rocky8.so
+          DSLX_STDLIB_PATH: /tmp/xlsynth_tools_smoke/xls/dslx/stdlib
+        run: |
+          cargo install cargo-fuzz
+          cd xlsynth-g8r/fuzz
+          cargo fuzz run fuzz_gate_transform_equiv -- -max_total_time=10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,7 @@ pre-commit run --all-files
 ```
 
 PRs that fail this check will not be accepted.
+
+## Agent Guidance: xlsynth-g8r and Fuzz Targets
+
+If you are modifying code in the `xlsynth-g8r` crate, you **must** ensure that all related fuzz targets (such as those in `xlsynth-g8r/fuzz/fuzz_targets`) still build. CI will fail if any fuzz target does not build. Always check the build status of these fuzz targets after making changes to `xlsynth-g8r`.

--- a/xlsynth-g8r/fuzz/Cargo.toml
+++ b/xlsynth-g8r/fuzz/Cargo.toml
@@ -17,6 +17,10 @@ rand = "0.8"
 xlsynth-test-helpers = { path = "../../xlsynth-test-helpers" }
 xlsynth-g8r = { path = "../../xlsynth-g8r", features = ["with-boolector-system"] }
 
+[lib]
+name = "xlsynth_g8r_fuzz"
+path = "src/lib.rs"
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
@@ -42,5 +46,11 @@ doc = false
 [[bin]]
 name = "fuzz_gate_fn_roundtrip"
 path = "fuzz_targets/fuzz_gate_fn_roundtrip.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_gate_transform_equiv"
+path = "fuzz_targets/fuzz_gate_transform_equiv.rs"
 test = false
 doc = false

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_fn_roundtrip.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_fn_roundtrip.rs
@@ -1,62 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #![no_main]
-use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 use xlsynth_g8r::gate::GateFn;
-use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
-use xlsynth_g8r::gate_parser::ParseError;
 use xlsynth_g8r::test_utils::structurally_equivalent;
-use xlsynth_g8r::gate::{AigBitVector};
-
-#[derive(Debug, Clone, Arbitrary)]
-struct FuzzOp {
-    lhs: u16,
-    rhs: u16,
-    lhs_neg: bool,
-    rhs_neg: bool,
-}
-
-#[derive(Debug, Clone, Arbitrary)]
-struct FuzzGraph {
-    num_inputs: u8,
-    input_width: u8,
-    num_ops: u8,
-    num_outputs: u8,
-    ops: Vec<FuzzOp>,
-    use_opt: bool,
-}
-
-fn build_graph(sample: &FuzzGraph) -> Option<GateFn> {
-    let num_inputs = sample.num_inputs.min(4);
-    let width = sample.input_width.min(4);
-    let num_ops = sample.num_ops.min(32);
-    let opts = if sample.use_opt { GateBuilderOptions::opt() } else { GateBuilderOptions::no_opt() };
-    let mut builder = GateBuilder::new("fuzz_rt".to_string(), opts);
-    let mut nodes = Vec::new();
-    for i in 0..num_inputs {
-        let bv = builder.add_input(format!("in{}", i), width as usize);
-        for j in 0..width {
-            nodes.push(*bv.get_lsb(j as usize));
-        }
-    }
-    if nodes.is_empty() {
-        nodes.push(builder.get_false());
-    }
-    for op in sample.ops.iter().take(num_ops as usize) {
-        let a = nodes[(op.lhs as usize) % nodes.len()];
-        let b = nodes[(op.rhs as usize) % nodes.len()];
-        let a = if op.lhs_neg { builder.add_not(a) } else { a };
-        let b = if op.rhs_neg { builder.add_not(b) } else { b };
-        let new_node = builder.add_and_binary(a, b);
-        nodes.push(new_node);
-        if nodes.len() > 256 { break; }
-    }
-    let outputs = nodes.len().min(sample.num_outputs as usize).max(1);
-    for i in 0..outputs {
-        builder.add_output(format!("out{}", i), AigBitVector::from_bit(nodes[i]));
-    }
-    Some(builder.build())
-}
+use xlsynth_g8r_fuzz::{build_graph, FuzzGraph};
 
 fuzz_target!(|graph: FuzzGraph| {
     let _ = env_logger::builder().is_test(true).try_init();

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_equiv.rs
@@ -11,20 +11,24 @@ fuzz_target!(|graph: FuzzGraph| {
         return;
     }
     let _ = env_logger::builder().is_test(true).try_init();
-    let Some(mut g) = build_graph(&graph) else { return; };
+    let Some(mut g) = build_graph(&graph) else {
+        return;
+    };
     let mut transforms = transforms::get_equiv_transforms();
     if transforms.is_empty() {
         return;
     }
     let mut rng = rand::thread_rng();
-    let t = transforms.iter().choose(&mut rng).unwrap();
+    let t = transforms.iter_mut().choose(&mut rng).unwrap();
     let candidates = t.find_candidates(&g, TransformDirection::Forward);
     if candidates.is_empty() {
         return;
     }
     let cand = candidates.iter().choose(&mut rng).unwrap();
     let mut new_g = g.clone();
-    if t.apply(&mut new_g, cand, TransformDirection::Forward).is_err() {
+    if t.apply(&mut new_g, cand, TransformDirection::Forward)
+        .is_err()
+    {
         return;
     }
     if let Err(e) = check_equivalence::validate_same_gate_fn(&g, &new_g) {

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_equiv.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use rand::seq::IteratorRandom;
+use xlsynth_g8r::check_equivalence;
+use xlsynth_g8r::transforms::{self, transform_trait::TransformDirection};
+use xlsynth_g8r_fuzz::{build_graph, FuzzGraph};
+
+fuzz_target!(|graph: FuzzGraph| {
+    if std::env::var("XLSYNTH_TOOLS").is_err() {
+        return;
+    }
+    let _ = env_logger::builder().is_test(true).try_init();
+    let Some(mut g) = build_graph(&graph) else { return; };
+    let mut transforms = transforms::get_equiv_transforms();
+    if transforms.is_empty() {
+        return;
+    }
+    let mut rng = rand::thread_rng();
+    let t = transforms.iter().choose(&mut rng).unwrap();
+    let candidates = t.find_candidates(&g, TransformDirection::Forward);
+    if candidates.is_empty() {
+        return;
+    }
+    let cand = candidates.iter().choose(&mut rng).unwrap();
+    let mut new_g = g.clone();
+    if t.apply(&mut new_g, cand, TransformDirection::Forward).is_err() {
+        return;
+    }
+    if let Err(e) = check_equivalence::validate_same_gate_fn(&g, &new_g) {
+        panic!("Transform {} broke equivalence: {}", t.display_name(), e);
+    }
+});

--- a/xlsynth-g8r/fuzz/src/lib.rs
+++ b/xlsynth-g8r/fuzz/src/lib.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+use arbitrary::Arbitrary;
+use xlsynth_g8r::gate::{AigBitVector, GateFn};
+use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
+
+#[derive(Debug, Clone, Arbitrary)]
+pub struct FuzzOp {
+    pub lhs: u16,
+    pub rhs: u16,
+    pub lhs_neg: bool,
+    pub rhs_neg: bool,
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+pub struct FuzzGraph {
+    pub num_inputs: u8,
+    pub input_width: u8,
+    pub num_ops: u8,
+    pub num_outputs: u8,
+    pub ops: Vec<FuzzOp>,
+    pub use_opt: bool,
+}
+
+pub fn build_graph(sample: &FuzzGraph) -> Option<GateFn> {
+    let num_inputs = sample.num_inputs.min(4);
+    let width = sample.input_width.min(4);
+    let num_ops = sample.num_ops.min(32);
+    let opts = if sample.use_opt {
+        GateBuilderOptions::opt()
+    } else {
+        GateBuilderOptions::no_opt()
+    };
+    let mut builder = GateBuilder::new("fuzz_rt".to_string(), opts);
+    let mut nodes = Vec::new();
+    for i in 0..num_inputs {
+        let bv = builder.add_input(format!("in{}", i), width as usize);
+        for j in 0..width {
+            nodes.push(*bv.get_lsb(j as usize));
+        }
+    }
+    if nodes.is_empty() {
+        nodes.push(builder.get_false());
+    }
+    for op in sample.ops.iter().take(num_ops as usize) {
+        let a = nodes[(op.lhs as usize) % nodes.len()];
+        let b = nodes[(op.rhs as usize) % nodes.len()];
+        let a = if op.lhs_neg { builder.add_not(a) } else { a };
+        let b = if op.rhs_neg { builder.add_not(b) } else { b };
+        let new_node = builder.add_and_binary(a, b);
+        nodes.push(new_node);
+        if nodes.len() > 256 {
+            break;
+        }
+    }
+    let outputs = nodes.len().min(sample.num_outputs as usize).max(1);
+    for i in 0..outputs {
+        builder.add_output(format!("out{}", i), AigBitVector::from_bit(nodes[i]));
+    }
+    Some(builder.build())
+}

--- a/xlsynth-g8r/src/transforms/mod.rs
+++ b/xlsynth-g8r/src/transforms/mod.rs
@@ -69,3 +69,11 @@ pub fn get_all_transforms() -> Vec<Box<dyn Transform>> {
         Box::new(UnfactorSharedAndTransform::new()),
     ]
 }
+
+/// Returns all transforms that are always semantics preserving.
+pub fn get_equiv_transforms() -> Vec<Box<dyn Transform>> {
+    get_all_transforms()
+        .into_iter()
+        .filter(|t| t.always_equivalent())
+        .collect()
+}


### PR DESCRIPTION
## Summary
- refactor GateFn fuzz graph generation into a small library crate
- expose `get_equiv_transforms` for transforms that are always equivalent
- add a new fuzz target `fuzz_gate_transform_equiv`
- use the library in `fuzz_gate_fn_roundtrip`
- run the new fuzzer and `fuzz_gate_fn_roundtrip` in CI

## Testing
- `pre-commit run --all-files`