### PR TITLE
Add ir-equiv-batch command with reusable Boolector context

### DIFF
--- a/xlsynth-driver/src/ir_equiv_batch.rs
+++ b/xlsynth-driver/src/ir_equiv_batch.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::toolchain_config::ToolchainConfig;
+use clap::ArgMatches;
+
+#[cfg(feature = "has-boolector")]
+use xlsynth_g8r::ir_equiv_boolector::{self, Ctx};
+#[cfg(feature = "has-boolector")]
+use xlsynth_g8r::xls_ir::ir_parser;
+
+#[cfg(feature = "has-boolector")]
+use xlsynth_g8r::ir_equiv_boolector::EquivResult;
+
+/// Runs a Boolector equivalence check using the given context.
+#[cfg(feature = "has-boolector")]
+fn run_check_with_ctx(
+    lhs_path: &std::path::Path,
+    rhs_path: &std::path::Path,
+    lhs_top: Option<&str>,
+    rhs_top: Option<&str>,
+    flatten_aggregates: bool,
+    drop_params: &[String],
+    ctx: &Ctx,
+) -> bool {
+    let lhs_pkg = match ir_parser::parse_path_to_package(lhs_path) {
+        Ok(pkg) => pkg,
+        Err(e) => {
+            eprintln!("Failed to parse lhs IR file: {}", e);
+            return false;
+        }
+    };
+    let rhs_pkg = match ir_parser::parse_path_to_package(rhs_path) {
+        Ok(pkg) => pkg,
+        Err(e) => {
+            eprintln!("Failed to parse rhs IR file: {}", e);
+            return false;
+        }
+    };
+    let lhs_fn = if let Some(top_name) = lhs_top {
+        lhs_pkg.get_fn(top_name).cloned().unwrap_or_else(|| {
+            eprintln!("Top function '{}' not found in lhs IR file", top_name);
+            std::process::exit(1);
+        })
+    } else {
+        lhs_pkg.get_top().cloned().unwrap_or_else(|| {
+            eprintln!("No top function found in lhs IR file");
+            std::process::exit(1);
+        })
+    };
+    let rhs_fn = if let Some(top_name) = rhs_top {
+        rhs_pkg.get_fn(top_name).cloned().unwrap_or_else(|| {
+            eprintln!("Top function '{}' not found in rhs IR file", top_name);
+            std::process::exit(1);
+        })
+    } else {
+        rhs_pkg.get_top().cloned().unwrap_or_else(|| {
+            eprintln!("No top function found in rhs IR file");
+            std::process::exit(1);
+        })
+    };
+    let lhs_fn = lhs_fn
+        .drop_params(drop_params)
+        .expect("Dropped parameter is used in the function body!");
+    let rhs_fn = rhs_fn
+        .drop_params(drop_params)
+        .expect("Dropped parameter is used in the function body!");
+    let result = if flatten_aggregates {
+        xlsynth_g8r::ir_equiv_boolector::prove_ir_equiv_flattened_with_ctx(&lhs_fn, &rhs_fn, ctx)
+    } else {
+        xlsynth_g8r::ir_equiv_boolector::prove_ir_fn_equiv_with_ctx(&lhs_fn, &rhs_fn, ctx)
+    };
+    match result {
+        EquivResult::Proved => {
+            println!("success: Boolector proved equivalence");
+            true
+        }
+        EquivResult::Disproved(cex) => {
+            println!("failure: Boolector found counterexample: {:?}", cex);
+            false
+        }
+    }
+}
+
+pub fn handle_ir_equiv_batch(matches: &ArgMatches, _config: &Option<ToolchainConfig>) {
+    #[cfg(not(feature = "has-boolector"))]
+    {
+        eprintln!("error: ir-equiv-batch requires --features=with-boolector-built or --features=with-boolector-system");
+        std::process::exit(1);
+    }
+    #[cfg(feature = "has-boolector")]
+    {
+        let files: Vec<String> = matches
+            .get_many::<String>("ir_files")
+            .unwrap()
+            .map(|s| s.to_string())
+            .collect();
+        if files.len() % 2 != 0 {
+            eprintln!("Error: expected an even number of IR files");
+            std::process::exit(1);
+        }
+        let mut lhs_top = matches.get_one::<String>("lhs_ir_top").map(|s| s.as_str());
+        let mut rhs_top = matches.get_one::<String>("rhs_ir_top").map(|s| s.as_str());
+        let top = matches.get_one::<String>("ir_top");
+        if top.is_some() && (lhs_top.is_some() || rhs_top.is_some()) {
+            eprintln!("Error: --ir_top and --lhs_ir_top/--rhs_ir_top cannot be used together");
+            std::process::exit(1);
+        }
+        if lhs_top.is_some() ^ rhs_top.is_some() {
+            eprintln!("Error: --lhs_ir_top and --rhs_ir_top must be used together");
+            std::process::exit(1);
+        }
+        if let Some(t) = top {
+            lhs_top = Some(t.as_str());
+            rhs_top = Some(t.as_str());
+        }
+        let flatten_aggregates = matches
+            .get_one::<String>("flatten_aggregates")
+            .map(|s| s == "true")
+            .unwrap_or(false);
+        let drop_params: Vec<String> = matches
+            .get_one::<String>("drop_params")
+            .map(|s| s.split(',').map(|x| x.trim().to_string()).collect())
+            .unwrap_or_else(Vec::new);
+        let ctx = Ctx::new();
+        let mut all_equiv = true;
+        for pair in files.chunks(2) {
+            let lhs_path = std::path::Path::new(&pair[0]);
+            let rhs_path = std::path::Path::new(&pair[1]);
+            let ok = run_check_with_ctx(
+                lhs_path,
+                rhs_path,
+                lhs_top,
+                rhs_top,
+                flatten_aggregates,
+                &drop_params,
+                &ctx,
+            );
+            if !ok {
+                all_equiv = false;
+            }
+        }
+        if all_equiv {
+            std::process::exit(0);
+        } else {
+            std::process::exit(1);
+        }
+    }
+}

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -48,6 +48,7 @@ mod ir2gates;
 mod ir2opt;
 mod ir2pipeline;
 mod ir_equiv;
