### PR TITLE
Add IrBits::u32

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ fn sample() -> Result<IrValue, XlsynthError> {
     let package: IrPackage = converted.ir;
     let mangled = xlsynth::mangle_dslx_name("sample", "id")?;
     let f: IrFunction = package.get_function(&mangled)?;
-    let mol: IrValue = IrValue::make_ubits(32, 42)?;
+    let mol: IrValue = IrValue::u32(42);
 
     // Use the IR interpreter.
     let interp_result: IrValue = f.interpret(&[mol.clone()])?;
@@ -28,7 +28,7 @@ fn sample() -> Result<IrValue, XlsynthError> {
 }
 
 fn main() {
-    assert_eq!(sample().unwrap(), IrValue::make_ubits(32, 42).unwrap());
+    assert_eq!(sample().unwrap(), IrValue::u32(42));
 }
 ```
 

--- a/xlsynth-g8r/src/gate2ir.rs
+++ b/xlsynth-g8r/src/gate2ir.rs
@@ -52,7 +52,7 @@ fn flatten(param: &BValue, ty: &ir::Type, fb: &mut FnBuilder) -> BValue {
         }) => {
             let mut elements = Vec::new();
             for i in 0..*element_count {
-                let index = fb.literal(&IrValue::make_ubits(32, i as u64).unwrap(), None);
+                let index = fb.literal(&IrValue::u32(i as u32), None);
                 let element = fb.array_index(param, &index, None);
                 elements.push(flatten(&element, element_type, fb));
             }

--- a/xlsynth/src/ir_builder.rs
+++ b/xlsynth/src/ir_builder.rs
@@ -733,13 +733,8 @@ fn f(x: bits[32] id=1, y: bits[32] id=2) -> (bits[32], bits[32]) {
         let result = builder.add(&a, &b, None);
         let f = builder.build_with_return_value(&result).unwrap();
 
-        let result = f
-            .interpret(&[
-                IrValue::make_ubits(32, 1).unwrap(),
-                IrValue::make_ubits(32, 2).unwrap(),
-            ])
-            .unwrap();
-        assert_eq!(result, IrValue::make_ubits(32, 3).unwrap());
+        let result = f.interpret(&[IrValue::u32(1), IrValue::u32(2)]).unwrap();
+        assert_eq!(result, IrValue::u32(3));
     }
 
     #[test]

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -28,6 +28,11 @@ impl IrBits {
         xls_bits_make_sbits(bit_count, value)
     }
 
+    pub fn u32(value: u32) -> Self {
+        // Unwrap should be ok since the u32 always fits.
+        Self::make_ubits(32, value as u64).unwrap()
+    }
+
     pub fn get_bit_count(&self) -> usize {
         let bit_count = unsafe { xlsynth_sys::xls_bits_get_bit_count(self.ptr) };
         assert!(bit_count >= 0);
@@ -617,7 +622,7 @@ mod tests {
         let bits = v.to_bits().expect("to_bits success");
 
         // Equality comparison.
-        let v2 = IrValue::make_ubits(32, 42).expect("make_ubits success");
+        let v2 = IrValue::u32(42);
         assert_eq!(v, v2);
 
         // Getting at bit values; 42 = 0b101010.
@@ -680,26 +685,24 @@ mod tests {
 
     #[test]
     fn test_ir_bits_add_two_plus_three() {
-        let two = IrBits::make_ubits(32, 2).expect("make_ubits success");
-        let three = IrBits::make_ubits(32, 3).expect("make_ubits success");
+        let two = IrBits::u32(2);
+        let three = IrBits::u32(3);
         let sum = two + three;
         assert_eq!(sum.to_string(), "bits[32]:5");
     }
 
     #[test]
     fn test_ir_bits_umul_two_times_three() {
-        let two = IrBits::make_ubits(32, 2).expect("make_ubits success");
-        let three = IrBits::make_ubits(32, 3).expect("make_ubits success");
+        let two = IrBits::u32(2);
+        let three = IrBits::u32(3);
         let product = two.umul(&three);
         assert_eq!(product.to_string(), "bits[64]:6");
     }
 
     #[test]
     fn test_ir_bits_smul_two_times_neg_three() {
-        let two = IrBits::make_ubits(32, 2).expect("make_ubits success");
-        let neg_three = IrBits::make_ubits(32, 3)
-            .expect("make_ubits success")
-            .negate();
+        let two = IrBits::u32(2);
+        let neg_three = IrBits::u32(3).negate();
         let product = two.smul(&neg_three);
         assert_eq!(product.msb(), true);
         assert_eq!(product.abs().to_string(), "bits[64]:6");
@@ -707,52 +710,58 @@ mod tests {
 
     #[test]
     fn test_ir_bits_width_slice() {
-        let bits = IrBits::make_ubits(32, 0x12345678).expect("make_ubits success");
+        let bits = IrBits::u32(0x12345678);
         let slice = bits.width_slice(8, 16);
         assert_eq!(slice.to_hex_string(), "bits[16]:0x3456");
     }
 
     #[test]
     fn test_ir_bits_shll() {
-        let bits = IrBits::make_ubits(32, 0x12345678).expect("make_ubits success");
+        let bits = IrBits::u32(0x12345678);
         let shifted = bits.shll(8);
         assert_eq!(shifted.to_hex_string(), "bits[32]:0x3456_7800");
     }
 
     #[test]
     fn test_ir_bits_shrl() {
-        let bits = IrBits::make_ubits(32, 0x12345678).expect("make_ubits success");
+        let bits = IrBits::u32(0x12345678);
         let shifted = bits.shrl(8);
         assert_eq!(shifted.to_hex_string(), "bits[32]:0x12_3456");
     }
 
     #[test]
     fn test_ir_bits_shra() {
-        let bits = IrBits::make_ubits(32, 0x92345678).expect("make_ubits success");
+        let bits = IrBits::u32(0x92345678);
         let shifted = bits.shra(8);
         assert_eq!(shifted.to_hex_string(), "bits[32]:0xff92_3456");
     }
 
     #[test]
+    fn test_ir_bits_u32() {
+        let bits = IrBits::u32(0x12345678);
+        assert_eq!(bits.to_hex_string(), "bits[32]:0x1234_5678");
+    }
+
+    #[test]
     fn test_ir_bits_and() {
-        let lhs = IrBits::make_ubits(32, 0x5a5a5a5a).expect("make_ubits success");
-        let rhs = IrBits::make_ubits(32, 0xa5a5a5a5).expect("make_ubits success");
+        let lhs = IrBits::u32(0x5a5a5a5a);
+        let rhs = IrBits::u32(0xa5a5a5a5);
         assert_eq!(lhs.and(&rhs).to_hex_string(), "bits[32]:0x0");
         assert_eq!(lhs.and(&rhs.not()).to_hex_string(), "bits[32]:0x5a5a_5a5a");
     }
 
     #[test]
     fn test_ir_bits_or() {
-        let lhs = IrBits::make_ubits(32, 0x5a5a5a5a).expect("make_ubits success");
-        let rhs = IrBits::make_ubits(32, 0xa5a5a5a5).expect("make_ubits success");
+        let lhs = IrBits::u32(0x5a5a5a5a);
+        let rhs = IrBits::u32(0xa5a5a5a5);
         assert_eq!(lhs.or(&rhs).to_hex_string(), "bits[32]:0xffff_ffff");
         assert_eq!(lhs.or(&rhs.not()).to_hex_string(), "bits[32]:0x5a5a_5a5a");
     }
 
     #[test]
     fn test_ir_bits_xor() {
-        let lhs = IrBits::make_ubits(32, 0x5a5a5a5a).expect("make_ubits success");
-        let rhs = IrBits::make_ubits(32, 0xa5a5a5a5).expect("make_ubits success");
+        let lhs = IrBits::u32(0x5a5a5a5a);
+        let rhs = IrBits::u32(0xa5a5a5a5);
         assert_eq!(lhs.xor(&rhs).to_hex_string(), "bits[32]:0xffff_ffff");
         assert_eq!(lhs.xor(&rhs.not()).to_hex_string(), "bits[32]:0x0");
     }


### PR DESCRIPTION
## Summary
- add `IrBits::u32` helper for easy creation of 32-bit values
- refactor tests and examples to use the new helper
- simplify constants with `IrValue::u32`

## Testing
- `pre-commit run --all-files`
- `cargo test -p xlsynth-test-helpers check_all_rust_files_for_spdx`
- `cargo test -p xlsynth`


------
https://chatgpt.com/codex/tasks/task_i_684db667ade88323b80a85d26f146971