### PR TITLE
[g8r:netlist] Add structured findings for integrity checks

### DIFF
--- a/xlsynth-g8r/src/netlist/integrity.rs
+++ b/xlsynth-g8r/src/netlist/integrity.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Basic integrity checks for parsed netlists.
+//!
+//! These checks look for simple wiring issues such as inputs that are never
+//! used, outputs that are never driven, and wires that are declared but never
+//! connected.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::liberty_proto::{Library, PinDirection};
+use crate::netlist::parse::{
+    Net, NetIndex, NetRef, NetlistInstance, NetlistModule, NetlistPort, PortDirection,
+};
+use string_interner::symbol::SymbolU32;
+use string_interner::{backend::StringBackend, StringInterner};
+
+/// A specific integrity problem found during checking.
+#[derive(Debug, PartialEq, Eq)]
+pub enum IntegrityFinding {
+    /// Input port was declared but never used by any instance.
+    UnusedInput(String),
+    /// Output port was declared but never driven by any instance.
+    UndrivenOutput(String),
+    /// A wire was declared but never driven by any instance.
+    UndrivenWire(String),
+    /// A wire was declared but never used by any instance.
+    UnusedWire(String),
+}
+
+/// Result of running the integrity checker over a module.
+#[derive(Debug, PartialEq, Eq)]
+pub enum IntegritySummary {
+    /// No issues were found.
+    Clean,
+    /// One or more problems were detected.
+    Findings(Vec<IntegrityFinding>),
+}
+
+/// Check a parsed module for simple wiring issues.
+///
+/// `module`    - The module to check.
+/// `nets`      - The global list of nets referenced by `module`.
+/// `interner`  - The interner used when parsing the netlist.
+/// `lib`       - Liberty library providing pin directions for instances.
+pub fn check_module(
+    module: &NetlistModule,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    lib: &Library,
+) -> IntegritySummary {
+    // Build mapping of (cell name -> {pin name -> direction})
+    let mut dir_map: HashMap<&str, HashMap<&str, i32>> = HashMap::new();
+    for cell in &lib.cells {
+        let mut pins = HashMap::new();
+        for pin in &cell.pins {
+            pins.insert(pin.name.as_str(), pin.direction);
+        }
+        dir_map.insert(cell.name.as_str(), pins);
+    }
+
+    let mut used_as_input: HashSet<SymbolU32> = HashSet::new();
+    let mut driven: HashSet<SymbolU32> = HashSet::new();
+
+    // Module ports contribute to driving/using sets.
+    for NetlistPort {
+        direction, name, ..
+    } in &module.ports
+    {
+        match direction {
+            PortDirection::Input => {
+                driven.insert(*name);
+            }
+            PortDirection::Output => {
+                used_as_input.insert(*name); // environment observes the output
+            }
+            PortDirection::Inout => {
+                driven.insert(*name);
+                used_as_input.insert(*name);
+            }
+        }
+    }
+
+    // Walk instances and classify connections according to pin directions.
+    for NetlistInstance {
+        type_name,
+        connections,
+        ..
+    } in &module.instances
+    {
+        let Some(type_str) = interner.resolve(*type_name) else {
+            continue;
+        };
+        let pin_dirs = dir_map.get(type_str);
+        for (port, netref) in connections {
+            let Some(port_str) = interner.resolve(*port) else {
+                continue;
+            };
+            let dir = pin_dirs
+                .and_then(|m| m.get(port_str))
+                .copied()
+                .unwrap_or(PinDirection::Invalid as i32);
+            let net_sym = match netref {
+                NetRef::Simple(idx) | NetRef::BitSelect(idx, _) | NetRef::PartSelect(idx, _, _) => {
+                    nets[idx.0].name
+                }
+                NetRef::Literal(_) => continue,
+            };
+            if dir == PinDirection::Output as i32 {
+                driven.insert(net_sym);
+            } else if dir == PinDirection::Input as i32 {
+                used_as_input.insert(net_sym);
+            } else {
+                // Unknown or inout pin - treat as both directions.
+                driven.insert(net_sym);
+                used_as_input.insert(net_sym);
+            }
+        }
+    }
+
+    let mut findings = Vec::new();
+
+    // Inputs should be used somewhere.
+    for port in &module.ports {
+        if port.direction == PortDirection::Input && !used_as_input.contains(&port.name) {
+            let name = interner
+                .resolve(port.name)
+                .unwrap_or("<unknown>")
+                .to_string();
+            findings.push(IntegrityFinding::UnusedInput(name));
+        }
+    }
+
+    // Outputs must be driven.
+    for port in &module.ports {
+        if port.direction == PortDirection::Output && !driven.contains(&port.name) {
+            let name = interner
+                .resolve(port.name)
+                .unwrap_or("<unknown>")
+                .to_string();
+            findings.push(IntegrityFinding::UndrivenOutput(name));
+        }
+    }
+
+    // Every declared wire should be driven and used.
+    for net_idx in &module.wires {
+        let sym = nets[net_idx.0].name;
+        if !driven.contains(&sym) {
+            let name = interner.resolve(sym).unwrap_or("<unknown>").to_string();
+            findings.push(IntegrityFinding::UndrivenWire(name.clone()));
+        }
+        if !used_as_input.contains(&sym) {
+            let name = interner.resolve(sym).unwrap_or("<unknown>").to_string();
+            findings.push(IntegrityFinding::UnusedWire(name));
+        }
+    }
+
+    if findings.is_empty() {
+        IntegritySummary::Clean
+    } else {
+        IntegritySummary::Findings(findings)
+    }
+}

