### PR TITLE
[driver] Add reset_data_path support

### DIFF
--- a/xlsynth-driver/src/common.rs
+++ b/xlsynth-driver/src/common.rs
@@ -39,6 +39,7 @@ pub struct CodegenFlags {
     reset: Option<String>,
     reset_active_low: Option<bool>,
     reset_asynchronous: Option<bool>,
+    reset_data_path: Option<bool>,
     gate_format: Option<String>,
     assert_format: Option<String>,
 }
@@ -90,6 +91,9 @@ pub fn extract_codegen_flags(
         reset_asynchronous: matches
             .get_one::<String>("reset_asynchronous")
             .map(|s| s == "true"),
+        reset_data_path: matches
+            .get_one::<String>("reset_data_path")
+            .map(|s| s == "true"),
         gate_format,
         assert_format,
     }
@@ -134,6 +138,9 @@ pub fn codegen_flags_to_textproto(codegen_flags: &CodegenFlags) -> String {
     }
     if let Some(reset_asynchronous) = codegen_flags.reset_asynchronous {
         pieces.push(format!("reset_asynchronous: {reset_asynchronous}"));
+    }
+    if let Some(reset_data_path) = codegen_flags.reset_data_path {
+        pieces.push(format!("reset_data_path: {reset_data_path}"));
     }
     if let Some(gate_format) = &codegen_flags.gate_format {
         pieces.push(format!("gate_format: {gate_format:?}"));
@@ -188,6 +195,9 @@ pub fn add_codegen_flags(command: &mut Command, codegen_flags: &CodegenFlags) {
     }
     if let Some(reset_asynchronous) = codegen_flags.reset_asynchronous {
         command.arg(format!("--reset_asynchronous={reset_asynchronous}"));
+    }
+    if let Some(reset_data_path) = codegen_flags.reset_data_path {
+        command.arg(format!("--reset_data_path={reset_data_path}"));
     }
     if let Some(gate_format) = &codegen_flags.gate_format {
         command.arg(format!("--gate_format={gate_format}"));

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -194,6 +194,10 @@ impl AppExt for clap::Command {
             )
             .add_bool_arg("reset_asynchronous", "Reset is asynchronous")
             .add_bool_arg("reset_active_low", "Reset is active low")
+            .add_bool_arg(
+                "reset_data_path",
+                "Reset datapath registers as well as valid signals",
+            )
     }
 
     fn add_ir_top_arg(self, required: bool) -> Self {

--- a/xlsynth-driver/tests/test_dslx2pipeline_reset_data_path_false.golden.sv
+++ b/xlsynth-driver/tests/test_dslx2pipeline_reset_data_path_false.golden.sv
@@ -1,0 +1,53 @@
+module __my_module__main(
+  input wire clk,
+  input wire rst,
+  input wire input_valid,
+  input wire [31:0] x,
+  output wire output_valid,
+  output wire [31:0] out
+);
+  // ===== Pipe stage 0:
+  wire p0_not_18_comb;
+  wire p0_load_en_comb;
+  assign p0_not_18_comb = ~rst;
+  assign p0_load_en_comb = input_valid | p0_not_18_comb;
+
+  // Registers for pipe stage 0:
+  reg p0_valid;
+  reg [31:0] p0_x;
+  always @ (posedge clk) begin
+    p0_x <= p0_load_en_comb ? x : p0_x;
+  end
+  always @ (posedge clk) begin
+    if (!rst) begin
+      p0_valid <= 1'h0;
+    end else begin
+      p0_valid <= input_valid;
+    end
+  end
+
+  // ===== Pipe stage 1:
+  wire [31:0] p1_literal_8_comb;
+  wire [31:0] p1_add_9_comb;
+  wire p1_load_en_comb;
+  assign p1_literal_8_comb = 32'h0000_0001;
+  assign p1_add_9_comb = p0_x + p1_literal_8_comb;
+  assign p1_load_en_comb = p0_valid | p0_not_18_comb;
+
+  // Registers for pipe stage 1:
+  reg p1_valid;
+  reg [31:0] p1_add_9;
+  always @ (posedge clk) begin
+    p1_add_9 <= p1_load_en_comb ? p1_add_9_comb : p1_add_9;
+  end
+  always @ (posedge clk) begin
+    if (!rst) begin
+      p1_valid <= 1'h0;
+    end else begin
+      p1_valid <= p0_valid;
+    end
+  end
+  assign output_valid = p1_valid;
+  assign out = p1_add_9;
+endmodule
+

--- a/xlsynth-driver/tests/test_dslx2pipeline_reset_data_path_true.golden.sv
+++ b/xlsynth-driver/tests/test_dslx2pipeline_reset_data_path_true.golden.sv
@@ -1,0 +1,51 @@
+module __my_module__main(
+  input wire clk,
+  input wire rst,
+  input wire input_valid,
+  input wire [31:0] x,
+  output wire output_valid,
+  output wire [31:0] out
+);
+  // ===== Pipe stage 0:
+  wire p0_not_18_comb;
+  wire p0_load_en_comb;
+  assign p0_not_18_comb = ~rst;
+  assign p0_load_en_comb = input_valid | p0_not_18_comb;
+
+  // Registers for pipe stage 0:
+  reg p0_valid;
+  reg [31:0] p0_x;
+  always @ (posedge clk) begin
+    if (!rst) begin
+      p0_valid <= 1'h0;
+      p0_x <= 32'h0000_0000;
+    end else begin
+      p0_valid <= input_valid;
+      p0_x <= p0_load_en_comb ? x : p0_x;
+    end
+  end
+
+  // ===== Pipe stage 1:
+  wire [31:0] p1_literal_8_comb;
+  wire [31:0] p1_add_9_comb;
+  wire p1_load_en_comb;
+  assign p1_literal_8_comb = 32'h0000_0001;
+  assign p1_add_9_comb = p0_x + p1_literal_8_comb;
+  assign p1_load_en_comb = p0_valid | p0_not_18_comb;
+
+  // Registers for pipe stage 1:
+  reg p1_valid;
+  reg [31:0] p1_add_9;
+  always @ (posedge clk) begin
+    if (!rst) begin
+      p1_valid <= 1'h0;
+      p1_add_9 <= 32'h0000_0000;
+    end else begin
+      p1_valid <= p0_valid;
+      p1_add_9 <= p1_load_en_comb ? p1_add_9_comb : p1_add_9;
+    end
+  end
+  assign output_valid = p1_valid;
+  assign out = p1_add_9;
+endmodule
+


### PR DESCRIPTION
## Summary
- support `--reset_data_path` in xlsynth-driver
- expose flag via CLI and codegen proto generation
- add integration tests with golden verilog

## Testing
- `pre-commit run --all-files`
- `cargo test -p xlsynth-driver test_dslx2pipeline_reset_data_path -- --nocapture`
- `cargo test -q`