### PR TITLE
Add modulus lowering for g8r

### DIFF
--- a/xlsynth-g8r/tests/gatify_tests.rs
+++ b/xlsynth-g8r/tests/gatify_tests.rs
@@ -637,11 +637,35 @@ fn do_udiv(x: bits[{bit_count}], y: bits[{bit_count}]) -> bits[{bit_count}] {{
     );
 }
 
+#[test_matrix(
+    1..3,
+    [Opt::Yes, Opt::No]
+)]
+fn test_umod_ir_to_gates(bit_count: u32, opt: Opt) {
+    do_test_ir_conversion(
+        &format!(
+            "package sample
+fn do_umod(x: bits[{bit_count}], y: bits[{bit_count}]) -> bits[{bit_count}] {{
+    ret result: bits[{bit_count}] = umod(x, y, id=3)
+}}",
+        ),
+        opt,
+    );
+}
+
 bit_count_test_cases!(test_sdiv_dslx_to_gates, |input_bits: u32, opt: Opt| -> () {
     do_test_dslx_conversion(
         input_bits,
         opt,
         "fn do_sdiv(x: sN[N], y: sN[N]) -> sN[N] { if y == sN[N]:0 { x } else { x / y } }",
+    );
+});
+
+bit_count_test_cases!(test_smod_dslx_to_gates, |input_bits: u32, opt: Opt| -> () {
+    do_test_dslx_conversion(
+        input_bits,
+        opt,
+        "fn do_smod(x: sN[N], y: sN[N]) -> sN[N] { if y == sN[N]:0 { x } else { x % y } }",
     );
 });
 


### PR DESCRIPTION
## Summary
- support `umod` and `smod` in `ir2gate`
- test unsigned and signed mod lowering

## Testing
- `pre-commit run --all-files`
- `cargo build --quiet --manifest-path xlsynth-g8r/fuzz/Cargo.toml`
- `cargo test -p xlsynth-g8r --test gatify_tests test_umod_ir_to_gates::_1_opt_no_expects -- --test-threads=1`
- `cargo test -p xlsynth-g8r --test gatify_tests test_smod_dslx_to_gates::bit_count_1_fold_false -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_i_684139bbd11c832393a4382317a3a24c