--- a/xlsynth-g8r/src/netlist/mod.rs
+++ b/xlsynth-g8r/src/netlist/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod gatefn_from_netlist;
+pub mod integrity;
 pub mod parse;

--- a/xlsynth-g8r/tests/test_netlist_integrity.rs
+++ b/xlsynth-g8r/tests/test_netlist_integrity.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use xlsynth_g8r::liberty_proto::{Cell, Library, Pin, PinDirection};
+use xlsynth_g8r::netlist::integrity::{check_module, IntegrityFinding, IntegritySummary};
+use xlsynth_g8r::netlist::parse::{Parser as NetlistParser, TokenScanner};
+
+fn build_simple_lib() -> Library {
+    Library {
+        cells: vec![Cell {
+            name: "INVX1".to_string(),
+            area: 1.0,
+            pins: vec![
+                Pin {
+                    name: "A".to_string(),
+                    direction: PinDirection::Input as i32,
+                    function: String::new(),
+                },
+                Pin {
+                    name: "Y".to_string(),
+                    direction: PinDirection::Output as i32,
+                    function: String::new(),
+                },
+            ],
+        }],
+    }
+}
+
+#[test]
+fn test_clean_netlist() {
+    let netlist = r#"module top (a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  INVX1 u1 (.A(a), .Y(y));
+endmodule"#;
+    let scanner = TokenScanner::with_line_lookup(netlist.as_bytes(), Box::new(|_| None));
+    let mut parser = NetlistParser::new(scanner);
+    let modules = parser.parse_file().unwrap();
+    assert_eq!(modules.len(), 1);
+    let lib = build_simple_lib();
+    let summary = check_module(&modules[0], &parser.nets, &parser.interner, &lib);
+    assert!(matches!(summary, IntegritySummary::Clean));
+}
+
+#[test]
+fn test_findings_netlist() {
+    let netlist = r#"module top (a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  wire n1;
+  INVX1 u1 (.A(y), .Y(y));
+endmodule"#;
+    let scanner = TokenScanner::with_line_lookup(netlist.as_bytes(), Box::new(|_| None));
+    let mut parser = NetlistParser::new(scanner);
+    let modules = parser.parse_file().unwrap();
+    assert_eq!(modules.len(), 1);
+    let lib = build_simple_lib();
+    let summary = check_module(&modules[0], &parser.nets, &parser.interner, &lib);
+    match summary {
+        IntegritySummary::Findings(f) => {
+            assert!(f.contains(&IntegrityFinding::UnusedInput("a".into())));
+            assert!(f.contains(&IntegrityFinding::UnusedWire("n1".into())));
+        }
+        _ => panic!("expected findings"),
+    }
+}


### PR DESCRIPTION
## Summary
- refine netlist integrity checker to return structured `IntegrityFinding`
- adapt tests to check new structured results

## Testing
- `cargo fuzz check` *(failed: could not access crates.io)*
- `pre-commit run --all-files` *(failed: could not download stdlib for xlsynth-sys)*

------
https://chatgpt.com/codex/tasks/task_e_683b4fecab24832085ce9c6e01c5e0c1