### PR TITLE
Starter implementation for case splitting on inputs

### DIFF
--- a/xlsynth-driver/src/ir_equiv.rs
+++ b/xlsynth-driver/src/ir_equiv.rs
@@ -15,6 +15,7 @@ use xlsynth_g8r::xls_ir::ir_parser;
 enum ParallelismStrategy {
     SingleThreaded,
     OutputBits,
+    InputBitSplit,
 }
 
 #[cfg(feature = "has-boolector")]
@@ -24,6 +25,7 @@ impl std::str::FromStr for ParallelismStrategy {
         match s {
             "single-threaded" => Ok(Self::SingleThreaded),
             "output-bits" => Ok(Self::OutputBits),
+            "input-bit-split" => Ok(Self::InputBitSplit),
             _ => Err(format!("invalid parallelism strategy: {}", s)),
         }
     }
@@ -152,6 +154,14 @@ fn run_boolector_equiv_check(
                 &lhs_fn,
                 &rhs_fn,
                 flatten_aggregates,
+            )
+        }
+        // Split on the first parameter and the first bit for now.
+        // TODO: introduce better heuristics like picking the maximal-fan-out bit or
+        // divide-and-conquer dynamically on more and more bits.
+        ParallelismStrategy::InputBitSplit => {
+            xlsynth_g8r::ir_equiv_boolector::prove_ir_fn_equiv_split_input_bit(
+                &lhs_fn, &rhs_fn, 0, 0,
             )
         }
     };

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -495,7 +495,7 @@ fn main() {
                         .long("parallelism-strategy")
                         .value_name("STRATEGY")
                         .help("Parallelism strategy when using Boolector")
-                        .value_parser(["single-threaded", "output-bits"])
+                        .value_parser(["single-threaded", "output-bits", "input-bit-split"])
                         .default_value("single-threaded")
                         .action(ArgAction::Set),
                 ),


### PR DESCRIPTION
# Summary
Introduce a **starter** implementation of input-bit case-splitting for equivalence proofs.

- The prover fixes the first bit of the first parameter to 0 and 1 and checks both sub-cases.
- Adds a parallelism strategy `input-bit-split` for the driver to invoke the heuristic.

# Current Stage

- No test is provided---It is in draft stage and I would love to have our understanding aligned before proceeding. After that I can add a simple one. I see no test for `prove_ir_fn_equiv_split_input_bit` either.
- The implementation is not parallelized for now. This is easy to add when we agree that we are on the right track. Would love to keep the pull request small and easy to review.
- The simple algorithm won't be able to solve the hard tasks.