### PR TITLE
[g8r] Add parametric ripple_carry_adder sample

### DIFF
--- a/xlsynth-g8r/src/mcmc_logic.rs
+++ b/xlsynth-g8r/src/mcmc_logic.rs
@@ -29,7 +29,7 @@ use crate::prove_gate_fn_equiv_common::EquivResult;
 use crate::prove_gate_fn_equiv_z3::{self, prove_gate_fn_equiv as prove_gate_fn_equiv_z3};
 
 use crate::test_utils::{
-    load_bf16_add_sample, load_bf16_mul_sample, load_ripple_carry_adder_8b_sample, Opt as SampleOpt,
+    load_bf16_add_sample, load_bf16_mul_sample, make_ripple_carry_adder, Opt as SampleOpt,
 };
 use crate::transforms::get_all_transforms;
 use crate::transforms::transform_trait::{TransformDirection, TransformKind};
@@ -710,8 +710,12 @@ pub fn load_start<P: AsRef<Path>>(p_generic: P) -> Result<GateFn> {
                 );
                 Ok(loaded_sample.gate_fn)
             }
-            "ripple_carry_adder_8b" => {
-                let gfn = load_ripple_carry_adder_8b_sample();
+            _ if sample_name.starts_with("ripple_carry_adder:") => {
+                let bits_str = sample_name.trim_start_matches("ripple_carry_adder:");
+                let bits: usize = bits_str.parse().map_err(|_| {
+                    anyhow::anyhow!("Invalid bit width '{}', expected integer", bits_str)
+                })?;
+                let gfn = make_ripple_carry_adder(bits);
                 let sample_cost = cost(&gfn);
                 println!(
                     "Sample '{}' loaded. Initial stats: nodes={}, depth={}",

--- a/xlsynth-g8r/src/test_utils.rs
+++ b/xlsynth-g8r/src/test_utils.rs
@@ -210,11 +210,6 @@ pub fn make_ripple_carry_adder(bits: usize) -> GateFn {
     gb.build()
 }
 
-/// Returns an eight-bit ripple-carry adder sample as a `GateFn`.
-pub fn load_ripple_carry_adder_8b_sample() -> GateFn {
-    make_ripple_carry_adder(8)
-}
-
 pub struct TestGraph {
     pub g: GateFn,
     pub i0: AigOperand,

--- a/xlsynth-g8r/tests/invoke_mcmc_driver_test.rs
+++ b/xlsynth-g8r/tests/invoke_mcmc_driver_test.rs
@@ -8,7 +8,7 @@ fn test_invoke_mcmc_driver_with_sample() {
     let temp_dir = tempfile::tempdir().unwrap();
     let exe = env!("CARGO_BIN_EXE_mcmc-driver");
     let mut cmd = Command::new(exe);
-    cmd.arg("sample://ripple_carry_adder_8b")
+    cmd.arg("sample://ripple_carry_adder:8")
         .arg("-n")
         .arg("10")
         .arg("--paranoid")


### PR DESCRIPTION
## Summary
- support `sample://ripple_carry_adder:N` in `load_start`
- update tests to use the new form
- drop the legacy `ripple_carry_adder_8b` path

## Testing
- `pre-commit run --all-files`
- `cargo build -p xlsynth-g8r`
- `cargo fuzz build` in `xlsynth-g8r`
- `cargo test --test invoke_mcmc_driver_test --quiet`