### PR TITLE
Add pipeline simulation helper and test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,7 @@ cargo test -p xlsynth-test-helpers check_all_rust_files_for_spdx
 ## Deterministic Output
 
 All tools, and especially the `xlsynth-driver` subcommands, are expected to produce deterministic output. This is critical for test stability and reproducibility. While hash maps (`HashMap`) can be used internally for performance, they must not cause observable run-to-run nondeterminism in any output (e.g., emitted Verilog, SystemVerilog, or other netlists). If the order of items in a map affects output, a stably ordered map (such as `BTreeMap`) or explicit sorting should be used before emitting output.
+
+## Style
+
+Prefer using raw string syntax (`r#"..."#`) for multi-line SystemVerilog testbench strings to avoid needless escaping.

--- a/xlsynth-test-helpers/src/lib.rs
+++ b/xlsynth-test-helpers/src/lib.rs
@@ -4,6 +4,6 @@ mod assert_valid_sv;
 mod simulate_sv;
 
 pub use assert_valid_sv::{assert_valid_sv, assert_valid_sv_flist, FlistEntry};
-pub use simulate_sv::simulate_sv_flist;
+pub use simulate_sv::{simulate_pipeline_single_pulse, simulate_sv_flist};
 
 pub mod ir_fuzz;


### PR DESCRIPTION
## Summary
- enhance instructions about using raw strings for multiline SV in `AGENTS.md`
- extend `simulate_pipeline_single_pulse` to handle multiple inputs via `IrBits`
- add regression test that builds and simulates a small pipeline

## Testing
- `pre-commit run --files xlsynth-test-helpers/src/simulate_sv.rs xlsynth-driver/tests/invoke_test.rs AGENTS.md`
- `cargo test --workspace --exclude xlsynth-sys`

------
https://chatgpt.com/codex/tasks/task_i_68507bc52a7c83238aae116806253306