### PR TITLE
Always collect position info in XLS IR parser

### DIFF
--- a/xlsynth-g8r/src/process_ir_path.rs
+++ b/xlsynth-g8r/src/process_ir_path.rs
@@ -70,7 +70,7 @@ pub fn process_ir_path(ir_path: &std::path::Path, options: &Options) -> Ir2Gates
     // Read the file into a string.
     let file_content = std::fs::read_to_string(&ir_path)
         .unwrap_or_else(|err| panic!("Failed to read {}: {}", ir_path.display(), err));
-    let mut parser = ir_parser::Parser::new_with_pos(&file_content, true);
+    let mut parser = ir_parser::Parser::new(&file_content);
     let ir_package = parser.parse_package().unwrap_or_else(|err| {
         eprintln!("Error encountered parsing XLS IR package: {:?}", err);
         std::process::exit(1);


### PR DESCRIPTION
## Summary
- drop option to disable position collection in the XLS IR parser
- update parser users and tests accordingly

## Testing
- `pre-commit run --all-files` *(fails: `cargo` not found)*
- `cargo fuzz build` *(fails: `cargo` not found)*

------
https://chatgpt.com/codex/tasks/task_i_685b75d15c988323a1678cc01094dc6e