### PR TITLE
Avoid string parsing for to_u64/to_u32/...

### DIFF
--- a/xlsynth/Cargo.toml
+++ b/xlsynth/Cargo.toml
@@ -40,3 +40,7 @@ harness = false
 [[bench]]
 name = "f32_add"
 harness = false
+
+[[bench]]
+name = "ir_value_bench"
+harness = false

--- a/xlsynth/benches/ir_value_bench.rs
+++ b/xlsynth/benches/ir_value_bench.rs
@@ -1,0 +1,31 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use xlsynth::ir_value::{IrFormatPreference, IrValue};
+
+fn bench_to_u64_old(c: &mut Criterion) {
+    let v = IrValue::parse_typed("bits[32]:305419896").unwrap(); // 0x12345678
+    c.bench_function("to_u64_old", |b| {
+        b.iter(|| {
+            // Old implementation: parse string
+            let string = v
+                .to_string_fmt(IrFormatPreference::UnsignedDecimal)
+                .unwrap();
+            let number = string.split(':').nth(1).unwrap();
+            let val: u64 = number.parse().unwrap();
+            black_box(val)
+        })
+    });
+}
+
+fn bench_to_u64_new(c: &mut Criterion) {
+    let v = IrValue::parse_typed("bits[32]:305419896").unwrap(); // 0x12345678
+    c.bench_function("to_u64_new", |b| {
+        b.iter(|| {
+            // New implementation: direct bits
+            let val = v.to_u64().unwrap();
+            black_box(val)
+        })
+    });
+}
+
+criterion_group!(benches, bench_to_u64_old, bench_to_u64_new);
+criterion_main!(benches);

--- a/xlsynth/benches/ir_value_bench.rs
+++ b/xlsynth/benches/ir_value_bench.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use xlsynth::ir_value::{IrFormatPreference, IrValue};
 


### PR DESCRIPTION
For reference
```
to_u64_old              time:   [3.1043 µs 3.2647 µs 3.4309 µs]                        
                        change: [-15.218% -8.2447% -0.7238%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

to_u64_new              time:   [601.20 ns 616.21 ns 632.37 ns]                        
                        change: [-50.632% -45.500% -40.393%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
  ```