### PR TITLE
Add combinational pipeline wrapper with valid flops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,15 @@ jobs:
 
       - name: Install Icarus Verilog
         run: |
+          export DEBIAN_FRONTEND=noninteractive
+          # First, remove any existing iverilog.
+          sudo apt-get remove -y iverilog
+          echo "--- Verifying removal ---"
+          iverilog -V || echo "iverilog not found, as expected."
+          # Now, install build dependencies.
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends git autoconf bison flex gperf libreadline-dev zlib1g-dev build-essential
+          # And build from source.
           git clone https://github.com/steveicarus/iverilog.git /tmp/iverilog
           cd /tmp/iverilog
           git checkout ea26587b5ef485f2ca82a3e4364e58ec3307240f
@@ -137,7 +144,10 @@ jobs:
           ./configure --prefix=/usr
           make -j$(nproc)
           sudo make install
+          sudo ldconfig
           cd ..
+          echo "--- Verifying installation ---"
+          which iverilog
           iverilog -V
 
       - name: Set up Rust
@@ -254,8 +264,27 @@ jobs:
 
       - name: Install Icarus Verilog
         run: |
+          export DEBIAN_FRONTEND=noninteractive
+          # First, remove any existing iverilog.
+          sudo apt-get remove -y iverilog
+          echo "--- Verifying removal ---"
+          iverilog -V || echo "iverilog not found, as expected."
+          # Now, install build dependencies.
           sudo apt-get update
-          sudo apt-get install -y iverilog
+          sudo apt-get install -y --no-install-recommends git autoconf bison flex gperf libreadline-dev zlib1g-dev build-essential
+          # And build from source.
+          git clone https://github.com/steveicarus/iverilog.git /tmp/iverilog
+          cd /tmp/iverilog
+          git checkout ea26587b5ef485f2ca82a3e4364e58ec3307240f
+          sh autoconf.sh
+          ./configure --prefix=/usr
+          make -j$(nproc)
+          sudo make install
+          sudo ldconfig
+          cd ..
+          echo "--- Verifying installation ---"
+          which iverilog
+          iverilog -V
 
       - name: Install libc++ from llvm-18
         run: |

