### PR TITLE
[driver] Add type_inference_v2 flags to dslx2... subcommands

### DIFF
--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -89,10 +89,16 @@ The resulting Verilog is printed on **stdout**.
 Diagnostic messages and the path to temporary files (when
 `--keep_temps=true`) are written to **stderr**.
 
+- The `--type_inference_v2` flag enables the experimental type inference v2 algorithm.
+  **Requires:** `--toolchain` (external tool path). If used without `--toolchain`, the driver will print an error and exit.
+
 ### `dslx2ir`: DSLX to IR
 
 Converts DSLX source code to the XLS IR. The IR text is emitted on **stdout**.
 DSLX warnings and errors appear on **stderr**.
+
+- The `--type_inference_v2` flag enables the experimental type inference v2 algorithm.
+  **Requires:** `--toolchain` (external tool path). If used without `--toolchain`, the driver will print an error and exit.
 
 ### `dslx2sv-types`: DSLX type definitions to SystemVerilog
 
@@ -104,6 +110,9 @@ The output is written to **stdout**.
 Converts a DSLX entry point all the way to a gate-level representation and
 prints a JSON summary of structural statistics. It performs IR conversion,
 optimization, and gatification using either the toolchain or the runtime APIs.
+
+- The `--type_inference_v2` flag enables the experimental type inference v2 algorithm.
+  **Requires:** `--toolchain` (external tool path). If used without `--toolchain`, the driver will print an error and exit.
 
 ### `ir2opt`: optimize IR
 
@@ -188,3 +197,41 @@ Supported fields:
 Only the fields you need must be present.  When invoked with
 `--toolchain <FILE>` the driver uses these values as defaults for the
 corresponding command-line flags.
+
+## Experimental `--type_inference_v2` Flag
+
+Some subcommands support an experimental flag:
+
+```
+--type_inference_v2
+```
+
+This flag enables the experimental type inference v2 algorithm for DSLX-to-IR and related conversions.
+**It is only supported when using the external toolchain (`--toolchain`).**
+If you request this flag without `--toolchain`, the driver will print an error and exit.
+
+### Supported Subcommands
+
+| Subcommand         | Supports `--type_inference_v2`? | Requires `--toolchain` for TIv2? | Runtime API allowed without TIv2? |
+|--------------------|:-------------------------------:|:-------------------------------:|:---------------------------------:|
+| `dslx2pipeline`    | Yes                             | Yes                             | Yes                              |
+| `dslx2ir`          | Yes                             | Yes                             | Yes                              |
+| `dslx-g8r-stats`   | Yes                             | Yes                             | Yes                              |
+| `dslx2sv-types`    | No                              | N/A                             | Yes                              |
+
+### Migration and Use
+
+The main benefit of this flag is that it enables an attempt at migrating `.x` files with **no associated source text changes** (e.g., that would change the position metadata in the resulting IR file).
+
+> **Note:**
+> This flag may be short-lived, as it will likely become the default mode when TIv1 is deleted.
+> However, it may assist with migration testing and validation during the transition period.
+
+**How to use:**
+
+```shell
+xlsynth-driver --toolchain=path/to/xlsynth-toolchain.toml dslx2ir \
+  --dslx_input_file my_module.x \
+  --dslx_top main \
+  --type_inference_v2=true
+```

