### PR TITLE
Free memory in `c_strs_to_rust`

### DIFF
--- a/xlsynth/src/lib_support.rs
+++ b/xlsynth/src/lib_support.rs
@@ -609,6 +609,11 @@ unsafe fn c_strs_to_rust(c_strs: *mut *mut std::os::raw::c_char, count: usize) -
         let xls_c_str: *mut std::os::raw::c_char = unsafe { *c_strs.wrapping_add(i) };
         result.push(c_str_to_rust_no_dealloc(xls_c_str));
     }
+    if !c_strs.is_null() && count > 0 {
+        unsafe {
+            xlsynth_sys::xls_c_strs_free(c_strs, count);
+        }
+    }
     result
 }
 


### PR DESCRIPTION
`c_strs_to_rust` should free the pointer array. 