### PR TITLE
[g8r] Rename proof routines for clarity.

### DIFF
--- a/xlsynth-driver/src/ir_equiv.rs
+++ b/xlsynth-driver/src/ir_equiv.rs
@@ -121,9 +121,9 @@ fn run_boolector_equiv_check(
         .expect("Dropped parameter is used in the function body!");
     // Run Boolector equivalence check
     let result = if flatten_aggregates {
-        xlsynth_g8r::ir_equiv_boolector::check_equiv_flattened(&lhs_fn, &rhs_fn)
+        xlsynth_g8r::ir_equiv_boolector::prove_ir_equiv_flattened(&lhs_fn, &rhs_fn)
     } else {
-        xlsynth_g8r::ir_equiv_boolector::check_equiv(&lhs_fn, &rhs_fn)
+        xlsynth_g8r::ir_equiv_boolector::prove_ir_fn_equiv(&lhs_fn, &rhs_fn)
     };
     match result {
         ir_equiv_boolector::EquivResult::Proved => {
@@ -137,6 +137,7 @@ fn run_boolector_equiv_check(
     }
 }
 
+/// Implements the "ir-equiv" subcommand.
 pub fn handle_ir_equiv(matches: &clap::ArgMatches, config: &Option<ToolchainConfig>) {
     log::info!("handle_ir_equiv");
     let lhs = matches.get_one::<String>("lhs_ir_file").unwrap();

--- a/xlsynth-g8r/benches/mcmc_benchmark.rs
+++ b/xlsynth-g8r/benches/mcmc_benchmark.rs
@@ -87,7 +87,7 @@ fn benchmark_mcmc_iteration(c: &mut Criterion) {
                 current_cost,
                 mut best_gfn,
                 mut best_cost,
-                mut all_transforms,
+                all_transforms,
                 mut rng,
                 simd_inputs,
                 baseline_outputs,

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_equiv.rs
@@ -11,7 +11,7 @@ fuzz_target!(|graph: FuzzGraph| {
         return;
     }
     let _ = env_logger::builder().is_test(true).try_init();
-    let Some(mut g) = build_graph(&graph) else {
+    let Some(g) = build_graph(&graph) else {
         return;
     };
     let mut transforms = transforms::get_equiv_transforms();

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
@@ -3,9 +3,8 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use xlsynth_g8r::check_equivalence;
-use xlsynth_g8r::validate_equiv::{check_equiv as check_gate_equiv, Ctx, EquivResult as GateEquivResult};
-use xlsynth_g8r::ir_equiv_boolector;
 use xlsynth_g8r::ir2gate::{gatify, GatifyOptions};
+use xlsynth_g8r::ir_equiv_boolector;
 use xlsynth_g8r::xls_ir::ir_parser;
 use xlsynth_test_helpers::ir_fuzz::{generate_ir_fn, FuzzSample};
 
@@ -50,38 +49,17 @@ fuzz_target!(|sample: FuzzSample| {
     let orig_fn = orig_pkg.get_top().unwrap();
     let opt_fn = opt_pkg.get_top().unwrap();
 
-    let orig_gate = gatify(
-        &orig_fn,
-        GatifyOptions {
-            fold: true,
-            check_equivalence: false,
-            hash: true,
-        },
-    )
-    .unwrap()
-    .gate_fn;
-    let opt_gate = gatify(
-        &opt_fn,
-        GatifyOptions {
-            fold: true,
-            check_equivalence: false,
-            hash: true,
-        },
-    )
-    .unwrap()
-    .gate_fn;
-    let mut gate_ctx = Ctx::new();
-
     // Check equivalence using the external tool first, specifying the top function
     let orig_ir = pkg.to_string();
     let opt_ir = optimized_pkg.to_string();
     let top_fn_name = "fuzz_test";
     let ext_equiv =
         check_equivalence::check_equivalence_with_top(&orig_ir, &opt_ir, Some(top_fn_name));
+    let boolector_result = ir_equiv_boolector::prove_ir_fn_equiv(orig_fn, opt_fn);
     match ext_equiv {
         Ok(()) => {
-            // External tool says equivalent, Boolector and gate-level checks should agree
-            match ir_equiv_boolector::check_equiv(orig_fn, opt_fn) {
+            // External tool says equivalent, Boolector should agree
+            match boolector_result {
                 ir_equiv_boolector::EquivResult::Proved => (),
                 ir_equiv_boolector::EquivResult::Disproved(cex) => {
                     log::info!("==== IR disagreement detected ====");
@@ -93,22 +71,10 @@ fuzz_target!(|sample: FuzzSample| {
                     );
                 }
             }
-            match check_gate_equiv(&orig_gate, &opt_gate, &mut gate_ctx) {
-                GateEquivResult::Proved => (),
-                GateEquivResult::Disproved(cex) => {
-                    log::info!("==== Gate disagreement detected ====");
-                    log::info!("Original IR:\n{}", orig_ir);
-                    log::info!("Optimized IR:\n{}", opt_ir);
-                    panic!(
-                        "Disagreement: external tool says equivalent, gate-level solver disproves: {:?}",
-                        cex
-                    );
-                }
-            }
         }
         Err(ext_err) => {
             // External tool says not equivalent, check Boolector
-            match ir_equiv_boolector::check_equiv(orig_fn, opt_fn) {
+            match boolector_result {
                 ir_equiv_boolector::EquivResult::Proved => {
                     log::info!("==== IR disagreement detected ====");
                     log::info!("Original IR:\n{}", orig_ir);
@@ -119,18 +85,6 @@ fuzz_target!(|sample: FuzzSample| {
                     );
                 }
                 ir_equiv_boolector::EquivResult::Disproved(_cex) => (), // Both agree not equivalent
-            }
-            match check_gate_equiv(&orig_gate, &opt_gate, &mut gate_ctx) {
-                GateEquivResult::Proved => {
-                    log::info!("==== Gate disagreement detected ====");
-                    log::info!("Original IR:\n{}", orig_ir);
-                    log::info!("Optimized IR:\n{}", opt_ir);
-                    panic!(
-                        "Disagreement: external tool says NOT equivalent, gate-level solver proves equivalence. External error: {}",
-                        ext_err
-                    );
-                }
-                GateEquivResult::Disproved(_) => (),
             }
         }
     }

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
@@ -3,7 +3,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use xlsynth_g8r::check_equivalence;
-use xlsynth_g8r::ir2gate::{gatify, GatifyOptions};
 use xlsynth_g8r::ir_equiv_boolector;
 use xlsynth_g8r::xls_ir::ir_parser;
 use xlsynth_test_helpers::ir_fuzz::{generate_ir_fn, FuzzSample};

--- a/xlsynth-g8r/src/bin/check-ir-equivalence.rs
+++ b/xlsynth-g8r/src/bin/check-ir-equivalence.rs
@@ -51,7 +51,7 @@ fn main_has_boolector(args: Args) {
         .get_fn(&args.top)
         .unwrap_or_else(|| panic!("function '{}' not found in {}", args.top, args.ir2));
 
-    match ir_equiv_boolector::check_equiv(f1, f2) {
+    match ir_equiv_boolector::prove_ir_fn_equiv(f1, f2) {
         ir_equiv_boolector::EquivResult::Proved => {
             println!("Equivalence result: PROVED");
         }

--- a/xlsynth-g8r/src/fraig.rs
+++ b/xlsynth-g8r/src/fraig.rs
@@ -21,7 +21,8 @@ use xlsynth::IrBits;
 use crate::{
     bulk_replace::bulk_replace, bulk_replace::SubstitutionMap, gate::AigOperand, gate::AigRef,
     gate::GateFn, gate_builder::GateBuilderOptions, get_summary_stats::get_gate_depth,
-    propose_equiv::propose_equiv, propose_equiv::EquivNode, validate_equiv::validate_equiv,
+    propose_equiv::propose_equivalence_classes, propose_equiv::EquivNode,
+    validate_equiv::validate_equivalence_classes,
 };
 
 pub enum IterationBounds {
@@ -72,7 +73,8 @@ pub fn fraig_optimize(
                 // Keep going!
             }
         }
-        let equiv_classes = propose_equiv(&current_fn, input_sample_count, rng, &counterexamples);
+        let equiv_classes =
+            propose_equivalence_classes(&current_fn, input_sample_count, rng, &counterexamples);
 
         log::info!(
             "fraig_optimize: propose_equiv proposed {} classes",
@@ -95,7 +97,7 @@ pub fn fraig_optimize(
             (rep_node.is_inverted(), rep_node.aig_ref().id)
         });
 
-        let validation_result = validate_equiv(&current_fn, &equiv_classes_vec)?;
+        let validation_result = validate_equivalence_classes(&current_fn, &equiv_classes_vec)?;
 
         if validation_result.proven_equiv_sets.is_empty() {
             // Converged -- no proven equivalences found.

--- a/xlsynth-g8r/src/ir_equiv_boolector.rs
+++ b/xlsynth-g8r/src/ir_equiv_boolector.rs
@@ -1034,12 +1034,12 @@ fn check_equiv_internal(lhs: &Fn, rhs: &Fn, flatten_aggregates: bool) -> EquivRe
 }
 
 /// Standard equivalence check (no aggregate flattening)
-pub fn check_equiv(lhs: &Fn, rhs: &Fn) -> EquivResult {
+pub fn prove_ir_fn_equiv(lhs: &Fn, rhs: &Fn) -> EquivResult {
     check_equiv_internal(lhs, rhs, false)
 }
 
 /// Equivalence check with tuple/array flattening
-pub fn check_equiv_flattened(lhs: &Fn, rhs: &Fn) -> EquivResult {
+pub fn prove_ir_equiv_flattened(lhs: &Fn, rhs: &Fn) -> EquivResult {
     check_equiv_internal(lhs, rhs, true)
 }
 
@@ -1157,7 +1157,7 @@ mod tests {
     fn assert_fn_equiv_to_self(ir_text: &str) {
         let mut parser = ir_parser::Parser::new(ir_text);
         let f = parser.parse_fn().expect("Failed to parse IR");
-        let result = check_equiv(&f, &f);
+        let result = prove_ir_fn_equiv(&f, &f);
         assert_eq!(
             result,
             EquivResult::Proved,
@@ -1226,7 +1226,7 @@ mod tests {
 }"#;
         let f = ir_parser::Parser::new(ir_text_f).parse_fn().unwrap();
         let g = ir_parser::Parser::new(ir_text_g).parse_fn().unwrap();
-        let result = check_equiv(&f, &g);
+        let result = prove_ir_fn_equiv(&f, &g);
         match result {
             EquivResult::Disproved(ref cex) => {
                 assert_eq!(cex.len(), 1);
@@ -1362,7 +1362,7 @@ mod tests {
         // Use the existing assert_fn_equiv helper to check equivalence
         let f = ir_parser::Parser::new(ir_identity).parse_fn().unwrap();
         let g = ir_parser::Parser::new(ir_recompose).parse_fn().unwrap();
-        let result = check_equiv(&f, &g);
+        let result = prove_ir_fn_equiv(&f, &g);
         match result {
             EquivResult::Proved => (),
             EquivResult::Disproved(_) => panic!("Expected Proved, got Disproved"),
@@ -1585,7 +1585,7 @@ fn fuzz_test(input: bits[4] id=1) -> bits[1] {
         let mut parser = ir_parser::Parser::new(ir_text);
         let pkg = parser.parse_package().unwrap();
         let f = pkg.get_fn("fuzz_test").unwrap();
-        let result = check_equiv(f, f);
+        let result = prove_ir_fn_equiv(f, f);
         assert_eq!(
             result,
             EquivResult::Proved,
@@ -1634,7 +1634,7 @@ fn fuzz_test(input: bits[4] id=1) -> bits[1] {
         let zero_f = crate::xls_ir::ir_parser::Parser::new(ir_zero)
             .parse_fn()
             .unwrap();
-        let result = check_equiv(&slice_f, &zero_f);
+        let result = prove_ir_fn_equiv(&slice_f, &zero_f);
         assert_eq!(result, EquivResult::Proved);
     }
 
@@ -1684,7 +1684,7 @@ fn fuzz_test(input: bits[4] id=1) -> bits[1] {
         let g = crate::xls_ir::ir_parser::Parser::new(ir_const)
             .parse_fn()
             .unwrap();
-        let result = check_equiv(&f, &g);
+        let result = prove_ir_fn_equiv(&f, &g);
         assert_eq!(
             result,
             EquivResult::Proved,
@@ -1708,7 +1708,7 @@ fn fuzz_test(input: bits[4] id=1) -> bits[1] {
         let g = crate::xls_ir::ir_parser::Parser::new(ir_id)
             .parse_fn()
             .unwrap();
-        let res = check_equiv(&f, &g);
+        let res = prove_ir_fn_equiv(&f, &g);
         assert_eq!(res, EquivResult::Proved);
     }
 
@@ -1727,7 +1727,7 @@ fn fuzz_test(input: bits[4] id=1) -> bits[1] {
         let g = crate::xls_ir::ir_parser::Parser::new(ir_static)
             .parse_fn()
             .unwrap();
-        assert_eq!(check_equiv(&f, &g), EquivResult::Proved);
+        assert_eq!(prove_ir_fn_equiv(&f, &g), EquivResult::Proved);
     }
 
     #[test]
@@ -1751,7 +1751,7 @@ fn func_literal_7() -> bits[3] {
             .parse_fn()
             .expect("Failed to parse literal_7 IR");
 
-        let result = check_equiv(&f_encode, &f_literal);
+        let result = prove_ir_fn_equiv(&f_encode, &f_literal);
         assert_eq!(
             result,
             EquivResult::Proved,
@@ -1785,7 +1785,7 @@ fn optimized_fn(input: bits[3] id=1) -> bits[5] {
             .parse_fn()
             .expect("Failed to parse optimized_fn IR for one_hot_reverse_fuzz_case");
 
-        let result = check_equiv(&fn_original, &fn_optimized);
+        let result = prove_ir_fn_equiv(&fn_original, &fn_optimized);
         assert_eq!(
             result,
             EquivResult::Proved,
@@ -1817,7 +1817,7 @@ fn optimized_shrl_saturation_fn(input: bits[8] id=1) -> bits[1] {
             .parse_fn()
             .expect("Failed to parse optimized_shrl_saturation_fn IR");
 
-        let result = check_equiv(&fn_original, &fn_optimized);
+        let result = prove_ir_fn_equiv(&fn_original, &fn_optimized);
         assert_eq!(
             result,
             EquivResult::Proved,
@@ -1840,6 +1840,6 @@ fn optimized_shrl_saturation_fn(input: bits[8] id=1) -> bits[1] {
         let f_id = crate::xls_ir::ir_parser::Parser::new(ir_id)
             .parse_fn()
             .unwrap();
-        assert_eq!(check_equiv(&f_shl, &f_id), EquivResult::Proved);
+        assert_eq!(prove_ir_fn_equiv(&f_shl, &f_id), EquivResult::Proved);
     }
 }

--- a/xlsynth-g8r/src/mcmc_logic.rs
+++ b/xlsynth-g8r/src/mcmc_logic.rs
@@ -431,7 +431,7 @@ pub fn mcmc(
     let simd_inputs = generate_simd_inputs(&original_gfn_for_check, &mut iteration_rng);
 
     // Compute baseline outputs for the initial GateFn.
-    let mut baseline_outputs = gate_simd::eval(&original_gfn_for_check, &simd_inputs).outputs;
+    let baseline_outputs = gate_simd::eval(&original_gfn_for_check, &simd_inputs).outputs;
 
     let mut mcmc_context = McmcContext {
         rng: &mut iteration_rng,

--- a/xlsynth-g8r/src/propose_equiv.rs
+++ b/xlsynth-g8r/src/propose_equiv.rs
@@ -66,7 +66,7 @@ fn gen_random_inputs(gate_fn: &GateFn, rng: &mut impl Rng) -> Vec<IrBits> {
 /// Returns a mapping from hash value (a hash over the history for a given gate
 /// as it's fed random samples) to a sequence of the nodes that had the same
 /// history.
-pub fn propose_equiv(
+pub fn propose_equivalence_classes(
     gate_fn: &GateFn,
     input_sample_count: usize,
     rng: &mut impl Rng,
@@ -168,7 +168,8 @@ mod tests {
         let graph = setup_simple_graph();
         let mut seeded_rng = rand::rngs::StdRng::seed_from_u64(0);
         let counterexamples = HashSet::new();
-        let equiv_classes = propose_equiv(&graph.g, 4096, &mut seeded_rng, &counterexamples);
+        let equiv_classes =
+            propose_equivalence_classes(&graph.g, 4096, &mut seeded_rng, &counterexamples);
         // There are no redundancies in this graph, so we should not find any
         // equivalence classes.
         assert!(equiv_classes.is_empty());
@@ -180,7 +181,8 @@ mod tests {
         let graph = setup_graph_with_redundancies();
         let mut seeded_rng = rand::rngs::StdRng::seed_from_u64(0);
         let counterexamples = HashSet::new();
-        let equiv_classes = propose_equiv(&graph.g, 4096, &mut seeded_rng, &counterexamples);
+        let equiv_classes =
+            propose_equivalence_classes(&graph.g, 4096, &mut seeded_rng, &counterexamples);
         log::info!("equiv_classes: {:?}", equiv_classes);
         assert_eq!(equiv_classes.len(), 4); // Expect 4 classes: normal pairs and inverted pairs
         let mut values = equiv_classes.values().collect::<Vec<_>>();

--- a/xlsynth-g8r/tests/test_gate_equiv_varisat.rs
+++ b/xlsynth-g8r/tests/test_gate_equiv_varisat.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
-use xlsynth_g8r::validate_equiv::{check_equiv, Ctx, EquivResult};
+use xlsynth_g8r::validate_equiv::{prove_gate_fn_equiv, Ctx, EquivResult};
 
 #[test]
 fn test_simple_equivalence() {
@@ -13,7 +13,7 @@ fn test_simple_equivalence() {
     let g1 = gb.build();
 
     let mut ctx = Ctx::new();
-    assert_eq!(check_equiv(&g1, &g1, &mut ctx), EquivResult::Proved);
+    assert_eq!(prove_gate_fn_equiv(&g1, &g1, &mut ctx), EquivResult::Proved);
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn test_simple_inequivalence() {
     let g2 = gb2.build();
 
     let mut ctx = Ctx::new();
-    match check_equiv(&g1, &g2, &mut ctx) {
+    match prove_gate_fn_equiv(&g1, &g2, &mut ctx) {
         EquivResult::Proved => panic!("Expected inequivalent"),
         EquivResult::Disproved(_) => (),
     }


### PR DESCRIPTION
Also remove gate equivalence from the IR fuzzing test, we should do a dedicated one for g8r opt fuzzing and subsequent equivalence.