### PR TITLE
Report outputs in counterexamples

### DIFF
--- a/xlsynth-driver/src/ir_equiv.rs
+++ b/xlsynth-driver/src/ir_equiv.rs
@@ -171,8 +171,13 @@ fn run_boolector_equiv_check(
             println!("success: Boolector proved equivalence");
             std::process::exit(0);
         }
-        ir_equiv_boolector::EquivResult::Disproved(cex) => {
+        ir_equiv_boolector::EquivResult::Disproved {
+            inputs: cex,
+            outputs: (lhs_bits, rhs_bits),
+        } => {
             println!("failure: Boolector found counterexample: {:?}", cex);
+            println!("    output LHS: {:?}", lhs_bits);
+            println!("    output RHS: {:?}", rhs_bits);
             std::process::exit(1);
         }
     }

--- a/xlsynth-driver/src/ir_equiv_batch.rs
+++ b/xlsynth-driver/src/ir_equiv_batch.rs
@@ -83,7 +83,10 @@ fn run_check_with_ctx(
             );
             true
         }
-        EquivResult::Disproved(cex) => {
+        EquivResult::Disproved {
+            inputs: cex,
+            outputs: (lhs_bits, rhs_bits),
+        } => {
             println!(
                 "failure: Boolector found counterexample for {}:{} vs {}:{}: {:?} (in {:?})",
                 lhs_path.display(),
@@ -93,6 +96,8 @@ fn run_check_with_ctx(
                 cex,
                 duration
             );
+            println!("    output lhs: {:?}", lhs_bits);
+            println!("    output rhs: {:?}", rhs_bits);
             false
         }
     }

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
@@ -65,8 +65,10 @@ fuzz_target!(|sample: FuzzSample| {
         Ok(()) => {
             // External tool says equivalent, Boolector should agree
             match (boolector_result, parallel_result) {
-                (ir_equiv_boolector::EquivResult::Proved, Some(ir_equiv_boolector::EquivResult::Proved)) | (ir_equiv_boolector::EquivResult::Proved, None) => (),
-                (ir_equiv_boolector::EquivResult::Disproved(cex), _) | (_, Some(ir_equiv_boolector::EquivResult::Disproved(cex))) => {
+            (ir_equiv_boolector::EquivResult::Proved, Some(ir_equiv_boolector::EquivResult::Proved))
+            | (ir_equiv_boolector::EquivResult::Proved, None) => (),
+            (ir_equiv_boolector::EquivResult::Disproved { inputs: cex, .. }, _)
+            | (_, Some(ir_equiv_boolector::EquivResult::Disproved { inputs: cex, .. })) => {
                     log::info!("==== IR disagreement detected ====");
                     log::info!("Original IR:\n{}", orig_ir);
                     log::info!("Optimized IR:\n{}", opt_ir);
@@ -80,7 +82,9 @@ fuzz_target!(|sample: FuzzSample| {
         Err(ext_err) => {
             // External tool says not equivalent, check Boolector and parallel
             match (boolector_result, parallel_result) {
-                (ir_equiv_boolector::EquivResult::Proved, _) | (_, Some(ir_equiv_boolector::EquivResult::Proved)) | (ir_equiv_boolector::EquivResult::Proved, None) => {
+                (ir_equiv_boolector::EquivResult::Proved, _)
+                | (_, Some(ir_equiv_boolector::EquivResult::Proved))
+                | (ir_equiv_boolector::EquivResult::Proved, None) => {
                     log::info!("==== IR disagreement detected ====");
                     log::info!("Original IR:\n{}", orig_ir);
                     log::info!("Optimized IR:\n{}", opt_ir);
@@ -89,7 +93,8 @@ fuzz_target!(|sample: FuzzSample| {
                         ext_err
                     );
                 }
-                (ir_equiv_boolector::EquivResult::Disproved(_), Some(ir_equiv_boolector::EquivResult::Disproved(_))) | (ir_equiv_boolector::EquivResult::Disproved(_), None) => (), // All agree not equivalent
+                (ir_equiv_boolector::EquivResult::Disproved { .. }, Some(ir_equiv_boolector::EquivResult::Disproved { .. }))
+                | (ir_equiv_boolector::EquivResult::Disproved { .. }, None) => (), // All agree not equivalent
             }
         }
     }

--- a/xlsynth-g8r/src/bin/check-ir-equivalence.rs
+++ b/xlsynth-g8r/src/bin/check-ir-equivalence.rs
@@ -71,12 +71,15 @@ fn main_has_boolector(args: Args) {
                 boolector_elapsed
             );
         }
-        ir_equiv_boolector::EquivResult::Disproved(cex) => {
+        ir_equiv_boolector::EquivResult::Disproved {
+            inputs: cex,
+            outputs: (lhs_out_bits, rhs_out_bits),
+        } => {
             println!(
                 "Equivalence result (boolector): DISPROVED (took {:?})",
                 boolector_elapsed
             );
-            println!("Counterexample(s):");
+            println!("Counterexample inputs:");
             let values: Vec<_> = cex
                 .iter()
                 .zip(&f1.params)
@@ -87,6 +90,11 @@ fn main_has_boolector(args: Args) {
             } else {
                 println!("  {:?}", values);
             }
+            // Report outputs for the counterexample
+            let lhs_val = ir_value_from_bits_with_type(&lhs_out_bits, &f1.ret_ty);
+            let rhs_val = ir_value_from_bits_with_type(&rhs_out_bits, &f2.ret_ty);
+            println!("Output LHS: {}", lhs_val);
+            println!("Output RHS: {}", rhs_val);
         }
     }
 

--- a/xlsynth-g8r/src/ir_equiv_boolector.rs
+++ b/xlsynth-g8r/src/ir_equiv_boolector.rs
@@ -1609,7 +1609,10 @@ mod tests {
         let g = ir_parser::Parser::new(ir_text_g).parse_fn().unwrap();
         let result = prove_ir_fn_equiv(&f, &g);
         match result {
-            EquivResult::Disproved(ref cex) => {
+            EquivResult::Disproved {
+                inputs: ref cex,
+                outputs: _,
+            } => {
                 assert_eq!(cex.len(), 1);
                 let bits = &cex[0];
                 assert_eq!(bits.get_bit_count(), 8);
@@ -1746,7 +1749,10 @@ mod tests {
         let result = prove_ir_fn_equiv(&f, &g);
         match result {
             EquivResult::Proved => (),
-            EquivResult::Disproved(_) => panic!("Expected Proved, got Disproved"),
+            EquivResult::Disproved {
+                inputs: _,
+                outputs: _,
+            } => panic!("Expected Proved, got Disproved"),
         }
     }
 


### PR DESCRIPTION
This PR extends the Boolector-based IR equivalence checker to also report the actual outputs for counterexamples, improving debugging:

- Records both inputs and outputs in the counterexamples.
- Updates CLI and driver to print outputs.
- Adjusts parallel/bit-split prover and fuzz targets for the new counterexample representation.

Note that in this version, the outputs are reported flatten.