### PR TITLE
Add BitSliceUpdate gatify support

### DIFF
--- a/xlsynth-g8r/tests/gatify_tests.rs
+++ b/xlsynth-g8r/tests/gatify_tests.rs
@@ -396,6 +396,14 @@ bit_count_test_cases!(test_dynamic_bit_slice, |input_bits: u32, opt: Opt| -> () 
     );
 });
 
+bit_count_test_cases!(test_bit_slice_update, |input_bits: u32, opt: Opt| -> () {
+    do_test_dslx_conversion(
+        input_bits,
+        opt,
+        "fn do_bit_slice_update(x: uN[N], i: uN[N], u: uN[N]) -> uN[N] { bit_slice_update(x, i, u) }",
+    );
+});
+
 bit_count_test_cases!(test_shra_dslx_to_gates, |input_bits: u32, opt: Opt| -> () {
     do_test_dslx_conversion(
         input_bits,

--- a/xlsynth-g8r/tests/gatify_tests.rs
+++ b/xlsynth-g8r/tests/gatify_tests.rs
@@ -872,3 +872,21 @@ fn test_assert_macro_gatify(opt: Opt) {
     let ir_text = ir_package.to_string();
     do_test_ir_conversion_no_equiv(&ir_text, opt);
 }
+
+#[test]
+fn test_bit_slice_update_width_truncates_update() {
+    // Regression IR that previously caused a panic: update value wider than the
+    // destination bits. Now we expect successful lowering and semantic
+    // equivalence.
+    let ir_text = "package fuzz_test
+fn fuzz_test(input: bits[7]) -> bits[1] {
+  literal.2: bits[1] = literal(value=0, id=2)
+  ret bit_slice_update.3: bits[1] = bit_slice_update(literal.2, input, input)
+}
+";
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    // Use existing helper to convert and validate equivalence.
+    do_test_ir_conversion(ir_text, Opt::No);
+}


### PR DESCRIPTION
## Summary
- support `BitSliceUpdate` in `ir2gate`
- test bit_slice_update conversion

## Testing
- `pre-commit run --all-files`
- `cargo fuzz build` in `xlsynth-g8r/fuzz`
- `cargo test -p xlsynth-g8r --workspace --lib --tests`

------
https://chatgpt.com/codex/tasks/task_i_685645593a20832395d12b7fc07ca1b0