+mod ir_equiv_batch;
 mod ir_fn_eval;
 mod ir_ged;
 mod lib2proto;
@@ -474,6 +475,37 @@ fn main() {
                 ),
         )
         .subcommand(
+            clap::Command::new("ir-equiv-batch")
+                .about("Checks equivalence for pairs of IR files using a shared Boolector context")
+                .arg(
+                    Arg::new("ir_files")
+                        .help("Pairs of IR files: lhs1 rhs1 lhs2 rhs2 ...")
+                        .required(true)
+                        .num_args(2..),
+                )
+                .add_ir_top_arg(false)
+                .arg(
+                    Arg::new("lhs_ir_top")
+                        .long("lhs_ir_top")
+                        .help("The top-level entry point for the left-hand side IR"),
+                )
+                .arg(
+                    Arg::new("rhs_ir_top")
+                        .long("rhs_ir_top")
+                        .help("The top-level entry point for the right-hand side IR"),
+                )
+                .add_bool_arg(
+                    "flatten_aggregates",
+                    "Flatten tuple and array types to bits for equivalence checking",
+                )
+                .arg(
+                    Arg::new("drop_params")
+                        .long("drop_params")
+                        .help("Comma-separated list of parameter names to drop from both functions before equivalence checking")
+                        .action(ArgAction::Set),
+                ),
+        )
+        .subcommand(
             clap::Command::new("ir-ged")
                 .about("Tells the Graph Edit Distance between two IR functions")
                 .arg(
@@ -728,6 +760,8 @@ fn main() {
         ir2delayinfo::handle_ir2delayinfo(matches, &config);
     } else if let Some(matches) = matches.subcommand_matches("ir-equiv") {
         ir_equiv::handle_ir_equiv(matches, &config);
+    } else if let Some(matches) = matches.subcommand_matches("ir-equiv-batch") {
+        ir_equiv_batch::handle_ir_equiv_batch(matches, &config);
     } else if let Some(matches) = matches.subcommand_matches("ir-ged") {
         ir_ged::handle_ir_ged(matches, &config);
     } else if let Some(matches) = matches.subcommand_matches("ir2gates") {


### PR DESCRIPTION
## Summary
- share Boolector context across IR equivalence checks
- support new `ir-equiv-batch` subcommand

## Testing
- `pre-commit run --all-files`
- `cargo test -p xlsynth-test-helpers check_all_rust_files_for_spdx`

------
https://chatgpt.com/codex/tasks/task_i_6849bab052108323bf2f91f98c4d9e36