### PR TITLE
[g8r:xls_ir] Add source position retention in IR parser

### DIFF
--- a/xlsynth-g8r/src/xls_ir/ir.rs
+++ b/xlsynth-g8r/src/xls_ir/ir.rs
@@ -1001,12 +1001,29 @@ impl FileTable {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Pos {
+    pub fileno: usize,
+    pub lineno: usize,
+    pub colno: usize,
+}
+
+impl Pos {
+    pub fn to_human_string(&self, file_table: &FileTable) -> Option<String> {
+        let path = file_table.id_to_path.get(&self.fileno)?;
+        Some(format!("{}:{}:{}", path, self.lineno + 1, self.colno + 1))
+    }
+}
+
+pub type PosData = Vec<Pos>;
+
 #[derive(Debug)]
 pub struct Package {
     pub name: String,
     pub file_table: FileTable,
     pub fns: Vec<Fn>,
     pub top_name: Option<String>,
+    pub node_pos: Option<HashMap<usize, PosData>>,
 }
 
 impl Package {


### PR DESCRIPTION
## Summary
- retain position information during IR parsing
- store positions in new `Package::node_pos`
- add `Pos` structure with human-friendly formatting
- support parsing with or without position retention
- test for multi-file position data and no-pos case

## Testing
- `cargo check -p xlsynth-g8r`
- `cargo test -p xlsynth-g8r --lib --tests`
- `cargo build --manifest-path xlsynth-g8r/fuzz/Cargo.toml`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_i_685a3296ee4883238d76505815947a31