### PR TITLE
Add ripple carry adder sample and mcmc driver test

### DIFF
--- a/xlsynth-g8r/src/mcmc_logic.rs
+++ b/xlsynth-g8r/src/mcmc_logic.rs
@@ -20,7 +20,8 @@ use crate::gate_simd::{self, Vec256};
 use crate::get_summary_stats;
 use crate::ir2gate::{self, GatifyOptions};
 use crate::test_utils::{
-    load_bf16_add_sample, load_bf16_mul_sample, LoadedSample, Opt as SampleOpt,
+    load_bf16_add_sample, load_bf16_mul_sample, load_ripple_carry_adder_8b_sample, LoadedSample,
+    Opt as SampleOpt,
 };
 use crate::transforms::get_all_transforms;
 use crate::transforms::transform_trait::{TransformDirection, TransformKind};
@@ -679,18 +680,36 @@ pub fn load_start<P: AsRef<Path>>(p_generic: P) -> Result<GateFn> {
 
     if p_str.starts_with("sample://") {
         let sample_name = p_str.trim_start_matches("sample://");
-        let loaded_sample_res: Result<LoadedSample, anyhow::Error> = match sample_name {
-            "bf16_add" => Ok(load_bf16_add_sample(SampleOpt::Yes)),
-            "bf16_mul" => Ok(load_bf16_mul_sample(SampleOpt::Yes)),
+        match sample_name {
+            "bf16_add" => {
+                let loaded_sample = load_bf16_add_sample(SampleOpt::Yes);
+                let sample_cost = cost(&loaded_sample.gate_fn);
+                println!(
+                    "Sample '{}' loaded. Initial stats: nodes={}, depth={}",
+                    sample_name, sample_cost.nodes, sample_cost.depth
+                );
+                Ok(loaded_sample.gate_fn)
+            }
+            "bf16_mul" => {
+                let loaded_sample = load_bf16_mul_sample(SampleOpt::Yes);
+                let sample_cost = cost(&loaded_sample.gate_fn);
+                println!(
+                    "Sample '{}' loaded. Initial stats: nodes={}, depth={}",
+                    sample_name, sample_cost.nodes, sample_cost.depth
+                );
+                Ok(loaded_sample.gate_fn)
+            }
+            "ripple_carry_adder_8b" => {
+                let gfn = load_ripple_carry_adder_8b_sample();
+                let sample_cost = cost(&gfn);
+                println!(
+                    "Sample '{}' loaded. Initial stats: nodes={}, depth={}",
+                    sample_name, sample_cost.nodes, sample_cost.depth
+                );
+                Ok(gfn)
+            }
             _ => Err(anyhow::anyhow!("Unknown sample name: {}", sample_name)),
-        };
-        let loaded_sample = loaded_sample_res?;
-        let sample_cost = cost(&loaded_sample.gate_fn);
-        println!(
-            "Sample '{}' loaded. Initial stats: nodes={}, depth={}",
-            sample_name, sample_cost.nodes, sample_cost.depth
-        );
-        Ok(loaded_sample.gate_fn)
+        }
     } else {
         println!("Loading IR from path: {}", p_str);
         let package = ir_parser::parse_path_to_package(p_generic.as_ref())

--- a/xlsynth-g8r/tests/invoke_mcmc_driver_test.rs
+++ b/xlsynth-g8r/tests/invoke_mcmc_driver_test.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+#[test]
+fn test_invoke_mcmc_driver_with_sample() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let exe = env!("CARGO_BIN_EXE_mcmc-driver");
+    let mut cmd = Command::new(exe);
+    cmd.arg("sample://ripple_carry_adder_8b")
+        .arg("-n")
+        .arg("10")
+        .arg("--paranoid")
+        .arg("--output")
+        .arg(temp_dir.path());
+    if let Ok(rust_log) = std::env::var("RUST_LOG") {
+        cmd.env("RUST_LOG", rust_log);
+    }
+    let output = cmd.output().expect("mcmc-driver should run");
+    println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+    println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+    assert!(temp_dir.path().join("best.g8r").exists());
+}


### PR DESCRIPTION
## Summary
- add helper in test_utils to build an 8-bit ripple-carry adder
- recognize `samples://ripple_carry_adder_8b` in the MCMC driver
- test invoking mcmc-driver with the new sample

## Testing
- `pre-commit run --all-files`
- `cargo test --test invoke_mcmc_driver_test -- --nocapture`
- `cargo test --quiet`