### PR TITLE
Fix clock port naming in g8r2v

### DIFF
--- a/xlsynth-driver/tests/invoke_test.rs
+++ b/xlsynth-driver/tests/invoke_test.rs
@@ -1590,6 +1590,11 @@ fn test_g8r2v_add_clk_port_behavior() {
         "netlist should contain clk as first input: {}",
         stdout
     );
+    assert!(
+        !stdout.contains("clk_0"),
+        "clock port should not be suffixed with _0: {}",
+        stdout
+    );
     // 3. --add-clk-port=foo: should see foo as first input
     let output = std::process::Command::new(command_path)
         .arg("g8r2v")
@@ -1606,6 +1611,11 @@ fn test_g8r2v_add_clk_port_behavior() {
     assert!(
         stdout.contains("foo"),
         "netlist should contain foo as first input: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("foo_0"),
+        "clock port should not be suffixed with _0: {}",
         stdout
     );
 }

--- a/xlsynth-g8r/src/emit_netlist.rs
+++ b/xlsynth-g8r/src/emit_netlist.rs
@@ -16,8 +16,13 @@ pub fn emit_netlist(name: &str, gate_fn: &gate::GateFn) -> String {
 
     // Add all the inputs to the module.
     for input in gate_fn.inputs.iter() {
+        let bit_count = input.bit_vector.get_bit_count();
         for (i, bit) in input.bit_vector.iter_lsb_to_msb().enumerate() {
-            let name = format!("{}_{}", input.name, i);
+            let name = if bit_count == 1 {
+                input.name.clone()
+            } else {
+                format!("{}_{}", input.name, i)
+            };
             let logic_ref = module.add_input(name.as_str(), &bit_type);
             gate_ref_to_vast.insert(bit.node, logic_ref);
         }
@@ -27,8 +32,13 @@ pub fn emit_netlist(name: &str, gate_fn: &gate::GateFn) -> String {
 
     // Add all the outputs to the module.
     for output in gate_fn.outputs.iter() {
+        let bit_count = output.bit_vector.get_bit_count();
         for (i, bit) in output.bit_vector.iter_lsb_to_msb().enumerate() {
-            let name = format!("{}_{}", output.name, i);
+            let name = if bit_count == 1 {
+                output.name.clone()
+            } else {
+                format!("{}_{}", output.name, i)
+            };
             let logic_ref = module.add_output(name.as_str(), &bit_type);
             output_operand_to_logic_ref.insert(bit, logic_ref.clone());
         }
@@ -111,12 +121,12 @@ mod tests {
         assert_eq!(
             netlist,
             "module my_inverter(
-  input wire i_0,
-  output wire o_0
+  input wire i,
+  output wire o
 );
   wire G0;
   assign G0 = 1'b0;
-  assign o_0 = ~i_0;
+  assign o = ~i;
 endmodule
 "
         );
@@ -136,15 +146,15 @@ endmodule
         assert_eq!(
             netlist,
             "module my_and_gate(
-  input wire i_0,
-  input wire j_0,
-  output wire o_0
+  input wire i,
+  input wire j,
+  output wire o
 );
   wire G0;
   assign G0 = 1'b0;
   wire G3;
-  assign G3 = i_0 & j_0;
-  assign o_0 = G3;
+  assign G3 = i & j;
+  assign o = G3;
 endmodule
 "
         );


### PR DESCRIPTION
## Summary
- keep single-bit port names intact when emitting netlists
- update emit_netlist tests for new naming
- assert that clock ports are not suffixed in g8r2v tests

## Testing
- `pre-commit run --files xlsynth-g8r/src/emit_netlist.rs xlsynth-driver/tests/invoke_test.rs`
- `cargo test -p xlsynth-test-helpers check_all_rust_files_for_spdx` *(fails: failed to download stdlib tarball)*

------
https://chatgpt.com/codex/tasks/task_e_683b3bfc851c83208adbca198a8b231d