### PR TITLE
[g8r] Handle DSLX assert/fail translation

### DIFF
--- a/xlsynth-g8r/src/ir2gate.rs
+++ b/xlsynth-g8r/src/ir2gate.rs
@@ -1548,7 +1548,11 @@ fn gatify_internal(
             | ir::NodePayload::AfterAll(..)
             | ir::NodePayload::Trace { .. }
             | ir::NodePayload::Nil => {
-                // No incarnation in gates.
+                // These IR nodes manipulate tokens or have no semantic
+                // representation in gates. Map them to a zero-width bit
+                // vector so any subsequent references (e.g. via tuples) have
+                // a placeholder value.
+                env.add(node_ref, GateOrVec::BitVector(AigBitVector::zeros(0)));
             }
             ir::NodePayload::DynamicBitSlice { arg, start, width } => {
                 let arg_bits = env


### PR DESCRIPTION
## Summary
- ensure ir2gate handles Assert and similar nodes by providing zero-width placeholders
- add tests verifying gatification of DSLX functions containing `fail!` and `assert!`

## Testing
- `pre-commit run --all-files`
- `cargo fuzz build`
- `cargo test -p xlsynth-g8r`
- `cargo test -p xlsynth-test-helpers check_all_rust_files_for_spdx`


------
https://chatgpt.com/codex/tasks/task_i_683e7b99a7bc8323a5381cf5160ca07f