--- a/xlsynth-driver/src/dslx2ir.rs
+++ b/xlsynth-driver/src/dslx2ir.rs
@@ -44,6 +44,10 @@ fn dslx2ir(
         }
         println!("{}", output);
     } else {
+        if type_inference_v2 == Some(true) {
+            eprintln!("error: --type_inference_v2 is only supported when using --toolchain (external tool path)");
+            std::process::exit(1);
+        }
         let dslx_contents = std::fs::read_to_string(input_file).expect(&format!(
             "file read should succeed for path {:?}",
             input_file

--- a/xlsynth-driver/src/dslx2ir.rs
+++ b/xlsynth-driver/src/dslx2ir.rs
@@ -16,6 +16,7 @@ fn dslx2ir(
     tool_path: Option<&str>,
     enable_warnings: Option<&[String]>,
     disable_warnings: Option<&[String]>,
+    type_inference_v2: Option<bool>,
     opt: bool,
 ) {
     log::info!("dslx2ir");
@@ -32,6 +33,7 @@ fn dslx2ir(
             tool_path,
             enable_warnings,
             disable_warnings,
+            type_inference_v2,
         );
         if opt {
             // Write the output of conversion to a temp file and then pass that.
@@ -109,6 +111,15 @@ pub fn handle_dslx2ir(matches: &ArgMatches, config: &Option<ToolchainConfig>) {
         _ => false,
     };
 
+    let type_inference_v2 = match matches
+        .get_one::<String>("type_inference_v2")
+        .map(|s| s.as_str())
+    {
+        Some("true") => Some(true),
+        Some("false") => Some(false),
+        _ => None,
+    };
+
     dslx2ir(
         input_path,
         top,
@@ -117,6 +128,7 @@ pub fn handle_dslx2ir(matches: &ArgMatches, config: &Option<ToolchainConfig>) {
         tool_path,
         enable_warnings,
         disable_warnings,
+        type_inference_v2,
         opt,
     );
 }

--- a/xlsynth-driver/src/dslx2pipeline.rs
+++ b/xlsynth-driver/src/dslx2pipeline.rs
@@ -20,6 +20,7 @@ fn dslx2pipeline(
     codegen_flags: &CodegenFlags,
     delay_model: &str,
     keep_temps: &Option<bool>,
+    type_inference_v2: Option<bool>,
     config: &Option<ToolchainConfig>,
 ) {
     log::info!("dslx2pipeline; config: {:?}", config);
@@ -46,6 +47,7 @@ fn dslx2pipeline(
             tool_path,
             enable_warnings,
             disable_warnings,
+            type_inference_v2,
         );
         let unopt_ir_path = temp_dir.path().join("unopt.ir");
         std::fs::write(&unopt_ir_path, unopt_ir).unwrap();
@@ -145,7 +147,16 @@ pub fn handle_dslx2pipeline(matches: &ArgMatches, config: &Option<ToolchainConfi
     let keep_temps = matches.get_one::<String>("keep_temps").map(|s| s == "true");
     let codegen_flags = extract_codegen_flags(matches, config.as_ref());
 
-    // Stub function for DSLX to SV conversion
+    // extract type_inference_v2 flag
+    let type_inference_v2 = match matches
+        .get_one::<String>("type_inference_v2")
+        .map(|s| s.as_str())
+    {
+        Some("true") => Some(true),
+        Some("false") => Some(false),
+        _ => None,
+    };
+
     dslx2pipeline(
         input_path,
         top,
@@ -153,6 +164,7 @@ pub fn handle_dslx2pipeline(matches: &ArgMatches, config: &Option<ToolchainConfi
         &codegen_flags,
         delay_model,
         &keep_temps,
+        type_inference_v2,
         config,
     );
 }

--- a/xlsynth-driver/src/dslx2pipeline.rs
+++ b/xlsynth-driver/src/dslx2pipeline.rs
@@ -75,6 +75,10 @@ fn dslx2pipeline(
         }
         println!("{}", sv);
     } else {
+        if type_inference_v2 == Some(true) {
+            eprintln!("error: --type_inference_v2 is only supported when using --toolchain (external tool path)");
+            std::process::exit(1);
+        }
         log::info!("dslx2pipeline using runtime APIs");
         let dslx = std::fs::read_to_string(input_file).unwrap();
 

--- a/xlsynth-driver/src/dslx_g8r_stats.rs
+++ b/xlsynth-driver/src/dslx_g8r_stats.rs
@@ -24,6 +24,15 @@ pub fn handle_dslx_g8r_stats(matches: &ArgMatches, config: &Option<ToolchainConf
     let enable_warnings = config.as_ref().and_then(|c| c.enable_warnings.as_deref());
     let disable_warnings = config.as_ref().and_then(|c| c.disable_warnings.as_deref());
 
+    let type_inference_v2 = matches
+        .get_one::<String>("type_inference_v2")
+        .map(|s| s == "true");
+
+    if type_inference_v2 == Some(true) && tool_path.is_none() {
+        eprintln!("error: --type_inference_v2 is only supported when using --toolchain (external tool path)");
+        std::process::exit(1);
+    }
+
     let ir_text = if let Some(tool_path) = tool_path {
         let mut output = run_ir_converter_main(
             input_path,
@@ -33,6 +42,7 @@ pub fn handle_dslx_g8r_stats(matches: &ArgMatches, config: &Option<ToolchainConf
             tool_path,
             enable_warnings,
             disable_warnings,
+            type_inference_v2,
         );
         let temp_file = NamedTempFile::new().unwrap();
         std::fs::write(temp_file.path(), &output).unwrap();

--- a/xlsynth-driver/src/dslx_g8r_stats.rs
+++ b/xlsynth-driver/src/dslx_g8r_stats.rs
@@ -49,6 +49,10 @@ pub fn handle_dslx_g8r_stats(matches: &ArgMatches, config: &Option<ToolchainConf
         output = run_opt_main(temp_file.path(), None, tool_path);
         output
     } else {
+        if type_inference_v2 == Some(true) {
+            eprintln!("error: --type_inference_v2 is only supported when using --toolchain (external tool path)");
+            std::process::exit(1);
+        }
         let dslx_contents = std::fs::read_to_string(input_path).expect("failed to read DSLX input");
         let stdlib_path = dslx_stdlib_path.map(|s| std::path::Path::new(s));
         let additional_paths: Vec<&std::path::Path> = dslx_path

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -330,13 +330,21 @@ fn main() {
                 .add_dslx_input_args(true)
                 .add_pipeline_args()
                 .add_codegen_args()
-                .add_bool_arg("keep_temps", "Keep temporary files"),
+                .add_bool_arg("keep_temps", "Keep temporary files")
+                .add_bool_arg(
+                    "type_inference_v2",
+                    "Enable the experimental type-inference v2 algorithm",
+                ),
         )
         .subcommand(
             clap::Command::new("dslx2ir")
                 .about("Converts DSLX to IR")
                 .add_dslx_input_args(true)
-                .add_bool_arg("opt", "Optimize the IR we emit as well"),
+                .add_bool_arg("opt", "Optimize the IR we emit as well")
+                .add_bool_arg(
+                    "type_inference_v2",
+                    "Enable the experimental type-inference v2 algorithm",
+                ),
         )
         // dslx2sv-types converts all the definitions in the .x file to SV types
         .subcommand(

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -355,7 +355,11 @@ fn main() {
         .subcommand(
             clap::Command::new("dslx-g8r-stats")
                 .about("Emit gate-level summary stats for a DSLX entry point")
-                .add_dslx_input_args(true),
+                .add_dslx_input_args(true)
+                .add_bool_arg(
+                    "type_inference_v2",
+                    "Enable the experimental type-inference v2 algorithm",
+                ),
         )
         // ir2opt subcommand requires a top symbol
         .subcommand(

--- a/xlsynth-driver/src/tools.rs
+++ b/xlsynth-driver/src/tools.rs
@@ -86,6 +86,7 @@ pub fn run_ir_converter_main(
     tool_path: &str,
     enable_warnings: Option<&[String]>,
     disable_warnings: Option<&[String]>,
+    type_inference_v2: Option<bool>,
 ) -> String {
     log::info!(
         "run_ir_converter_main; enable_warnings: {:?}; disable_warnings: {:?}",
@@ -123,6 +124,11 @@ pub fn run_ir_converter_main(
         command
             .arg("--disable_warnings")
             .arg(disable_warnings.join(","));
+    }
+
+    // Pass through the experimental type inference flag if requested.
+    if let Some(true) = type_inference_v2 {
+        command.arg("--type_inference_v2");
     }
 
     log::info!("command: {:?}", command);

--- a/xlsynth-driver/tests/invoke_test.rs
+++ b/xlsynth-driver/tests/invoke_test.rs
@@ -1978,6 +1978,7 @@ top fn my_main() -> bits[32] {
         assert!(!has_asserts, "Did not expect invariant assertions when --add_invariant_assertions=false, but some were found. stdout: {}", stdout);
     }
 }
+
 #[test_case(true; "with_tool_path")]
 #[test_case(false; "without_tool_path")]
 fn test_dslx_g8r_stats_subcommand(use_tool_path: bool) {
@@ -2052,4 +2053,97 @@ fn test_ir_fn_eval() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert_eq!(String::from_utf8_lossy(&output.stdout), "bits[32]:3\n");
+}
+
+// Add tests for type inference v2 slice bounds behavior
+#[test_case(true; "with_tool_path")]
+#[test_case(false; "without_tool_path")]
+fn test_tiv1_slice_oob_allows_compilation(use_tool_path: bool) {
+    let _ = env_logger::builder().is_test(true).try_init();
+    // DSLX attempting to slice starting at bit 32 of a 32-bit value.
+    let dslx = "fn f(x: u32) -> u32 { x[32 +: u32] }";
+    let temp_dir = tempfile::tempdir().unwrap();
+    let dslx_path = temp_dir.path().join("f.x");
+    std::fs::write(&dslx_path, dslx).unwrap();
+
+    // Prepare toolchain.toml
+    let toolchain_path = temp_dir.path().join("xlsynth-toolchain.toml");
+    let toolchain_toml = "[toolchain]\n";
+    let toolchain_contents = if use_tool_path {
+        add_tool_path_value(toolchain_toml)
+    } else {
+        toolchain_toml.to_string()
+    };
+    std::fs::write(&toolchain_path, toolchain_contents).unwrap();
+
+    let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
+
+    // Run without --type_inference_v2 flag (tiv1).
+    let output = std::process::Command::new(command_path)
+        .arg("--toolchain")
+        .arg(toolchain_path.to_str().unwrap())
+        .arg("dslx2ir")
+        .arg("--dslx_input_file")
+        .arg(dslx_path.to_str().unwrap())
+        .arg("--dslx_top")
+        .arg("f")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "tiv1 compile should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test_case(true; "with_tool_path")]
+#[test_case(false; "without_tool_path")]
+fn test_tiv2_slice_oob_is_error(use_tool_path: bool) {
+    let _ = env_logger::builder().is_test(true).try_init();
+    // Same DSLX code as above.
+    let dslx = "fn f(x: u32) -> u32 { x[32 +: u32] }";
+    let temp_dir = tempfile::tempdir().unwrap();
+    let dslx_path = temp_dir.path().join("f.x");
+    std::fs::write(&dslx_path, dslx).unwrap();
+
+    // Prepare toolchain.toml
+    let toolchain_path = temp_dir.path().join("xlsynth-toolchain.toml");
+    let toolchain_toml = "[toolchain]\n";
+    let toolchain_contents = if use_tool_path {
+        add_tool_path_value(toolchain_toml)
+    } else {
+        toolchain_toml.to_string()
+    };
+    std::fs::write(&toolchain_path, toolchain_contents).unwrap();
+
+    let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
+
+    // Pass --type_inference_v2=true
+    let output = std::process::Command::new(command_path)
+        .arg("--toolchain")
+        .arg(toolchain_path.to_str().unwrap())
+        .arg("dslx2ir")
+        .arg("--dslx_input_file")
+        .arg(dslx_path.to_str().unwrap())
+        .arg("--dslx_top")
+        .arg("f")
+        .arg("--type_inference_v2=true")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "tiv2 compile should fail; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Optionally, ensure the stderr mentions slice or bounds.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.to_lowercase().contains("slice") || stderr.to_lowercase().contains("bound"),
+        "expected slice/bound error message, got: {}",
+        stderr
+    );
 }

--- a/xlsynth-driver/tests/invoke_test.rs
+++ b/xlsynth-driver/tests/invoke_test.rs
@@ -2097,8 +2097,9 @@ fn test_tiv1_slice_oob_allows_compilation(use_tool_path: bool) {
     );
 }
 
+/// TODO(cdleary): 2025-06-10 This only works when there is a tool path
+/// available because the runtime APIs don't support specifying TIv2.
 #[test_case(true; "with_tool_path")]
-#[test_case(false; "without_tool_path")]
 fn test_tiv2_slice_oob_is_error(use_tool_path: bool) {
     let _ = env_logger::builder().is_test(true).try_init();
     // Same DSLX code as above.

--- a/xlsynth-g8r/src/bin/mcmc-driver.rs
+++ b/xlsynth-g8r/src/bin/mcmc-driver.rs
@@ -297,21 +297,6 @@ fn run_explore_exploit(
                         let global_best_cost = best_cl.cost.load(Ordering::SeqCst);
                         if metric_val > global_best_cost + cfg_cl.initial_temperature as usize {
                             local_gfn = best_cl.get();
-                            // Next segment: explore with full temperature to
-                            // differentiate search direction.
-                            segment_temperature = if chain_no == 0 {
-                                explorer_temp
-                            } else {
-                                cfg_cl.initial_temperature
-                            };
-                        } else {
-                            // Otherwise revert to (or keep) the chain's base temperature.
-                            if chain_no != 0 {
-                                segment_temperature = segment_temperature
-                                    .max(MIN_TEMP_RATIO * cfg_cl.initial_temperature);
-                            } else {
-                                segment_temperature = explorer_temp;
-                            }
                         }
                     }
                     Err(e) => {

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.0.200";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.0.202";
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 3;
 
 struct DsoInfo {


### PR DESCRIPTION
The main benefit of this flag is that it enables an attempt at migrating .x files with no associated source text changes (e.g. that would change the position metadata in the resulting IR file)

This flag may be short lived as it will likely be the default mode when TIv1 is deleted, but it may assist with migration testing.