### PR TITLE
Update publish workflow to refresh version docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,3 +143,17 @@ jobs:
           git add $(find . -type f -name "Cargo.toml")
           git commit -m "Bump version numbers after successful publish"
           git push "https://${GITHUB_ACTOR}:${MY_PAT}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+
+      - name: Update version compatibility docs
+        if: success()
+        run: |
+          python3 gen_version_compat.py
+
+      - name: Commit version metadata update
+        if: success()
+        run: |
+          git config user.name "github-actions"
+          git config user.email "xlsynth-github-actions@xlsynth.org"
+          git add docs/version_metadata.md
+          git commit -m "Update version metadata after successful publish"
+          git push "https://${GITHUB_ACTOR}:${MY_PAT}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main


### PR DESCRIPTION
## Summary
- update GitHub publish workflow to generate docs/version_metadata.md after publishing
- commit the docs update separately

## Testing
- `pre-commit run --all-files`
- `cargo test -p xlsynth-test-helpers check_all_rust_files_for_spdx`