### PR TITLE
Add ir-fn-eval subcommand

### DIFF
--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -150,6 +150,15 @@ Maps an IR function to a gate-level representation and prints structural
 statistics.  With `--quiet=true` a compact JSON summary is produced; otherwise
 the report is human-readable text.
 
+### `ir-fn-eval`
+
+Interprets an IR function with a tuple of typed argument values and prints the
+result. Example:
+
+```shell
+xlsynth-driver ir-fn-eval my_mod.ir add '(bits[32]:1, bits[32]:2)'
+```
+
 ### `g8r-equiv`
 
 Checks two GateFns for functional equivalence using the available engines.  A

--- a/xlsynth-driver/src/ir_fn_eval.rs
+++ b/xlsynth-driver/src/ir_fn_eval.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::toolchain_config::ToolchainConfig;
+
+pub fn handle_ir_fn_eval(matches: &clap::ArgMatches, _config: &Option<ToolchainConfig>) {
+    let ir_path = matches.get_one::<String>("ir_file").unwrap();
+    let entry_fn = matches.get_one::<String>("entry_fn").unwrap();
+    let arg_tuple = matches.get_one::<String>("arg_tuple").unwrap();
+
+    let package = match xlsynth::IrPackage::parse_ir_from_path(std::path::Path::new(ir_path)) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Failed to parse IR file: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let func = match package.get_function(entry_fn) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Failed to get function '{}': {}", entry_fn, e);
+            std::process::exit(1);
+        }
+    };
+
+    let args_value = match xlsynth::IrValue::parse_typed(arg_tuple) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Failed to parse argument tuple: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let args = match args_value.get_elements() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Argument value is not a tuple: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let result = match func.interpret(&args) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Interpretation failed: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    println!("{}", result);
+}

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -48,6 +48,7 @@ mod ir2gates;
 mod ir2opt;
 mod ir2pipeline;
 mod ir_equiv;
+mod ir_fn_eval;
 mod ir_ged;
 mod lib2proto;
 mod report_cli_error;
@@ -630,6 +631,28 @@ fn main() {
                         .index(2),
                 )
         )
+        .subcommand(
+            clap::Command::new("ir-fn-eval")
+                .about("Interprets an IR function with the provided argument tuple")
+                .arg(
+                    clap::Arg::new("ir_file")
+                        .help("Path to the IR file")
+                        .required(true)
+                        .index(1),
+                )
+                .arg(
+                    clap::Arg::new("entry_fn")
+                        .help("Name of the function to invoke")
+                        .required(true)
+                        .index(2),
+                )
+                .arg(
+                    clap::Arg::new("arg_tuple")
+                        .help("Tuple of typed IR values for the function arguments")
+                        .required(true)
+                        .index(3),
+                )
+        )
         .get_matches();
 
     let mut toml_path: Option<String> = matches
@@ -707,6 +730,8 @@ fn main() {
         if let Err(e) = g8r2v::handle_g8r2v(matches) {
             report_cli_error::report_cli_error_and_exit(&e, None, vec![]);
         }
+    } else if let Some(matches) = matches.subcommand_matches("ir-fn-eval") {
+        ir_fn_eval::handle_ir_fn_eval(matches, &config);
     } else if let Some(matches) = matches.subcommand_matches("g8r-equiv") {
         g8r_equiv::handle_g8r_equiv(matches, &config);
     } else if let Some(matches) = matches.subcommand_matches("ir2combo") {

--- a/xlsynth-driver/tests/invoke_test.rs
+++ b/xlsynth-driver/tests/invoke_test.rs
@@ -2028,3 +2028,28 @@ fn test_dslx_g8r_stats_subcommand(use_tool_path: bool) {
         "stats missing fanout_histogram"
     );
 }
+
+#[test]
+fn test_ir_fn_eval() {
+    let ir = "package test\n\nfn add(a: bits[32], b: bits[32]) -> bits[32] {\n  ret add.1: bits[32] = add(a, b)\n}\n";
+    let dir = tempfile::tempdir().unwrap();
+    let ir_path = dir.path().join("add.ir");
+    std::fs::write(&ir_path, ir).unwrap();
+
+    let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
+    let output = Command::new(command_path)
+        .arg("ir-fn-eval")
+        .arg(ir_path.to_str().unwrap())
+        .arg("add")
+        .arg("(bits[32]:1, bits[32]:2)")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "bits[32]:3\n");
+}


### PR DESCRIPTION
## Summary
- add `ir-fn-eval` subcommand for interpreting IR functions
- document new subcommand in README
- test invocation via new CLI command

## Testing
- `cargo fmt --all -- --check`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_i_68462b837f248323b42a04ed84abbac8