### PR TITLE
Embed IR node positions

### DIFF
--- a/xlsynth-g8r/src/ir_equiv_boolector.rs
+++ b/xlsynth-g8r/src/ir_equiv_boolector.rs
@@ -1345,6 +1345,7 @@ pub fn prove_ir_fn_equiv_output_bits_parallel(
                 start: bit,
                 width: 1,
             },
+            pos: None,
         });
         nf.ret_node_ref = Some(slice_ref);
         nf.ret_ty = Type::Bits(1);

--- a/xlsynth-g8r/src/process_ir_path.rs
+++ b/xlsynth-g8r/src/process_ir_path.rs
@@ -105,19 +105,17 @@ pub fn process_ir_path(ir_path: &std::path::Path, options: &Options) -> Ir2Gates
 
     // Map each gate reference back to the IR node positions, if available.
     let mut gate_to_sources: HashMap<usize, Vec<String>> = HashMap::new();
-    if let Some(pos_map) = ir_package.node_pos.as_ref() {
-        for (node_ref, bit_vec) in gatify_output.lowering_map.iter() {
-            if let Some(pos_data) = pos_map.get(&node_ref.index) {
-                let sources: Vec<String> = pos_data
-                    .iter()
-                    .filter_map(|p| p.to_human_string(&ir_package.file_table))
-                    .collect();
-                for operand in bit_vec.iter_lsb_to_msb() {
-                    gate_to_sources
-                        .entry(operand.node.id)
-                        .or_default()
-                        .extend(sources.clone());
-                }
+    for (node_ref, bit_vec) in gatify_output.lowering_map.iter() {
+        if let Some(pos_data) = ir_top.get_node(*node_ref).pos.as_ref() {
+            let sources: Vec<String> = pos_data
+                .iter()
+                .filter_map(|p| p.to_human_string(&ir_package.file_table))
+                .collect();
+            for operand in bit_vec.iter_lsb_to_msb() {
+                gate_to_sources
+                    .entry(operand.node.id)
+                    .or_default()
+                    .extend(sources.clone());
             }
         }
     }

--- a/xlsynth-g8r/src/xls_ir/ir.rs
+++ b/xlsynth-g8r/src/xls_ir/ir.rs
@@ -752,6 +752,7 @@ pub struct Node {
     pub name: Option<String>,
     pub ty: Type,
     pub payload: NodePayload,
+    pub pos: Option<PosData>,
 }
 
 impl Node {
@@ -1023,7 +1024,6 @@ pub struct Package {
     pub file_table: FileTable,
     pub fns: Vec<Fn>,
     pub top_name: Option<String>,
-    pub node_pos: Option<HashMap<usize, PosData>>,
 }
 
 impl Package {


### PR DESCRIPTION
## Summary
- store `PosData` inside each `Node`
- drop `node_pos` map from the parser and package
- propagate position data to consumers
- update tests and fuzz build

## Testing
- `pre-commit run --all-files`
- `cargo build --manifest-path xlsynth-g8r/fuzz/Cargo.toml --bins`

------
https://chatgpt.com/codex/tasks/task_i_685b85f5e03c8323a1aff46cc6f6288e