### PR TITLE
Expose a DSO_PATH that works properly from build.rs under cross-compilation.

### DIFF
--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -354,6 +354,7 @@ fn main() {
         );
         let dso_name = &dso_name[3..];
         println!("cargo:rustc-env=XLS_DSO_PATH={}", dso_path.display());
+        println!("cargo:DSO_PATH={}", dso_path.display());
         println!("cargo:rustc-env=DSLX_STDLIB_PATH={stdlib_path_string}");
         println!("cargo:rustc-link-search=native={}", dso_dir.display());
         println!("cargo:rustc-link-lib=dylib={dso_name}");
@@ -445,6 +446,7 @@ fn main() {
         let dso_name_str = dso_info.get_dso_name();
         println!("cargo:rustc-link-lib=dylib={dso_name_str}");
         println!("cargo:rustc-env=XLS_DSO_PATH={out_dir}");
+        println!("cargo:DSO_PATH={out_dir}");
         return;
     }
 
@@ -455,5 +457,15 @@ fn main() {
     println!("cargo:rustc-link-search=native={out_dir}");
     let dso_name_str = dso_info.get_dso_name();
     println!("cargo:rustc-link-lib=dylib={dso_name_str}");
+
+    // This is exposed as `xlsynth_sys::XLS_DSO_PATH` from rust via
+    // xlsynth-sys/src/lib.rs.  DO NOT USE THIS FROM WITHIN YOUR build.rs.  See
+    // the definition in lib.rs for an explanation.
     println!("cargo:rustc-env=XLS_DSO_PATH={out_dir}");
+
+    // Path to the directory containing the DSO.  This is the one you should use
+    // from build.rs.  The build.rs of a dependent crate can read this value via
+    // the DEP_XLSYNTH_DSO_PATH envvar.  See
+    // https://doc.rust-lang.org/cargo/reference/build-script-examples.html#using-another-sys-crate.
+    println!("cargo:DSO_PATH={out_dir}");
 }

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -1377,4 +1377,34 @@ extern "C" {
 }
 
 pub const DSLX_STDLIB_PATH: &str = env!("DSLX_STDLIB_PATH");
+
+/// Directory containing the libxls DSO.
+///
+/// *** DO NOT USE THIS VARIABLE FROM WITHIN YOUR build.rs ***
+///
+/// You might be tempted to write the following in your build.rs:
+///
+/// ```ignore
+/// // DO NOT DO THIS IN YOUR build.rs!!
+/// let dylib_dirpath = xlsynth_sys::XLS_DSO_PATH;
+/// // set rpath to dylib_dirpath or something.
+/// ```
+///
+/// The problem is that build.rs is compiled for host, whereas if you're setting
+/// an rpath (or something similar) you want to get the path from compiling
+/// xlsynth_sys for *target*.  In other words, the above will break
+/// cross-compilation.
+///
+/// Instead, your build.rs should get the path from an envvar which:
+///
+/// ```ignore
+/// // Do this from your build.rs instead.
+/// let dylib_path = std::env::var("DEP_XLSYNTH_DSO_PATH").unwrap();
+/// ```
+///
+/// More details are available at
+/// <https://doc.rust-lang.org/cargo/reference/build-script-examples.html#using-another-sys-crate>.
+///
+/// (If you use this envvar from your crate proper -- i.e. not from build.rs --
+/// then it's perfectly fine.)
 pub const XLS_DSO_PATH: &str = env!("XLS_DSO_PATH");


### PR DESCRIPTION
It is subtly wrong to use the Rust global xlsynth_sys::XLS_DSO_PATH from a
build.rs.  Instead you should read the new envvar DEP_XLSYNTH_DSO_PATH.
See explanation in the commit itself.
