### PR TITLE
Fix parsing of after_all pos metadata

### DIFF
--- a/xlsynth-g8r/src/xls_ir/ir_parser.rs
+++ b/xlsynth-g8r/src/xls_ir/ir_parser.rs
@@ -845,6 +845,7 @@ impl Parser {
                         self.rest_of_line()
                     )));
                 }
+                self.maybe_drop_pos_attribute()?;
                 (ir::NodePayload::AfterAll(operands), maybe_id.unwrap())
             }
             "invoke" => {
@@ -1372,6 +1373,20 @@ fn bar(x: bits[8] id=3) -> bits[8] {
         let mut parser = Parser::new(input);
         let node = parser.parse_node(&mut node_env).unwrap();
         println!("{:?}", node);
+    }
+
+    #[test]
+    fn test_parse_after_all_node_with_pos() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let mut node_env = IrNodeEnv::new();
+        node_env.add(Some("trace".to_string()), 17, ir::NodeRef { index: 17 });
+        let input = "after_all.19: token = after_all(trace.17, id=19, pos=[(1,1,1)])";
+        let mut parser = Parser::new(input);
+        let node = parser.parse_node(&mut node_env).unwrap();
+        assert_eq!(
+            node.payload,
+            ir::NodePayload::AfterAll(vec![ir::NodeRef { index: 17 }])
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- handle `pos` metadata in after_all nodes
- test after_all parsing with position info

## Testing
- `cargo check --bin fuzz_gatify` in `xlsynth-g8r/fuzz`
- `cargo check --bins` in `xlsynth-g8r/fuzz`
- `cargo test -p xlsynth-test-helpers check_all_rust_files_for_spdx`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_i_6857123e00348323bd9012c84ad775a8