--- a/xlsynth-g8r/src/dslx_stitch_pipeline.rs
+++ b/xlsynth-g8r/src/dslx_stitch_pipeline.rs
@@ -221,7 +221,7 @@ pub fn stitch_pipeline(
                                                // this function (until we emit the file) by storing them in this Vec.
     let mut dynamic_types: Vec<xlsynth::vast::VastDataType> = Vec::new();
 
-    let mut wrapper = file.add_module(&format!("{top}_pipeline"));
+    let mut wrapper = file.add_module(top);
     let clk_port = wrapper.add_input("clk", &scalar_type);
 
     // Input ports come from first stage inputs excluding clk.
@@ -421,7 +421,7 @@ pub fn stitch_pipeline_with_valid(
     let scalar_type = file.make_scalar_type();
     let mut dynamic_types: Vec<xlsynth::vast::VastDataType> = Vec::new();
 
-    let mut wrapper = file.add_module(&format!("{top}_pipeline"));
+    let mut wrapper = file.add_module(top);
     let clk_port = wrapper.add_input("clk", &scalar_type);
     let rst_port = wrapper.add_input("rst", &scalar_type);
     let input_valid_port = wrapper.add_input("input_valid", &scalar_type);
@@ -621,7 +621,7 @@ mod tests {
         // Validate generated SV.
         xlsynth_test_helpers::assert_valid_sv(&result);
 
-        let golden_path = std::path::Path::new("tests/goldens/mul_add_pipeline.golden.sv");
+        let golden_path = std::path::Path::new("tests/goldens/mul_add.golden.sv");
         if std::env::var("XLSYNTH_UPDATE_GOLDEN").is_ok() || !golden_path.exists() {
             std::fs::write(golden_path, &result).expect("write golden");
         } else if golden_path.metadata().map(|m| m.len()).unwrap_or(0) == 0 {
@@ -649,7 +649,7 @@ mod tests {
         .unwrap();
         xlsynth_test_helpers::assert_valid_sv(&result);
 
-        let golden_path = std::path::Path::new("tests/goldens/foo_pipeline.golden.sv");
+        let golden_path = std::path::Path::new("tests/goldens/foo.golden.sv");
         if std::env::var("XLSYNTH_UPDATE_GOLDEN").is_ok() || !golden_path.exists() {
             std::fs::write(golden_path, &result).expect("write golden");
         } else if golden_path.metadata().map(|m| m.len()).unwrap_or(0) == 0 {
@@ -677,7 +677,7 @@ mod tests {
         .unwrap();
         xlsynth_test_helpers::assert_valid_sv(&result);
 
-        let golden_path = std::path::Path::new("tests/goldens/one_pipeline.golden.sv");
+        let golden_path = std::path::Path::new("tests/goldens/one.golden.sv");
         if std::env::var("XLSYNTH_UPDATE_GOLDEN").is_ok() || !golden_path.exists() {
             std::fs::write(golden_path, &result).expect("write golden");
         } else if golden_path.metadata().map(|m| m.len()).unwrap_or(0) == 0 {
@@ -711,7 +711,7 @@ mod tests {
         xlsynth_test_helpers::assert_valid_sv(&result);
 
         // Golden file check
-        let golden_path = std::path::Path::new("tests/goldens/foo_pipeline_with_valid.golden.sv");
+        let golden_path = std::path::Path::new("tests/goldens/foo_with_valid.golden.sv");
         if std::env::var("XLSYNTH_UPDATE_GOLDEN").is_ok() || !golden_path.exists() {
             std::fs::write(golden_path, &result).expect("write golden");
         } else if golden_path.metadata().map(|m| m.len()).unwrap_or(0) == 0 {
@@ -729,11 +729,7 @@ mod tests {
         let inputs = vec![("x", IrBits::u32(5))];
         let expected = IrBits::u32(8);
         let vcd = xlsynth_test_helpers::simulate_pipeline_single_pulse(
-            &result,
-            "foo_pipeline",
-            &inputs,
-            &expected,
-            2,
+            &result, "foo", &inputs, &expected, 2,
         )
         .expect("simulation succeeds");
         assert!(vcd.contains("$var"));

--- a/xlsynth-g8r/tests/goldens/foo.golden.sv
+++ b/xlsynth-g8r/tests/goldens/foo.golden.sv
@@ -1,0 +1,62 @@
+module foo_cycle0(
+  input wire clk,
+  input wire [63:0] s,
+  output wire [63:0] out
+);
+  // ===== Pipe stage 0:
+
+  // Registers for pipe stage 0:
+  reg [63:0] p0_s;
+  always_ff @ (posedge clk) begin
+    p0_s <= s;
+  end
+  assign out = p0_s;
+endmodule
+
+module foo_cycle1(
+  input wire clk,
+  input wire [63:0] s,
+  output wire [31:0] out
+);
+  // ===== Pipe stage 0:
+
+  // Registers for pipe stage 0:
+  reg [63:0] p0_s;
+  always_ff @ (posedge clk) begin
+    p0_s <= s;
+  end
+
+  // ===== Pipe stage 1:
+  wire [31:0] p1_s_a_comb;
+  wire [31:0] p1_s_b_comb;
+  wire [31:0] p1_add_11_comb;
+  assign p1_s_a_comb = p0_s[63:32];
+  assign p1_s_b_comb = p0_s[31:0];
+  assign p1_add_11_comb = p1_s_a_comb + p1_s_b_comb;
+
+  // Registers for pipe stage 1:
+  reg [31:0] p1_add_11;
+  always_ff @ (posedge clk) begin
+    p1_add_11 <= p1_add_11_comb;
+  end
+  assign out = p1_add_11;
+endmodule
+module foo(
+  input wire clk,
+  input wire [63:0] s,
+  output wire [31:0] out
+);
+  wire [63:0] stage0_out;
+  foo_cycle0 foo_cycle0_i (
+    .clk(clk),
+    .s(s),
+    .out(stage0_out)
+  );
+  wire [31:0] final_out;
+  foo_cycle1 foo_cycle1_i (
+    .clk(clk),
+    .s(stage0_out),
+    .out(final_out)
+  );
+  assign out = final_out;
+endmodule

--- a/xlsynth-g8r/tests/goldens/foo.golden.sv
+++ b/xlsynth-g8r/tests/goldens/foo.golden.sv
@@ -42,19 +42,16 @@ module foo_cycle1(
   assign out = p1_add_11;
 endmodule
 module foo(
-  input wire clk,
   input wire [63:0] s,
   output wire [31:0] out
 );
   wire [63:0] stage0_out;
   foo_cycle0 foo_cycle0_i (
-    .clk(clk),
     .s(s),
     .out(stage0_out)
   );
   wire [31:0] final_out;
   foo_cycle1 foo_cycle1_i (
-    .clk(clk),
     .s(stage0_out),
     .out(final_out)
   );

--- a/xlsynth-g8r/tests/goldens/foo_pipeline_with_valid.golden.sv
+++ b/xlsynth-g8r/tests/goldens/foo_pipeline_with_valid.golden.sv
@@ -1,0 +1,72 @@
+module foo_cycle0(
+  input wire clk,
+  input wire [31:0] x,
+  output wire [31:0] out
+);
+  // ===== Pipe stage 0:
+  wire [31:0] p0_literal_5_comb;
+  wire [31:0] p0_add_6_comb;
+  assign p0_literal_5_comb = 32'h0000_0001;
+  assign p0_add_6_comb = x + p0_literal_5_comb;
+  assign out = p0_add_6_comb;
+endmodule
+
+module foo_cycle1(
+  input wire clk,
+  input wire [31:0] y,
+  output wire [31:0] out
+);
+  // ===== Pipe stage 0:
+  wire [30:0] p0_bit_slice_17_comb;
+  wire [30:0] p0_literal_18_comb;
+  wire [30:0] p0_add_19_comb;
+  wire p0_bit_slice_20_comb;
+  wire [31:0] p0_concat_21_comb;
+  assign p0_bit_slice_17_comb = y[31:1];
+  assign p0_literal_18_comb = 31'h0000_0001;
+  assign p0_add_19_comb = p0_bit_slice_17_comb + p0_literal_18_comb;
+  assign p0_bit_slice_20_comb = y[0];
+  assign p0_concat_21_comb = {p0_add_19_comb, p0_bit_slice_20_comb};
+  assign out = p0_concat_21_comb;
+endmodule
+module foo_pipeline(
+  input wire clk,
+  input wire rst,
+  input wire input_valid,
+  input wire [31:0] x,
+  output wire [31:0] out,
+  output wire output_valid
+);
+  reg [31:0] p0_x;
+  reg p0_valid;
+  always_ff @ (posedge clk) begin
+    p0_x <= x;
+    p0_valid <= rst ? input_valid : 1'b0;
+  end
+  wire [31:0] stage0_out_comb;
+  foo_cycle0 foo_cycle0_i (
+    .clk(clk),
+    .x(p0_x),
+    .out(stage0_out_comb)
+  );
+  reg [31:0] p1_out;
+  reg p1_valid;
+  always_ff @ (posedge clk) begin
+    p1_out <= stage0_out_comb;
+    p1_valid <= rst ? p0_valid : 1'b0;
+  end
+  wire [31:0] stage1_out_comb;
+  foo_cycle1 foo_cycle1_i (
+    .clk(clk),
+    .y(p1_out),
+    .out(stage1_out_comb)
+  );
+  reg [31:0] p2_out;
+  reg p2_valid;
+  always_ff @ (posedge clk) begin
+    p2_out <= stage1_out_comb;
+    p2_valid <= rst ? p1_valid : 1'b0;
+  end
+  assign out = p2_out;
+  assign output_valid = p2_valid;
+endmodule

--- a/xlsynth-g8r/tests/goldens/foo_with_valid.golden.sv
+++ b/xlsynth-g8r/tests/goldens/foo_with_valid.golden.sv
@@ -1,0 +1,72 @@
+module foo_cycle0(
+  input wire clk,
+  input wire [31:0] x,
+  output wire [31:0] out
+);
+  // ===== Pipe stage 0:
+  wire [31:0] p0_literal_5_comb;
+  wire [31:0] p0_add_6_comb;
+  assign p0_literal_5_comb = 32'h0000_0001;
+  assign p0_add_6_comb = x + p0_literal_5_comb;
+  assign out = p0_add_6_comb;
+endmodule
+
+module foo_cycle1(
+  input wire clk,
+  input wire [31:0] y,
+  output wire [31:0] out
+);
+  // ===== Pipe stage 0:
+  wire [30:0] p0_bit_slice_17_comb;
+  wire [30:0] p0_literal_18_comb;
+  wire [30:0] p0_add_19_comb;
+  wire p0_bit_slice_20_comb;
+  wire [31:0] p0_concat_21_comb;
+  assign p0_bit_slice_17_comb = y[31:1];
+  assign p0_literal_18_comb = 31'h0000_0001;
+  assign p0_add_19_comb = p0_bit_slice_17_comb + p0_literal_18_comb;
+  assign p0_bit_slice_20_comb = y[0];
+  assign p0_concat_21_comb = {p0_add_19_comb, p0_bit_slice_20_comb};
+  assign out = p0_concat_21_comb;
+endmodule
+module foo(
+  input wire clk,
+  input wire rst,
+  input wire input_valid,
+  input wire [31:0] x,
+  output wire [31:0] out,
+  output wire output_valid
+);
+  reg [31:0] p0_x;
+  reg p0_valid;
+  always_ff @ (posedge clk) begin
+    p0_x <= x;
+    p0_valid <= rst ? input_valid : 1'b0;
+  end
+  wire [31:0] stage0_out_comb;
+  foo_cycle0 foo_cycle0_i (
+    .clk(clk),
+    .x(p0_x),
+    .out(stage0_out_comb)
+  );
+  reg [31:0] p1_out;
+  reg p1_valid;
+  always_ff @ (posedge clk) begin
+    p1_out <= stage0_out_comb;
+    p1_valid <= rst ? p0_valid : 1'b0;
+  end
+  wire [31:0] stage1_out_comb;
+  foo_cycle1 foo_cycle1_i (
+    .clk(clk),
+    .y(p1_out),
+    .out(stage1_out_comb)
+  );
+  reg [31:0] p2_out;
+  reg p2_valid;
+  always_ff @ (posedge clk) begin
+    p2_out <= stage1_out_comb;
+    p2_valid <= rst ? p1_valid : 1'b0;
+  end
+  assign out = p2_out;
+  assign output_valid = p2_valid;
+endmodule

--- a/xlsynth-g8r/tests/goldens/foo_with_valid.golden.sv
+++ b/xlsynth-g8r/tests/goldens/foo_with_valid.golden.sv
@@ -1,33 +1,29 @@
 module foo_cycle0(
-  input wire clk,
   input wire [31:0] x,
   output wire [31:0] out
 );
-  // ===== Pipe stage 0:
-  wire [31:0] p0_literal_5_comb;
-  wire [31:0] p0_add_6_comb;
-  assign p0_literal_5_comb = 32'h0000_0001;
-  assign p0_add_6_comb = x + p0_literal_5_comb;
-  assign out = p0_add_6_comb;
+  wire [31:0] literal_5;
+  wire [31:0] add_6;
+  assign literal_5 = 32'h0000_0001;
+  assign add_6 = x + literal_5;
+  assign out = add_6;
 endmodule
 
 module foo_cycle1(
-  input wire clk,
   input wire [31:0] y,
   output wire [31:0] out
 );
-  // ===== Pipe stage 0:
-  wire [30:0] p0_bit_slice_17_comb;
-  wire [30:0] p0_literal_18_comb;
-  wire [30:0] p0_add_19_comb;
-  wire p0_bit_slice_20_comb;
-  wire [31:0] p0_concat_21_comb;
-  assign p0_bit_slice_17_comb = y[31:1];
-  assign p0_literal_18_comb = 31'h0000_0001;
-  assign p0_add_19_comb = p0_bit_slice_17_comb + p0_literal_18_comb;
-  assign p0_bit_slice_20_comb = y[0];
-  assign p0_concat_21_comb = {p0_add_19_comb, p0_bit_slice_20_comb};
-  assign out = p0_concat_21_comb;
+  wire [30:0] bit_slice_17;
+  wire [30:0] literal_18;
+  wire [30:0] add_19;
+  wire bit_slice_20;
+  wire [31:0] concat_21;
+  assign bit_slice_17 = y[31:1];
+  assign literal_18 = 31'h0000_0001;
+  assign add_19 = bit_slice_17 + literal_18;
+  assign bit_slice_20 = y[0];
+  assign concat_21 = {add_19, bit_slice_20};
+  assign out = concat_21;
 endmodule
 module foo(
   input wire clk,
@@ -45,7 +41,6 @@ module foo(
   end
   wire [31:0] stage0_out_comb;
   foo_cycle0 foo_cycle0_i (
-    .clk(clk),
     .x(p0_x),
     .out(stage0_out_comb)
   );
@@ -57,7 +52,6 @@ module foo(
   end
   wire [31:0] stage1_out_comb;
   foo_cycle1 foo_cycle1_i (
-    .clk(clk),
     .y(p1_out),
     .out(stage1_out_comb)
   );

--- a/xlsynth-g8r/tests/goldens/mul_add.golden.sv
+++ b/xlsynth-g8r/tests/goldens/mul_add.golden.sv
@@ -61,7 +61,6 @@ module mul_add_cycle1(
   assign out = p1_add_15;
 endmodule
 module mul_add(
-  input wire clk,
   input wire [31:0] x,
   input wire [31:0] y,
   input wire [31:0] z,
@@ -69,7 +68,6 @@ module mul_add(
 );
   wire [63:0] stage0_out;
   mul_add_cycle0 mul_add_cycle0_i (
-    .clk(clk),
     .x(x),
     .y(y),
     .z(z),
@@ -77,7 +75,6 @@ module mul_add(
   );
   wire [31:0] final_out;
   mul_add_cycle1 mul_add_cycle1_i (
-    .clk(clk),
     .partial(stage0_out[63:32]),
     .z(stage0_out[31:0]),
     .out(final_out)

--- a/xlsynth-g8r/tests/goldens/mul_add.golden.sv
+++ b/xlsynth-g8r/tests/goldens/mul_add.golden.sv
@@ -1,0 +1,86 @@
+module mul_add_cycle0(
+  input wire clk,
+  input wire [31:0] x,
+  input wire [31:0] y,
+  input wire [31:0] z,
+  output wire [63:0] out
+);
+  // lint_off MULTIPLY
+  function automatic [31:0] umul32b_32b_x_32b (input reg [31:0] lhs, input reg [31:0] rhs);
+    begin
+      umul32b_32b_x_32b = lhs * rhs;
+    end
+  endfunction
+  // lint_on MULTIPLY
+
+  // ===== Pipe stage 0:
+
+  // Registers for pipe stage 0:
+  reg [31:0] p0_x;
+  reg [31:0] p0_y;
+  reg [31:0] p0_z;
+  always_ff @ (posedge clk) begin
+    p0_x <= x;
+    p0_y <= y;
+    p0_z <= z;
+  end
+
+  // ===== Pipe stage 1:
+  wire [31:0] p1_umul_15_comb;
+  wire [63:0] p1_tuple_16_comb;
+  assign p1_umul_15_comb = umul32b_32b_x_32b(p0_x, p0_y);
+  assign p1_tuple_16_comb = {p1_umul_15_comb, p0_z};
+  assign out = p1_tuple_16_comb;
+endmodule
+
+module mul_add_cycle1(
+  input wire clk,
+  input wire [31:0] partial,
+  input wire [31:0] z,
+  output wire [31:0] out
+);
+  // ===== Pipe stage 0:
+
+  // Registers for pipe stage 0:
+  reg [31:0] p0_partial;
+  reg [31:0] p0_z;
+  always_ff @ (posedge clk) begin
+    p0_partial <= partial;
+    p0_z <= z;
+  end
+
+  // ===== Pipe stage 1:
+  wire [31:0] p1_add_15_comb;
+  assign p1_add_15_comb = p0_partial + p0_z;
+
+  // Registers for pipe stage 1:
+  reg [31:0] p1_add_15;
+  always_ff @ (posedge clk) begin
+    p1_add_15 <= p1_add_15_comb;
+  end
+  assign out = p1_add_15;
+endmodule
+module mul_add(
+  input wire clk,
+  input wire [31:0] x,
+  input wire [31:0] y,
+  input wire [31:0] z,
+  output wire [31:0] out
+);
+  wire [63:0] stage0_out;
+  mul_add_cycle0 mul_add_cycle0_i (
+    .clk(clk),
+    .x(x),
+    .y(y),
+    .z(z),
+    .out(stage0_out)
+  );
+  wire [31:0] final_out;
+  mul_add_cycle1 mul_add_cycle1_i (
+    .clk(clk),
+    .partial(stage0_out[63:32]),
+    .z(stage0_out[31:0]),
+    .out(final_out)
+  );
+  assign out = final_out;
+endmodule

--- a/xlsynth-g8r/tests/goldens/one.golden.sv
+++ b/xlsynth-g8r/tests/goldens/one.golden.sv
@@ -1,0 +1,42 @@
+module one_cycle0(
+  input wire clk,
+  input wire [31:0] x,
+  input wire [31:0] y,
+  output wire [31:0] out
+);
+  // ===== Pipe stage 0:
+
+  // Registers for pipe stage 0:
+  reg [31:0] p0_x;
+  reg [31:0] p0_y;
+  always_ff @ (posedge clk) begin
+    p0_x <= x;
+    p0_y <= y;
+  end
+
+  // ===== Pipe stage 1:
+  wire [31:0] p1_add_10_comb;
+  assign p1_add_10_comb = p0_x + p0_y;
+
+  // Registers for pipe stage 1:
+  reg [31:0] p1_add_10;
+  always_ff @ (posedge clk) begin
+    p1_add_10 <= p1_add_10_comb;
+  end
+  assign out = p1_add_10;
+endmodule
+module one(
+  input wire clk,
+  input wire [31:0] x,
+  input wire [31:0] y,
+  output wire [31:0] out
+);
+  wire [31:0] final_out;
+  one_cycle0 one_cycle0_i (
+    .clk(clk),
+    .x(x),
+    .y(y),
+    .out(final_out)
+  );
+  assign out = final_out;
+endmodule

--- a/xlsynth-g8r/tests/goldens/one.golden.sv
+++ b/xlsynth-g8r/tests/goldens/one.golden.sv
@@ -26,14 +26,12 @@ module one_cycle0(
   assign out = p1_add_10;
 endmodule
 module one(
-  input wire clk,
   input wire [31:0] x,
   input wire [31:0] y,
   output wire [31:0] out
 );
   wire [31:0] final_out;
   one_cycle0 one_cycle0_i (
-    .clk(clk),
     .x(x),
     .y(y),
     .out(final_out)


### PR DESCRIPTION
## Summary
- create `stitch_pipeline_with_valid` that emits a pipeline wrapper
  using external valid flops and active‑low reset
- generate combinational stage modules (no flop inputs/outputs)
- test new wrapper with simulation
- fix pipeline scheduling and adjust test latency

## Testing
- `pre-commit run --all-files`
- `cargo fuzz check` (xlsynth-g8r fuzz targets)
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6854b58a5e28832088016770eb2b6f32