### PR TITLE
[g8r] Improve deepest path reporting, show source positions

### DIFF
--- a/xlsynth-g8r/tests/goldens/invoke_ir2gates.golden.txt
+++ b/xlsynth-g8r/tests/goldens/invoke_ir2gates.golden.txt
@@ -1,0 +1,27 @@
+== Op frequencies:
+     3 :: get_param() -> bits[1]
+     1 :: identity(bits[1]) -> bits[1]
+     1 :: nil() -> ()
+     1 :: priority_sel(bits[1], bits[1], bits[1]) -> bits[1]
+== Fraig convergence: Yes(0)
+== Deepest path (3):
+     6 :: And2(~Ref(4), ~Ref(5))
+          tags: priority_sel_4_output_bit_0
+          source: bar.x:3:1 foo.x:2:1
+          uses: 1
+     4 :: And2(Ref(1), Ref(2))
+          uses: 1
+     1 :: Input(sel[0])
+          uses: 2
+== Logical effort deepest path min delay: 6.6667 (FO4 units)
+Gate Depth Histogram (Bucketed by 5):
+Depth   0 -   4 | ██████████████████████████████████████████████████ |    6
+== Live node count: 6
+== Structures:
+  2 :: x0
+  1 :: AND(not(AND(x0,x1)),not(AND(not(x2),x3)))
+  1 :: AND(not(x0),x1)
+  1 :: AND(x0,x1)
+== Fanout histogram:
+  1: 4
+  2: 1

--- a/xlsynth-g8r/tests/invoke_test.rs
+++ b/xlsynth-g8r/tests/invoke_test.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Write;
+use std::process::Command;
+
+#[test]
+fn test_ir2gates_invoke_golden() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let ir = r#"package prio_pkg
+file_number 0 "foo.x"
+file_number 1 "bar.x"
+
+top fn main(sel: bits[1] id=1, a: bits[1] id=2, b: bits[1] id=3) -> bits[1] {
+  p: bits[1] = priority_sel(sel, cases=[a], default=b, id=4, pos=[(0,1,0), (1,2,0)])
+  ret result: bits[1] = identity(p, id=5)
+}
+"#;
+
+    let mut temp_file = tempfile::Builder::new().suffix(".ir").tempfile().unwrap();
+    write!(temp_file, "{}", ir).unwrap();
+    let temp_path = temp_file.into_temp_path();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_g8r"))
+        .arg("--check-equivalence=false")
+        .arg(temp_path.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let golden_path = std::path::Path::new("tests/goldens/invoke_ir2gates.golden.txt");
+    if std::env::var("XLSYNTH_UPDATE_GOLDEN").is_ok() {
+        println!("INFO: Updating golden file: {}", golden_path.display());
+        std::fs::write(golden_path, &stdout).expect("Failed to write golden file");
+    } else {
+        let golden = std::fs::read_to_string(golden_path).expect("Failed to read golden file");
+        assert_eq!(
+            stdout, golden,
+            "Golden file mismatch. Run with XLSYNTH_UPDATE_GOLDEN=1 to update."
+        );
+    }
+}

--- a/xlsynth-g8r/tests/test_signature_compatibility.rs
+++ b/xlsynth-g8r/tests/test_signature_compatibility.rs
@@ -86,3 +86,27 @@ top fn pack_unpack(input: (bits[1], bits[8], bits[23]) id=1) -> (bits[1], bits[8
         "Output does not contain expected 'Deepest path' indication"
     );
 }
+
+#[test]
+fn test_deepest_path_source_display() {
+    let ir = "package pos_pkg\nfile_number 0 \"foo.x\"\n\n\
+top fn main() -> bits[32] {\n  ret literal.1: bits[32] = literal(value=1, id=1, pos=[(0,0,0)])\n}\n";
+    let mut temp_file = tempfile::Builder::new().suffix(".ir").tempfile().unwrap();
+    write!(temp_file, "{}", ir).unwrap();
+    let temp_path = temp_file.into_temp_path();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_g8r"))
+        .arg(temp_path.to_str().unwrap())
+        .env("RUST_LOG", std::env::var("RUST_LOG").unwrap_or_default())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    println!("stdout: {}", stdout);
+
+    assert!(
+        output.status.success(),
+        "g8r binary did not exit successfully"
+    );
+    assert!(stdout.contains("source:"), "Deepest path source not shown");
+}

--- a/xlsynth-test-helpers/tests/spdx_test.rs
+++ b/xlsynth-test-helpers/tests/spdx_test.rs
@@ -81,7 +81,8 @@ fn find_missing_spdx_files(root: &Path) -> Vec<PathBuf> {
 
             // For golden comparison files (i.e. ones we compare to literally for code
             // generation facilities) we don't require SPDX identifiers.
-            if path.as_os_str().to_str().unwrap().ends_with(".golden.sv") {
+            let path_str = path.as_os_str().to_str().unwrap();
+            if path_str.ends_with(".golden.sv") || path_str.ends_with(".golden.txt") {
                 continue;
             }
 
@@ -145,6 +146,16 @@ fn check_all_rust_files_for_spdx() {
     let metadata = MetadataCommand::new().exec().unwrap();
     let workspace_dir = metadata.workspace_root;
     let missing_spdx_files = find_missing_spdx_files(workspace_dir.as_std_path());
+    if !missing_spdx_files.is_empty() {
+        eprintln!(
+            "\nSummary of files missing SPDX identifiers ({}):",
+            missing_spdx_files.len()
+        );
+        for path in &missing_spdx_files {
+            eprintln!("  - {}", path.display());
+        }
+        eprintln!("\n");
+    }
     assert!(
         missing_spdx_files.is_empty(),
         "The following files are missing SPDX identifiers: {:?}",


### PR DESCRIPTION
## Summary
- parse IR with position data
- associate gates back to IR node source locations
- print tags and source information in deepest-path report
- show ir2gates output with tags and source locations in a golden test
- indent `uses:` lines consistently with tag/source output

## Testing
- `pre-commit run --all-files`
- `cargo test -p xlsynth-g8r --test invoke_test -- --nocapture`
- `cargo test -p xlsynth-g8r test_deepest_path_source_display -- --nocapture`
- `cargo fuzz build`

------
https://chatgpt.com/codex/tasks/task_i_685a3d1b03408323a1b5e9dd10144845