### PR TITLE
Expose schedule outputs in xlsynth-driver

### DIFF
--- a/xlsynth-driver/src/common.rs
+++ b/xlsynth-driver/src/common.rs
@@ -42,6 +42,8 @@ pub struct CodegenFlags {
     reset_data_path: Option<bool>,
     gate_format: Option<String>,
     assert_format: Option<String>,
+    output_schedule_path: Option<String>,
+    output_verilog_line_map_path: Option<String>,
 }
 
 /// Extracts flags that we pass to the "codegen" step of the process (i.e.
@@ -96,6 +98,12 @@ pub fn extract_codegen_flags(
             .map(|s| s == "true"),
         gate_format,
         assert_format,
+        output_schedule_path: matches
+            .get_one::<String>("output_schedule_path")
+            .map(|s| s.to_string()),
+        output_verilog_line_map_path: matches
+            .get_one::<String>("output_verilog_line_map_path")
+            .map(|s| s.to_string()),
     }
 }
 
@@ -147,6 +155,14 @@ pub fn codegen_flags_to_textproto(codegen_flags: &CodegenFlags) -> String {
     }
     if let Some(assert_format) = &codegen_flags.assert_format {
         pieces.push(format!("assert_format: {assert_format:?}"));
+    }
+    if let Some(output_schedule_path) = &codegen_flags.output_schedule_path {
+        pieces.push(format!("output_schedule_path: \"{output_schedule_path}\""));
+    }
+    if let Some(output_verilog_line_map_path) = &codegen_flags.output_verilog_line_map_path {
+        pieces.push(format!(
+            "output_verilog_line_map_path: \"{output_verilog_line_map_path}\""
+        ));
     }
     pieces.push(format!("assertion_macro_names: \"ASSERT_ON\""));
     pieces.join("\n")
@@ -204,6 +220,16 @@ pub fn add_codegen_flags(command: &mut Command, codegen_flags: &CodegenFlags) {
     }
     if let Some(assert_format) = &codegen_flags.assert_format {
         command.arg(format!("--assert_format={assert_format}"));
+    }
+    if let Some(output_schedule_path) = &codegen_flags.output_schedule_path {
+        command
+            .arg("--output_schedule_path")
+            .arg(output_schedule_path);
+    }
+    if let Some(output_verilog_line_map_path) = &codegen_flags.output_verilog_line_map_path {
+        command
+            .arg("--output_verilog_line_map_path")
+            .arg(output_verilog_line_map_path);
     }
 }
 

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -205,6 +205,18 @@ impl AppExt for clap::Command {
                 "reset_data_path",
                 "Reset datapath registers as well as valid signals",
             )
+            .arg(
+                Arg::new("output_schedule_path")
+                    .long("output_schedule_path")
+                    .value_name("OUTPUT_SCHEDULE_PATH")
+                    .help("Write schedule proto text to this path"),
+            )
+            .arg(
+                Arg::new("output_verilog_line_map_path")
+                    .long("output_verilog_line_map_path")
+                    .value_name("OUTPUT_VERILOG_LINE_MAP_PATH")
+                    .help("Write Verilog line map textproto to this path"),
+            )
     }
 
     fn add_ir_top_arg(self, required: bool) -> Self {


### PR DESCRIPTION
## Summary
- add `output_schedule_path` and `output_verilog_line_map_path` to codegen flags
- pass the flags through to codegen toolchain
- expose new options on CLI for commands that generate Verilog

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_i_68407b694d788323bf0225a91917f84e