### PR TITLE
Improve ir-equiv-batch reporting

### DIFF
--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -503,6 +503,10 @@ fn main() {
                         .long("drop_params")
                         .help("Comma-separated list of parameter names to drop from both functions before equivalence checking")
                         .action(ArgAction::Set),
+                )
+                .add_bool_arg(
+                    "stop_on_failure",
+                    "Stop processing further pairs on first failure",
                 ),
         )
         .subcommand(


### PR DESCRIPTION
## Summary
- print the IR files and top functions when ir-equiv-batch proves them equivalent
- print file/function info when a counterexample is found and show how long each check took
- add `--stop_on_failure` option so users can terminate on first failure

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_i_684a1f0b94588323844802335cd603d0