### PR TITLE
Add generic solver interface, add easy_smt backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,10 @@ jobs:
           echo "ldconfig -p | grep boolector:"
           ldconfig -p | grep boolector || echo "libboolector.so not found in ldconfig!"
 
+      - name: Install Z3 binary
+        run: |
+          sudo apt-get install -y z3
+
       - name: Test crate
         env:
           BOOLECTOR_LIB_DIR: ${{ github.workspace }}/boolector_libs
@@ -184,7 +188,7 @@ jobs:
             ls -l /usr/lib | grep boolector || true
             exit 1
           fi
-          cargo test --features with-boolector-system,with-z3-system --workspace
+          cargo test --features with-boolector-system,with-z3-system,with-easy-smt,with-z3-binary-test --workspace
 
       - name: Ensure benches compile
         env:
@@ -370,6 +374,10 @@ jobs:
           override: true
           components: clippy
 
+      - name: Install Z3 binary
+        run: |
+          brew install z3
+
       - name: Run pre-commit
         env:
           SKIP: no-commit-to-branch
@@ -380,7 +388,7 @@ jobs:
       - name: Test crate
         run: |
           export XLSYNTH_TOOLS=`realpath xlsynth_tools`
-          cargo test --features with-boolector-built,with-z3-built --workspace
+          cargo test --features with-boolector-built,with-z3-built,with-easy-smt,with-z3-binary-test --workspace
 
   # -----------------------------------------------------------
   # 5) Rocky Linux job

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Cargo.lock
 xlsynth_tools/
 slang
 .venv
+.spr.yml

--- a/xlsynth-g8r/Cargo.toml
+++ b/xlsynth-g8r/Cargo.toml
@@ -29,6 +29,7 @@ z3 = { version = "0.12", optional = true }
 rand_xoshiro = "0.6"
 num-traits = "0.2.19"
 boolector = { version = "0.4.3", optional = true }
+easy-smt = { version = "0.3.1", optional = true }
 prost = "0.12.6"
 prost-types = "0.12.6"
 prost-reflect = { version = "0.12.0", features = ["text-format"] }
@@ -63,10 +64,15 @@ prost-build = "0.12"
 [features]
 default = []
 has-boolector = []
+has-easy-smt = []
 with-boolector-system = ["dep:boolector", "has-boolector"]
 with-boolector-built = ["dep:boolector", "boolector/vendor-lgl", "has-boolector"]
 with-z3-system = ["dep:z3"]
 with-z3-built = ["dep:z3", "z3/static-link-z3"]
+with-easy-smt = ["dep:easy-smt", "has-easy-smt"]
+with-boolector-binary-test = ["with-easy-smt"]
+with-bitwuzla-binary-test = ["with-easy-smt"]
+with-z3-binary-test = ["with-easy-smt"]
 
 [lib]
 name = "xlsynth_g8r"

--- a/xlsynth-g8r/src/equiv/easy_smt_backend.rs
+++ b/xlsynth-g8r/src/equiv/easy_smt_backend.rs
@@ -1,0 +1,616 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "has-easy-smt")]
+
+use std::{
+    io,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use easy_smt::{Context, ContextBuilder, SExpr};
+
+use crate::{
+    equiv::solver_interface::{BitVec, Solver},
+    ir_value_utils::{ir_bits_from_lsb_is_0, ir_value_from_bits_with_type},
+    xls_ir::ir,
+};
+
+#[derive(Debug, Clone)]
+pub struct SolverFn {
+    pub push_fn: fn(&mut Context) -> io::Result<()>,
+    pub pop_fn: fn(&mut Context) -> io::Result<()>,
+    pub check_fn: fn(&mut Context) -> io::Result<easy_smt::Response>,
+    pub assert_fn: fn(&mut Context, SExpr) -> io::Result<()>,
+}
+
+impl SolverFn {
+    pub fn default() -> Self {
+        Self {
+            push_fn: Context::push,
+            pop_fn: Context::pop,
+            check_fn: Context::check,
+            assert_fn: Context::assert,
+        }
+    }
+}
+
+/// Configuration for executable solver backends using the `easy-smt` crate.
+///
+/// When using `easy-smt`, a persistent solver process is launched, and
+/// communication occurs via stdin/stdout. This introduces serialization
+/// overhead, so if an in-memory backend is available for a specific solver,
+/// it is generally preferable to use that instead.
+///
+/// The main advantage of using an executable solver backend is that it requires
+/// no additional FFI code. Any SMT-compatible solver can be used out of the
+/// box.
+#[derive(Clone)]
+pub struct EasySmtConfig {
+    pub solver_path: PathBuf,
+    pub solver_args: Vec<String>,
+    pub replay_file: Option<PathBuf>,
+    pub solver_fn: SolverFn,
+}
+
+impl EasySmtConfig {
+    pub fn bitwuzla() -> Self {
+        Self {
+            solver_path: PathBuf::from("bitwuzla"),
+            solver_args: ["--produce-models"].iter().map(|s| s.to_string()).collect(),
+            replay_file: None,
+            solver_fn: SolverFn {
+                push_fn: |ctx| ctx.push_many(1),
+                pop_fn: |ctx| ctx.pop_many(1),
+                ..SolverFn::default()
+            },
+        }
+    }
+
+    pub fn boolector() -> Self {
+        Self {
+            solver_path: PathBuf::from("boolector"),
+            solver_args: [
+                "--smt2",               // Use SMT2
+                "-m",                   // Produce models
+                "--output-format=smt2", // Output in SMT2 format
+                "--no-exit-codes",      // Don't exit with error code on failure
+                "--incremental",        // Use incremental solving
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+            replay_file: None,
+            solver_fn: SolverFn {
+                push_fn: |ctx| ctx.push_many(1),
+                pop_fn: |ctx| ctx.pop_many(1),
+                ..SolverFn::default()
+            },
+        }
+    }
+
+    pub fn z3() -> Self {
+        Self {
+            solver_path: PathBuf::from("z3"),
+            solver_args: [
+                "-nw",   // No warnings
+                "-smt2", // Use SMT2
+                "-in",   // Read from stdin
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+            replay_file: None,
+            solver_fn: SolverFn::default(),
+        }
+    }
+}
+
+pub struct EasySmtSolver {
+    context: Arc<Mutex<Context>>,
+    solver_fn: SolverFn,
+}
+
+impl EasySmtSolver {
+    fn bool_to(&self, context: &Context, value: SExpr) -> BitVec<SExpr> {
+        BitVec::BitVec {
+            width: 1,
+            rep: context.ite(value, context.binary(1, 1), context.binary(1, 0)),
+        }
+    }
+
+    fn bv_to_bool(&self, context: &Context, value: &BitVec<SExpr>) -> SExpr {
+        match value {
+            BitVec::BitVec { rep, width: 1 } => context.eq(rep.clone(), context.binary(1, 1)),
+            _ => panic!(
+                "Invalid bitvector width for boolean: {:?}",
+                value.get_width()
+            ),
+        }
+    }
+
+    fn unary_op<F>(&self, bit_vec: &BitVec<SExpr>, op: F) -> BitVec<SExpr>
+    where
+        F: Fn(&Context, SExpr) -> SExpr,
+    {
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        match bit_vec {
+            BitVec::BitVec { width, rep } => BitVec::BitVec {
+                width: *width,
+                rep: op(&context, rep.clone()),
+            },
+            BitVec::ZeroWidth => BitVec::ZeroWidth,
+        }
+    }
+
+    fn bin_bool_op<F>(
+        &self,
+        lhs: &BitVec<SExpr>,
+        rhs: &BitVec<SExpr>,
+        op: F,
+        zero_width_result: BitVec<SExpr>,
+    ) -> BitVec<SExpr>
+    where
+        F: Fn(&Context, SExpr, SExpr) -> SExpr,
+    {
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        match (lhs, rhs) {
+            (BitVec::BitVec { width: w1, rep: r1 }, BitVec::BitVec { width: w2, rep: r2 }) => {
+                assert_eq!(w1, w2, "Bitvector width mismatch");
+                self.bool_to(&context, op(&context, r1.clone(), r2.clone()))
+            }
+            (BitVec::ZeroWidth, BitVec::ZeroWidth) => zero_width_result,
+            _ => panic!("Bitvector width mismatch"),
+        }
+    }
+
+    fn bin_op<F>(&self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>, op: F) -> BitVec<SExpr>
+    where
+        F: Fn(&Context, SExpr, SExpr) -> SExpr,
+    {
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        match (lhs, rhs) {
+            (BitVec::BitVec { width: w1, rep: r1 }, BitVec::BitVec { width: w2, rep: r2 }) => {
+                assert_eq!(w1, w2, "Bitvector width mismatch");
+                BitVec::BitVec {
+                    width: *w1,
+                    rep: op(&context, r1.clone(), r2.clone()),
+                }
+            }
+            (BitVec::ZeroWidth, BitVec::ZeroWidth) => BitVec::ZeroWidth,
+            _ => panic!("Bitvector width mismatch"),
+        }
+    }
+
+    fn reduce<F>(&self, bit_vec: &BitVec<SExpr>, op: F) -> BitVec<SExpr>
+    where
+        F: Fn(&Context, SExpr, SExpr) -> SExpr,
+    {
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        match bit_vec {
+            BitVec::BitVec { width, rep } => {
+                let mut res = context.extract(0, 0, rep.clone());
+                for i in 1..*width {
+                    let bit = context.extract(i as i32, i as i32, rep.clone());
+                    res = op(&context, res.clone(), bit);
+                }
+                BitVec::BitVec { width: 1, rep: res }
+            }
+            BitVec::ZeroWidth => panic!("Cannot reduce zero-width bitvector"),
+        }
+    }
+}
+
+impl Solver for EasySmtSolver {
+    type Term = SExpr;
+    type Config = EasySmtConfig;
+    fn new(config: &EasySmtConfig) -> io::Result<EasySmtSolver> {
+        let mut builder = ContextBuilder::new();
+        if let Some(ref replay_file) = config.replay_file {
+            builder.replay_file(Some(std::fs::File::create(replay_file)?));
+        }
+        builder.solver(&config.solver_path);
+        builder.solver_args(&config.solver_args);
+        let context = builder.build()?;
+        Ok(EasySmtSolver {
+            context: Arc::new(Mutex::new(context)),
+            solver_fn: config.solver_fn.clone(),
+        })
+    }
+
+    fn declare(&mut self, name: &str, width: usize) -> io::Result<BitVec<SExpr>> {
+        if width == 0 {
+            return Ok(BitVec::ZeroWidth);
+        }
+        let shared = Arc::clone(&self.context);
+        let mut context = shared.lock().unwrap();
+        let width_numeral = context.numeral(width as i64);
+        let sort = context.bit_vec_sort(width_numeral);
+        let rep = context.declare_const(name, sort)?;
+        let ret = BitVec::BitVec { width, rep };
+        Ok(ret)
+    }
+
+    fn numerical(&mut self, width: usize, mut value: u64) -> BitVec<SExpr> {
+        assert!(width > 0, "Width must be positive");
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        if width < 64 {
+            value &= (1 << width) - 1;
+        }
+        let rep = context.binary(width, value);
+        BitVec::BitVec { width, rep }
+    }
+
+    fn from_raw_str(&mut self, width: usize, value: &str) -> BitVec<SExpr> {
+        assert!(width > 0, "Width must be positive");
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        BitVec::BitVec {
+            width,
+            rep: context.atom(value),
+        }
+    }
+
+    fn get_value(
+        &mut self,
+        bit_vec: &BitVec<SExpr>,
+        ty: &ir::Type,
+    ) -> io::Result<xlsynth::IrValue> {
+        let shared = Arc::clone(&self.context);
+        let mut context = shared.lock().unwrap();
+        match bit_vec {
+            BitVec::BitVec { rep, .. } => {
+                let value = context.get_value(vec![rep.clone()])?[0].1;
+                let atom = context.get_atom(value).expect("model value must be atom");
+                let bitstr = if let Some(rest) = atom.strip_prefix("#b") {
+                    rest.to_string()
+                } else if let Some(rest) = atom.strip_prefix("#x") {
+                    rest.chars()
+                        .map(|c| match c {
+                            '0'..='9' => c.to_digit(16).unwrap(),
+                            'a'..='f' => c.to_digit(16).unwrap(),
+                            _ => panic!("Invalid hex character: {}", c),
+                        })
+                        .map(|d| format!("{:04b}", d))
+                        .collect::<Vec<_>>()
+                        .join("")
+                } else {
+                    panic!("Invalid atom: {}", atom);
+                };
+                let bits: Vec<bool> = bitstr.chars().rev().map(|c| c == '1').collect();
+                Ok(ir_value_from_bits_with_type(
+                    &ir_bits_from_lsb_is_0(&bits),
+                    ty,
+                ))
+            }
+            BitVec::ZeroWidth => panic!("Cannot get value of zero-width bitvector"),
+        }
+    }
+
+    fn extract(&mut self, bit_vec: &BitVec<SExpr>, high: i32, low: i32) -> BitVec<SExpr> {
+        if high == low - 1 {
+            return BitVec::ZeroWidth;
+        }
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        match bit_vec {
+            BitVec::BitVec { width, rep } => {
+                assert!(
+                    high >= low,
+                    "Invalid bit slice: high = {}, low = {}",
+                    high,
+                    low
+                );
+                assert!(
+                    high < *width as i32,
+                    "Invalid bit slice: high = {}, width = {}",
+                    high,
+                    width
+                );
+                assert!(low >= 0, "Invalid bit slice: low = {}", low);
+                let new_width = high - low + 1;
+                BitVec::BitVec {
+                    width: new_width as usize,
+                    rep: context.extract(high, low, rep.clone()),
+                }
+            }
+            BitVec::ZeroWidth => panic!("Cannot extract from zero-width bitvector"),
+        }
+    }
+
+    fn not(&mut self, bit_vec: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.unary_op(bit_vec, Context::bvnot)
+    }
+
+    fn neg(&mut self, bit_vec: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.unary_op(bit_vec, Context::bvneg)
+    }
+
+    fn reverse(&mut self, bit_vec: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        match bit_vec {
+            BitVec::BitVec { width, rep } => {
+                let mut res = context.extract(0, 0, rep.clone());
+                for i in 1..*width {
+                    let bit = context.extract(i as i32, i as i32, rep.clone());
+                    res = context.concat(res, bit);
+                }
+                BitVec::BitVec {
+                    width: *width,
+                    rep: res,
+                }
+            }
+            BitVec::ZeroWidth => BitVec::ZeroWidth,
+        }
+    }
+
+    fn or_reduce(&mut self, bit_vec: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.reduce(bit_vec, Context::bvor)
+    }
+
+    fn and_reduce(&mut self, bit_vec: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.reduce(bit_vec, Context::bvand)
+    }
+
+    fn xor_reduce(&mut self, bit_vec: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.reduce(bit_vec, Context::bvxor)
+    }
+
+    fn add(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvadd)
+    }
+
+    fn sub(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvsub)
+    }
+
+    fn mul(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvmul)
+    }
+
+    fn udiv(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvudiv)
+    }
+
+    fn urem(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvurem)
+    }
+
+    fn srem(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvsrem)
+    }
+
+    fn sdiv(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvsdiv)
+    }
+
+    fn shl(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvshl)
+    }
+
+    fn lshr(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvlshr)
+    }
+
+    fn ashr(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvashr)
+    }
+
+    fn concat(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        match (&lhs, &rhs) {
+            (BitVec::BitVec { width: w1, rep: r1 }, BitVec::BitVec { width: w2, rep: r2 }) => {
+                BitVec::BitVec {
+                    width: w1 + w2,
+                    rep: context.concat(r1.clone(), r2.clone()),
+                }
+            }
+            (BitVec::ZeroWidth, _) => rhs.clone(),
+            (_, BitVec::ZeroWidth) => lhs.clone(),
+        }
+    }
+
+    fn or(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvor)
+    }
+
+    fn and(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvand)
+    }
+
+    fn xor(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, Context::bvxor)
+    }
+
+    fn nand(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, |ctx, r1, r2| ctx.bvnot(ctx.bvand(r1, r2)))
+    }
+
+    fn nor(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        self.bin_op(lhs, rhs, |ctx, r1, r2| ctx.bvnot(ctx.bvor(r1, r2)))
+    }
+
+    fn extend(
+        &mut self,
+        bit_vec: &BitVec<SExpr>,
+        extend_width: usize,
+        signed: bool,
+    ) -> BitVec<SExpr> {
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        match bit_vec {
+            BitVec::BitVec { width, rep } => {
+                if extend_width == 0 {
+                    return bit_vec.clone();
+                }
+                let extend_operator = if signed {
+                    context.atom("sign_extend")
+                } else {
+                    context.atom("zero_extend")
+                };
+                let extend_rep = context.list(vec![
+                    context.list(vec![
+                        context.atoms().und,
+                        extend_operator,
+                        context.numeral(extend_width),
+                    ]),
+                    rep.clone(),
+                ]);
+                BitVec::BitVec {
+                    width: width + extend_width,
+                    rep: extend_rep,
+                }
+            }
+            BitVec::ZeroWidth => panic!("Cannot extend zero-width bitvector"),
+        }
+    }
+
+    fn ite(
+        &mut self,
+        lhs: &BitVec<SExpr>,
+        then: &BitVec<SExpr>,
+        else_: &BitVec<SExpr>,
+    ) -> BitVec<SExpr> {
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        match (lhs.clone(), then, else_) {
+            (
+                BitVec::BitVec { width: w1, rep: _ },
+                BitVec::BitVec { width: w2, rep: r2 },
+                BitVec::BitVec { width: w3, rep: r3 },
+            ) => {
+                assert_eq!(w1, 1, "Condition must be 1-bit");
+                assert_eq!(w2, w3, "Then and else must have the same width");
+                BitVec::BitVec {
+                    width: *w2,
+                    rep: context.ite(self.bv_to_bool(&context, lhs), r2.clone(), r3.clone()),
+                }
+            }
+            (BitVec::BitVec { width: w1, rep: _ }, BitVec::ZeroWidth, BitVec::ZeroWidth) => {
+                assert_eq!(w1, 1, "Condition must be 1-bit");
+                BitVec::ZeroWidth
+            }
+            _ => panic!("Bitvector width mismatch"),
+        }
+    }
+
+    fn eq(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let result = self.true_bv();
+        self.bin_bool_op(lhs, rhs, Context::eq, result)
+    }
+
+    fn ne(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let result = self.false_bv();
+        self.bin_bool_op(lhs, rhs, |ctx, r1, r2| ctx.not(ctx.eq(r1, r2)), result)
+    }
+
+    fn slt(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let result = self.false_bv();
+        self.bin_bool_op(lhs, rhs, Context::bvslt, result)
+    }
+
+    fn sgt(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let result = self.false_bv();
+        self.bin_bool_op(lhs, rhs, Context::bvsgt, result)
+    }
+
+    fn sle(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let result = self.true_bv();
+        self.bin_bool_op(lhs, rhs, Context::bvsle, result)
+    }
+
+    fn sge(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let result = self.true_bv();
+        self.bin_bool_op(lhs, rhs, Context::bvsge, result)
+    }
+
+    fn ult(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let result = self.false_bv();
+        self.bin_bool_op(lhs, rhs, Context::bvult, result)
+    }
+
+    fn ugt(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let result = self.false_bv();
+        self.bin_bool_op(lhs, rhs, Context::bvugt, result)
+    }
+
+    fn ule(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let result = self.true_bv();
+        self.bin_bool_op(lhs, rhs, Context::bvule, result)
+    }
+
+    fn uge(&mut self, lhs: &BitVec<SExpr>, rhs: &BitVec<SExpr>) -> BitVec<SExpr> {
+        let result = self.true_bv();
+        self.bin_bool_op(lhs, rhs, Context::bvuge, result)
+    }
+
+    fn push(&mut self) -> io::Result<()> {
+        let shared = Arc::clone(&self.context);
+        let mut context = shared.lock().unwrap();
+        (self.solver_fn.push_fn)(&mut context)
+    }
+
+    fn pop(&mut self) -> io::Result<()> {
+        let shared = Arc::clone(&self.context);
+        let mut context = shared.lock().unwrap();
+        (self.solver_fn.pop_fn)(&mut context)
+    }
+
+    fn check(&mut self) -> io::Result<super::solver_interface::Response> {
+        let shared = Arc::clone(&self.context);
+        let mut context = shared.lock().unwrap();
+        match (self.solver_fn.check_fn)(&mut context) {
+            Ok(easy_smt::Response::Sat) => Ok(super::solver_interface::Response::Sat),
+            Ok(easy_smt::Response::Unsat) => Ok(super::solver_interface::Response::Unsat),
+            Ok(easy_smt::Response::Unknown) => Ok(super::solver_interface::Response::Unknown),
+            Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
+        }
+    }
+
+    fn assert(&mut self, bit_vec: &BitVec<SExpr>) -> io::Result<()> {
+        let shared = Arc::clone(&self.context);
+        let mut context = shared.lock().unwrap();
+        let bool_expr = self.bv_to_bool(&context, bit_vec);
+        (self.solver_fn.assert_fn)(&mut context, bool_expr)
+    }
+
+    fn render(&mut self, bit_vec: &BitVec<SExpr>) -> String {
+        let shared = Arc::clone(&self.context);
+        let context = shared.lock().unwrap();
+        match bit_vec.get_rep() {
+            None => "<zero-width>".to_string(),
+            Some(rep) => context.display(rep.clone()).to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+use crate::test_solver;
+
+#[cfg(test)]
+#[cfg(feature = "with-bitwuzla-binary-test")]
+test_solver!(
+    bitwuzla_tests,
+    super::EasySmtSolver::new(&super::EasySmtConfig::bitwuzla()).unwrap()
+);
+
+#[cfg(test)]
+#[cfg(feature = "with-boolector-binary-test")]
+test_solver!(
+    boolector_tests,
+    super::EasySmtSolver::new(&super::EasySmtConfig::boolector()).unwrap()
+);
+
+#[cfg(test)]
+#[cfg(feature = "with-z3-binary-test")]
+test_solver!(
+    z3_tests,
+    super::EasySmtSolver::new(&super::EasySmtConfig::z3()).unwrap()
+);

--- a/xlsynth-g8r/src/equiv/mod.rs
+++ b/xlsynth-g8r/src/equiv/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod easy_smt_backend;
+pub mod solver_interface;

--- a/xlsynth-g8r/src/equiv/solver_interface.rs
+++ b/xlsynth-g8r/src/equiv/solver_interface.rs
@@ -1,0 +1,857 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io;
+
+use xlsynth::IrValue;
+
+use crate::xls_ir::ir;
+
+#[derive(Debug, PartialEq)]
+pub enum Response {
+    Sat,
+    Unsat,
+    Unknown,
+}
+
+pub trait Solver: Sized {
+    type Term: Clone;
+    type Config: Send + Sync;
+    fn new(config: &Self::Config) -> io::Result<Self>;
+    fn declare(&mut self, name: &str, width: usize) -> io::Result<BitVec<Self::Term>>;
+    fn numerical(&mut self, width: usize, value: u64) -> BitVec<Self::Term>;
+    fn true_bv(&mut self) -> BitVec<Self::Term> {
+        self.numerical(1, 1)
+    }
+    fn false_bv(&mut self) -> BitVec<Self::Term> {
+        self.numerical(1, 0)
+    }
+    fn from_raw_str(&mut self, width: usize, value: &str) -> BitVec<Self::Term>;
+    fn zero_width(&mut self) -> BitVec<Self::Term> {
+        BitVec::ZeroWidth
+    }
+    fn get_value(&mut self, bit_vec: &BitVec<Self::Term>, ty: &ir::Type) -> io::Result<IrValue>;
+    fn extract(&mut self, bit_vec: &BitVec<Self::Term>, high: i32, low: i32) -> BitVec<Self::Term>;
+    fn slice(
+        &mut self,
+        bit_vec: &BitVec<Self::Term>,
+        start: usize,
+        width: usize,
+    ) -> BitVec<Self::Term> {
+        self.extract(bit_vec, (start + width - 1) as i32, start as i32)
+    }
+    fn not(&mut self, bit_vec: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn neg(&mut self, bit_vec: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn reverse(&mut self, bit_vec: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn or_reduce(&mut self, bit_vec: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn and_reduce(&mut self, bit_vec: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn xor_reduce(&mut self, bit_vec: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn add(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn sub(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn mul(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn udiv(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn urem(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn srem(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn sdiv(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn shl(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn lshr(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn ashr(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn concat(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn or(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn and(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn xor(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn nor(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn nand(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn extend(
+        &mut self,
+        bit_vec: &BitVec<Self::Term>,
+        extend_width: usize,
+        signed: bool,
+    ) -> BitVec<Self::Term>;
+    fn extend_to(
+        &mut self,
+        bit_vec: &BitVec<Self::Term>,
+        new_width: usize,
+        signed: bool,
+    ) -> BitVec<Self::Term> {
+        let width = bit_vec.get_width();
+        assert!(new_width >= width, "Cannot extend to smaller width");
+        self.extend(bit_vec, new_width - width, signed)
+    }
+    fn zero_extend(
+        &mut self,
+        bit_vec: &BitVec<Self::Term>,
+        extend_width: usize,
+    ) -> BitVec<Self::Term> {
+        self.extend(bit_vec, extend_width, false)
+    }
+    fn sign_extend(
+        &mut self,
+        bit_vec: &BitVec<Self::Term>,
+        extend_width: usize,
+    ) -> BitVec<Self::Term> {
+        self.extend(bit_vec, extend_width, true)
+    }
+    fn zero_extend_to(
+        &mut self,
+        bit_vec: &BitVec<Self::Term>,
+        new_width: usize,
+    ) -> BitVec<Self::Term> {
+        self.extend_to(bit_vec, new_width, false)
+    }
+    fn sign_extend_to(
+        &mut self,
+        bit_vec: &BitVec<Self::Term>,
+        new_width: usize,
+    ) -> BitVec<Self::Term> {
+        self.extend_to(bit_vec, new_width, true)
+    }
+    fn ite(
+        &mut self,
+        lhs: &BitVec<Self::Term>,
+        then: &BitVec<Self::Term>,
+        else_: &BitVec<Self::Term>,
+    ) -> BitVec<Self::Term>;
+    fn eq(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn ne(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn slt(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn sgt(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn sle(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn sge(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn ult(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn ugt(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn ule(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn uge(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term>;
+    fn push(&mut self) -> io::Result<()>;
+    fn pop(&mut self) -> io::Result<()>;
+    fn check(&mut self) -> io::Result<Response>;
+    fn assert(&mut self, bit_vec: &BitVec<Self::Term>) -> io::Result<()>;
+    fn render(&mut self, bit_vec: &BitVec<Self::Term>) -> String;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BitVec<Rep> {
+    BitVec { width: usize, rep: Rep },
+    ZeroWidth,
+}
+
+impl<Rep> BitVec<Rep> {
+    pub fn get_width(&self) -> usize {
+        match self {
+            BitVec::BitVec { width, .. } => *width,
+            BitVec::ZeroWidth => 0,
+        }
+    }
+
+    pub fn get_rep(&self) -> Option<&Rep> {
+        match self {
+            BitVec::BitVec { rep, .. } => Some(rep),
+            BitVec::ZeroWidth => None,
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test_utils {
+    use super::*;
+    pub fn test_bitvec_equiv_basic<S: Solver>(solver: &mut S) {
+        let a = solver.declare("a", 16).unwrap();
+        let eq_constraint = solver.eq(&a, &a);
+        solver.assert(&eq_constraint).unwrap();
+        assert_eq!(solver.check().unwrap(), Response::Sat);
+    }
+
+    pub fn test_numerical_inbound<S: Solver>(solver: &mut S) {
+        let a = solver.declare("a", 16).unwrap();
+        let b = solver.numerical(16, 14);
+        let eq_constraint = solver.eq(&a, &b);
+        solver.assert(&eq_constraint).unwrap();
+        assert_eq!(solver.check().unwrap(), Response::Sat);
+        assert_eq!(
+            solver.get_value(&a, &ir::Type::Bits(16)).unwrap(),
+            IrValue::make_ubits(16, 14).unwrap()
+        );
+    }
+
+    pub fn test_numerical_outbound<S: Solver>(solver: &mut S) {
+        let a = solver.declare("a", 16).unwrap();
+        let b = solver.numerical(16, 0xfedca);
+        let eq_constraint = solver.eq(&a, &b);
+        solver.assert(&eq_constraint).unwrap();
+        assert_eq!(solver.check().unwrap(), Response::Sat);
+        assert_eq!(
+            solver.get_value(&a, &ir::Type::Bits(16)).unwrap(),
+            IrValue::make_ubits(16, 0xedca).unwrap()
+        );
+    }
+
+    pub fn test_extract<S: Solver>(solver: &mut S) {
+        let a = solver.declare("a", 8).unwrap();
+        let b = solver.numerical(16, 0x89ab);
+        let c = solver.extract(&b, 12, 5);
+        let eq_constraint = solver.eq(&a, &c);
+        solver.assert(&eq_constraint).unwrap();
+        assert_eq!(solver.check().unwrap(), Response::Sat);
+        assert_eq!(
+            solver.get_value(&a, &ir::Type::Bits(8)).unwrap(),
+            IrValue::make_ubits(8, 0x4d).unwrap()
+        );
+    }
+
+    pub fn test_slice<S: Solver>(solver: &mut S) {
+        let a = solver.declare("a", 8).unwrap();
+        let b = solver.numerical(16, 0x89ab);
+        let c = solver.slice(&b, 5, 8);
+        let eq_constraint = solver.eq(&a, &c);
+        solver.assert(&eq_constraint).unwrap();
+        assert_eq!(solver.check().unwrap(), Response::Sat);
+        assert_eq!(
+            solver.get_value(&a, &ir::Type::Bits(8)).unwrap(),
+            IrValue::make_ubits(8, 0x4d).unwrap()
+        );
+    }
+
+    pub fn assert_solver_eq<S: Solver>(
+        solver: &mut S,
+        lhs: &BitVec<S::Term>,
+        rhs: &BitVec<S::Term>,
+    ) {
+        solver.push().unwrap();
+        let eq_constraint = solver.eq(&lhs, &rhs);
+        solver.assert(&eq_constraint).unwrap();
+        assert_eq!(solver.check().unwrap(), Response::Sat);
+        solver.pop().unwrap();
+        solver.push().unwrap();
+        let ne_constraint = solver.ne(&lhs, &rhs);
+        solver.assert(&ne_constraint).unwrap();
+        assert_eq!(solver.check().unwrap(), Response::Unsat);
+        solver.pop().unwrap();
+    }
+
+    #[macro_export]
+    macro_rules! test_get_value {
+        ($fn_name:ident,
+         $solver:expr,
+         $in_w:expr,  $in_val:expr,
+         $out_ty:expr, $out_val:expr $(,)?
+        ) => {
+            #[test]
+            fn $fn_name() {
+                let mut solver = $solver;
+                let operand = solver.from_raw_str($in_w, $in_val);
+                solver.check().unwrap();
+                let actual = solver.get_value(&operand, &$out_ty).unwrap();
+                let expected = $out_val;
+                assert_eq!(actual, expected);
+            }
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Generic "one-operand → one result" test helper for Solver.
+    //
+    //  • `$fn_name`     – the Rust test-function identifier that will be
+    //                     generated by the macro.
+    //  • `$op`          – the `Solver` method to call (e.g. `not`, `neg`,
+    //                     `reverse`, `or_reduce`, …).
+    //  • `$in_w`        – bit-width of the operand fed to the solver.
+    //  • `$in_val`      – literal value of that operand.
+    //  • `$out_w`       – bit-width expected from the operation
+    //                     (use 1 for reductions).
+    //  • `$out_val`     – literal value expected from the operation.
+    // -----------------------------------------------------------------------
+    #[macro_export]
+    macro_rules! test_solver_unary {
+        ($fn_name:ident,
+         $solver:expr,
+         $op:ident,
+         $in_w:expr,  $in_val:expr,
+         $out_w:expr, $out_val:expr $(,)?
+        ) => {
+            #[test]
+            fn $fn_name() {
+                // Arrange
+                let mut solver = $solver;
+                let operand = solver.numerical($in_w, $in_val);
+
+                // Act
+                let actual = solver.$op(&operand);
+                let expected = solver.numerical($out_w, $out_val);
+                // Assert (via the common helper already in the file)
+                crate::equiv::solver_interface::test_utils::assert_solver_eq(
+                    &mut solver,
+                    &actual,
+                    &expected,
+                );
+            }
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Generic "two-operand → one result" test helper for Solver.
+    //
+    //  • `$fn_name`     – the Rust test-function identifier that will be
+    //                     generated by the macro.
+    //  • `$op`          – the `Solver` method to call (e.g. `add`, `sub`,
+    //                     `mul`, `udiv`, …).
+    //  • `$in_w`        – bit-width of the operands fed to the solver.
+    //  • `$in_val`      – literal value of that operand.
+    //  • `$out_w`       – bit-width expected from the operation
+    //                     (use 1 for reductions).
+    //  • `$out_val`     – literal value expected from the operation.
+    // -----------------------------------------------------------------------
+    #[macro_export]
+    macro_rules! test_solver_binary {
+        ($fn_name:ident,
+         $solver:expr,
+         $op:ident,
+         $in_w:expr,  $in_val1:expr, $in_val2:expr,
+         $out_w:expr, $out_val:expr $(,)?
+        ) => {
+            #[test]
+            fn $fn_name() {
+                // Arrange
+                let mut solver = $solver;
+                let operand1 = solver.numerical($in_w, $in_val1);
+                let operand2 = solver.numerical($in_w, $in_val2);
+
+                // Act
+                let actual = solver.$op(&operand1, &operand2);
+                let expected = solver.numerical($out_w, $out_val);
+
+                // Assert (via the common helper already in the file)
+                crate::equiv::solver_interface::test_utils::assert_solver_eq(
+                    &mut solver,
+                    &actual,
+                    &expected,
+                );
+            }
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Generic "extend" test helper (both zero_extend/sign_extend variants).
+    // The operator must have the signature (BitVec, usize) -> BitVec.
+    // -----------------------------------------------------------------------
+    #[macro_export]
+    macro_rules! test_solver_extend {
+        ($fn_name:ident,
+         $solver:expr,
+         $op:ident,
+         $in_w:expr,  $in_val:expr,
+         $ext_arg:expr,
+         $out_w:expr, $out_val:expr $(,)?
+        ) => {
+            #[test]
+            fn $fn_name() {
+                let mut solver = $solver;
+                let operand = solver.numerical($in_w, $in_val);
+                let actual = solver.$op(&operand, $ext_arg);
+                let expected = solver.numerical($out_w, $out_val);
+                crate::equiv::solver_interface::test_utils::assert_solver_eq(
+                    &mut solver,
+                    &actual,
+                    &expected,
+                );
+            }
+        };
+    }
+
+    // -------------------------------------------------------------------
+    // Macro for ITE tests
+    // -------------------------------------------------------------------
+    #[macro_export]
+    macro_rules! test_solver_ite {
+        ($fn_name:ident,
+         $solver:expr,
+         $cond_val:expr, $then_val:expr, $else_val:expr, $expected_val:expr $(,)?) => {
+            #[test]
+            fn $fn_name() {
+                let mut solver = $solver;
+                let cond = solver.numerical(1, $cond_val);
+                let then_val = solver.numerical(8, $then_val);
+                let else_val = solver.numerical(8, $else_val);
+                let actual = solver.ite(&cond, &then_val, &else_val);
+                let expected = solver.numerical(8, $expected_val);
+                crate::equiv::solver_interface::test_utils::assert_solver_eq(
+                    &mut solver,
+                    &actual,
+                    &expected,
+                );
+            }
+        };
+    }
+
+    // -------------------------------------------------------------------
+    // Comparison operator tests (eq, ne, slt … uge)
+    // -------------------------------------------------------------------
+    #[macro_export]
+    macro_rules! test_solver_cmp {
+        ($fn_name:ident,
+         $solver:expr,
+         $op:ident,
+         $w:expr, $lhs:expr, $rhs:expr, $expected:expr $(,)?) => {
+            #[test]
+            fn $fn_name() {
+                let mut solver = $solver;
+                let lhs = solver.numerical($w, $lhs);
+                let rhs = solver.numerical($w, $rhs);
+                let actual = solver.$op(&lhs, &rhs);
+                let expected = solver.numerical(1, $expected);
+                crate::equiv::solver_interface::test_utils::assert_solver_eq(
+                    &mut solver,
+                    &actual,
+                    &expected,
+                );
+            }
+        };
+    }
+
+    #[macro_export]
+    macro_rules! test_solver_cmp_zero_width {
+        ($fn_name:ident,
+         $solver:expr,
+         $op:ident,
+         $expected:expr) => {
+            #[test]
+            fn $fn_name() {
+                let mut solver = $solver;
+                let lhs = solver.zero_width();
+                let rhs = solver.zero_width();
+                let actual = solver.$op(&lhs, &rhs);
+                let expected = $expected(&mut solver);
+                crate::equiv::solver_interface::test_utils::assert_solver_eq(
+                    &mut solver,
+                    &actual,
+                    &expected,
+                );
+            }
+        };
+    }
+}
+
+#[cfg(test)]
+#[macro_export]
+macro_rules! test_solver {
+    ($mod_ident:ident, $solver:expr) => {
+        #[cfg(test)]
+        mod $mod_ident {
+            use crate::equiv::solver_interface::Solver;
+            use crate::equiv::solver_interface::test_utils;
+
+            #[test]
+            fn test_bitvec_equiv_basic() {
+                let mut solver = $solver;
+
+                test_utils::test_bitvec_equiv_basic(&mut solver);
+            }
+
+            #[test]
+            fn test_numerical_inbound() {
+                let mut solver = $solver;
+                test_utils::test_numerical_inbound(&mut solver);
+            }
+
+            #[test]
+            fn test_numerical_outbound() {
+                let mut solver = $solver;
+                test_utils::test_numerical_outbound(&mut solver);
+            }
+
+            crate::test_get_value!(
+                test_get_value_hex,
+                $solver,
+                8,
+                "#x53",
+                crate::xls_ir::ir::Type::Tuple(vec![
+                    Box::new(crate::xls_ir::ir::Type::Bits(2)),
+                    Box::new(crate::xls_ir::ir::Type::Bits(1)),
+                    Box::new(crate::xls_ir::ir::Type::Bits(5))
+                ]),
+                xlsynth::IrValue::make_tuple(&[
+                    xlsynth::IrValue::make_ubits(2, 0b11).unwrap(),
+                    xlsynth::IrValue::make_ubits(1, 0b0).unwrap(),
+                    xlsynth::IrValue::make_ubits(5, 0b01010).unwrap(),
+                ])
+            );
+
+            crate::test_get_value!(
+                test_get_value_bin,
+                $solver,
+                8,
+                "#b01010011",
+                crate::xls_ir::ir::Type::Tuple(vec![
+                    Box::new(crate::xls_ir::ir::Type::Bits(2)),
+                    Box::new(crate::xls_ir::ir::Type::Bits(1)),
+                    Box::new(crate::xls_ir::ir::Type::Bits(5))
+                ]),
+                xlsynth::IrValue::make_tuple(&[
+                    xlsynth::IrValue::make_ubits(2, 0b11).unwrap(),
+                    xlsynth::IrValue::make_ubits(1, 0b0).unwrap(),
+                    xlsynth::IrValue::make_ubits(5, 0b01010).unwrap(),
+                ])
+            );
+
+            #[test]
+            fn test_extract() {
+                let mut solver = $solver;
+                test_utils::test_extract(&mut solver);
+            }
+
+            #[test]
+            fn test_slice() {
+                let mut solver = $solver;
+                test_utils::test_slice(&mut solver);
+            }
+
+            crate::test_solver_unary!(test_not, $solver, not, 8, 0x89, 8, 0x76);
+            crate::test_solver_unary!(test_neg, $solver, neg, 8, 0x05, 8, 0xFB);
+
+            // Bit-reverse (16-bit example)
+            crate::test_solver_unary!(test_reverse, $solver, reverse, 16, 0x1234, 16, 0x2c48);
+
+            // OR-reduce, AND-reduce, XOR-reduce examples
+            crate::test_solver_unary!(test_or_reduce_some, $solver, or_reduce, 4, 0b1010, 1, 1);
+            crate::test_solver_unary!(
+                test_or_reduce_all_zeros,
+                $solver,
+                or_reduce,
+                4,
+                0b0000,
+                1,
+                0
+            );
+            crate::test_solver_unary!(test_and_reduce_some, $solver, and_reduce, 4, 0b1010, 1, 0);
+            crate::test_solver_unary!(
+                test_and_reduce_all_ones,
+                $solver,
+                and_reduce,
+                4,
+                0b1111,
+                1,
+                1
+            );
+            crate::test_solver_unary!(
+                test_xor_reduce_odd_ones,
+                $solver,
+                xor_reduce,
+                4,
+                0b1011,
+                1,
+                1
+            );
+            crate::test_solver_unary!(
+                test_xor_reduce_even_ones,
+                $solver,
+                xor_reduce,
+                4,
+                0b1010,
+                1,
+                0
+            );
+
+            crate::test_solver_binary!(test_add, $solver, add, 8, 0x15, 0x93, 8, 0xa8);
+            crate::test_solver_binary!(test_add_overflow, $solver, add, 8, 0x75, 0x9c, 8, 0x11);
+            crate::test_solver_binary!(test_sub, $solver, sub, 8, 0x93, 0x15, 8, 0x7e);
+            crate::test_solver_binary!(test_sub_overflow, $solver, sub, 8, 0x15, 0x93, 8, 0x82);
+            crate::test_solver_binary!(test_mul, $solver, mul, 8, 0x15, 0x03, 8, 0x3f);
+            crate::test_solver_binary!(test_mul_overflow, $solver, mul, 8, 0x53, 0x42, 8, 0x66);
+            crate::test_solver_binary!(test_udiv, $solver, udiv, 8, 0x05, 0x03, 8, 0x01);
+            crate::test_solver_binary!(test_urem, $solver, urem, 8, 0x05, 0x03, 8, 0x02);
+            crate::test_solver_binary!(test_srem, $solver, srem, 8, 0x05, 0x03, 8, 0x02);
+            crate::test_solver_binary!(test_sdiv, $solver, sdiv, 8, 0x05, 0x03, 8, 0x01);
+
+            // -----------------------------
+            // Division / remainder edge-case tests (SMT-LIB semantics)
+            // -----------------------------
+
+            // Unsigned division/rem: divisor = 0 → udiv = all 1s, urem = dividend
+            crate::test_solver_binary!(test_udiv_by_zero, $solver, udiv, 8, 0x05, 0x00, 8, 0xFF);
+            crate::test_solver_binary!(test_urem_by_zero, $solver, urem, 8, 0x05, 0x00, 8, 0x05);
+            crate::test_solver_binary!(
+                test_udiv_zero_by_zero,
+                $solver,
+                udiv,
+                8,
+                0x00,
+                0x00,
+                8,
+                0xFF
+            );
+            crate::test_solver_binary!(
+                test_urem_zero_by_zero,
+                $solver,
+                urem,
+                8,
+                0x00,
+                0x00,
+                8,
+                0x00
+            );
+
+            // Signed division/rem: divisor = 0 → sdiv = all 1s or 1, srem = dividend
+            // (SMT-LIB spec)
+            crate::test_solver_binary!(
+                test_sdiv_pos_by_zero,
+                $solver,
+                sdiv,
+                8,
+                0x05,
+                0x00,
+                8,
+                0xFF
+            );
+            crate::test_solver_binary!(
+                test_srem_pos_by_zero,
+                $solver,
+                srem,
+                8,
+                0x05,
+                0x00,
+                8,
+                0x05
+            );
+            crate::test_solver_binary!(
+                test_sdiv_zero_by_zero,
+                $solver,
+                sdiv,
+                8,
+                0x00,
+                0x00,
+                8,
+                0xFF
+            );
+            crate::test_solver_binary!(
+                test_srem_zero_by_zero,
+                $solver,
+                srem,
+                8,
+                0x00,
+                0x00,
+                8,
+                0x00
+            );
+            crate::test_solver_binary!(
+                test_sdiv_neg_by_zero,
+                $solver,
+                sdiv,
+                8,
+                0xFB,
+                0x00,
+                8,
+                0x01
+            );
+            crate::test_solver_binary!(
+                test_srem_neg_by_zero,
+                $solver,
+                srem,
+                8,
+                0xFB,
+                0x00,
+                8,
+                0xFB
+            );
+
+            // Signed INT_MIN / -1 → result = INT_MIN, remainder = 0
+            crate::test_solver_binary!(
+                test_sdiv_intmin_neg_one,
+                $solver,
+                sdiv,
+                8,
+                0x80,
+                0xFF,
+                8,
+                0x80
+            );
+            crate::test_solver_binary!(
+                test_srem_intmin_neg_one,
+                $solver,
+                srem,
+                8,
+                0x80,
+                0xFF,
+                8,
+                0x00
+            );
+
+            // Various sign combinations for signed division/remainder
+            // -5 / 3  → -1, rem = -2
+            crate::test_solver_binary!(test_sdiv_neg_pos, $solver, sdiv, 8, 0xFB, 0x03, 8, 0xFF);
+            crate::test_solver_binary!(test_srem_neg_pos, $solver, srem, 8, 0xFB, 0x03, 8, 0xFE);
+            // 5 / -3  → -1, rem = 2
+            crate::test_solver_binary!(test_sdiv_pos_neg, $solver, sdiv, 8, 0x05, 0xFD, 8, 0xFF);
+            crate::test_solver_binary!(test_srem_pos_neg, $solver, srem, 8, 0x05, 0xFD, 8, 0x02);
+            // -5 / -3 → 1,  rem = -2
+            crate::test_solver_binary!(test_sdiv_neg_neg, $solver, sdiv, 8, 0xFB, 0xFD, 8, 0x01);
+            crate::test_solver_binary!(test_srem_neg_neg, $solver, srem, 8, 0xFB, 0xFD, 8, 0xFE);
+
+            // Shift operations -------------------------------------------------------
+            crate::test_solver_binary!(test_shl_1, $solver, shl, 8, 0x96, 0x01, 8, 0x2C);
+            crate::test_solver_binary!(test_lshr_1, $solver, lshr, 8, 0x96, 0x01, 8, 0x4B);
+            crate::test_solver_binary!(test_ashr_1, $solver, ashr, 8, 0x96, 0x01, 8, 0xCB);
+
+            crate::test_solver_binary!(test_shl_by_zero, $solver, shl, 8, 0xAA, 0x00, 8, 0xAA);
+            crate::test_solver_binary!(test_lshr_by_zero, $solver, lshr, 8, 0xAA, 0x00, 8, 0xAA);
+            crate::test_solver_binary!(test_ashr_by_zero, $solver, ashr, 8, 0xAA, 0x00, 8, 0xAA);
+
+            // Shift by width (8) should zero-fill for shl/lshr; ashr depends on sign
+            crate::test_solver_binary!(test_shl_by_width, $solver, shl, 8, 0xAA, 0x08, 8, 0x00);
+            crate::test_solver_binary!(test_lshr_by_width, $solver, lshr, 8, 0xAA, 0x08, 8, 0x00);
+            crate::test_solver_binary!(
+                test_ashr_pos_by_width,
+                $solver,
+                ashr,
+                8,
+                0x21,
+                0x08,
+                8,
+                0x00
+            );
+            crate::test_solver_binary!(
+                test_ashr_neg_by_width,
+                $solver,
+                ashr,
+                8,
+                0x80,
+                0x08,
+                8,
+                0xFF
+            );
+
+            crate::test_solver_binary!(test_or, $solver, or, 4, 0b1010, 0b1100, 4, 0b1110);
+            crate::test_solver_binary!(test_and, $solver, and, 4, 0b1010, 0b1100, 4, 0b1000);
+            crate::test_solver_binary!(test_xor, $solver, xor, 4, 0b1010, 0b1100, 4, 0b0110);
+            crate::test_solver_binary!(test_nor, $solver, nor, 4, 0b1010, 0b1100, 4, 0b0001);
+            crate::test_solver_binary!(test_nand, $solver, nand, 4, 0b1010, 0b1100, 4, 0b0111);
+
+            crate::test_solver_extend!(
+                test_zero_extend_zero,
+                $solver,
+                zero_extend,
+                4,
+                0b1010,
+                0,
+                4,
+                0xA
+            );
+            crate::test_solver_extend!(
+                test_sign_extend_zero,
+                $solver,
+                sign_extend,
+                4,
+                0b1010,
+                0,
+                4,
+                0xA
+            );
+            crate::test_solver_extend!(
+                test_zero_extend,
+                $solver,
+                zero_extend,
+                4,
+                0b1010,
+                4,
+                8,
+                0x0A
+            );
+            crate::test_solver_extend!(
+                test_sign_extend_positive,
+                $solver,
+                sign_extend,
+                4,
+                0b0010,
+                4,
+                8,
+                0x02
+            );
+            crate::test_solver_extend!(
+                test_sign_extend_negative,
+                $solver,
+                sign_extend,
+                4,
+                0b1010,
+                4,
+                8,
+                0xFA
+            );
+
+            crate::test_solver_extend!(
+                test_zero_extend_to,
+                $solver,
+                zero_extend_to,
+                4,
+                0b1010,
+                8,
+                8,
+                0x0A
+            );
+            crate::test_solver_extend!(
+                test_sign_extend_to_positive,
+                $solver,
+                sign_extend_to,
+                4,
+                0b0010,
+                8,
+                8,
+                0x02
+            );
+            crate::test_solver_extend!(
+                test_sign_extend_to_negative,
+                $solver,
+                sign_extend_to,
+                4,
+                0b1010,
+                8,
+                8,
+                0xFA
+            );
+            crate::test_solver_ite!(test_ite_true, $solver, 1, 0x55, 0xAA, 0x55);
+            crate::test_solver_ite!(test_ite_false, $solver, 0, 0x55, 0xAA, 0xAA);
+
+            // eq / ne
+            crate::test_solver_cmp!(test_eq_true, $solver, eq, 8, 0x5A, 0x5A, 1);
+            crate::test_solver_cmp!(test_eq_false, $solver, eq, 8, 0x5A, 0x5B, 0);
+            crate::test_solver_cmp!(test_ne_true, $solver, ne, 8, 0x5A, 0x5B, 1);
+            crate::test_solver_cmp!(test_ne_false, $solver, ne, 8, 0x5A, 0x5A, 0);
+
+            // Signed comparisons: -3 (0xFD) vs 2 (0x02)
+            crate::test_solver_cmp!(test_slt_true, $solver, slt, 8, 0xFD, 0x02, 1);
+            crate::test_solver_cmp!(test_slt_false_eq, $solver, slt, 8, 0x02, 0x02, 0);
+            crate::test_solver_cmp!(test_slt_false_lt, $solver, slt, 8, 0x02, 0xFD, 0);
+            crate::test_solver_cmp!(test_sgt_true, $solver, sgt, 8, 0x02, 0xFD, 1);
+            crate::test_solver_cmp!(test_sgt_false_eq, $solver, sgt, 8, 0x02, 0x02, 0);
+            crate::test_solver_cmp!(test_sgt_false_lt, $solver, sgt, 8, 0xFD, 0x02, 0);
+            crate::test_solver_cmp!(test_sle_true_eq, $solver, sle, 8, 0x02, 0x02, 1);
+            crate::test_solver_cmp!(test_sle_true_lt, $solver, sle, 8, 0xFD, 0x02, 1);
+            crate::test_solver_cmp!(test_sle_false, $solver, sle, 8, 0x02, 0xFD, 0);
+            crate::test_solver_cmp!(test_sge_true_eq, $solver, sge, 8, 0x02, 0x02, 1);
+            crate::test_solver_cmp!(test_sge_true_gt, $solver, sge, 8, 0x02, 0xFD, 1);
+            crate::test_solver_cmp!(test_sge_false, $solver, sge, 8, 0xFD, 0x02, 0);
+
+            // Unsigned comparisons: 0x02 vs 0xFD (2 vs 253)
+            crate::test_solver_cmp!(test_ult_true, $solver, ult, 8, 0x02, 0xFD, 1);
+            crate::test_solver_cmp!(test_ult_false_eq, $solver, ult, 8, 0x02, 0x02, 0);
+            crate::test_solver_cmp!(test_ult_false_gt, $solver, ult, 8, 0xFD, 0x02, 0);
+            crate::test_solver_cmp!(test_ugt_true, $solver, ugt, 8, 0xFD, 0x02, 1);
+            crate::test_solver_cmp!(test_ugt_false_eq, $solver, ugt, 8, 0xAB, 0xAB, 0);
+            crate::test_solver_cmp!(test_ugt_false_gt, $solver, ugt, 8, 0x02, 0xFD, 0);
+            crate::test_solver_cmp!(test_ule_true_eq, $solver, ule, 8, 0x02, 0x02, 1);
+            crate::test_solver_cmp!(test_ule_true_lt, $solver, ule, 8, 0x02, 0xFD, 1);
+            crate::test_solver_cmp!(test_ule_false, $solver, ule, 8, 0xFD, 0x02, 0);
+            crate::test_solver_cmp!(test_uge_true_eq, $solver, uge, 8, 0xFD, 0xFD, 1);
+            crate::test_solver_cmp!(test_uge_true_gt, $solver, uge, 8, 0xFD, 0x02, 1);
+            crate::test_solver_cmp!(test_uge_false, $solver, uge, 8, 0x02, 0xFD, 0);
+
+            // Zero-width comparisons
+            crate::test_solver_cmp_zero_width!(test_eq_zero_width, $solver, eq, Solver::true_bv);
+            crate::test_solver_cmp_zero_width!(test_sle_zero_width, $solver, sle, Solver::true_bv);
+            crate::test_solver_cmp_zero_width!(test_sge_zero_width, $solver, sge, Solver::true_bv);
+            crate::test_solver_cmp_zero_width!(test_ule_zero_width, $solver, ule, Solver::true_bv);
+            crate::test_solver_cmp_zero_width!(test_uge_zero_width, $solver, uge, Solver::true_bv);
+            crate::test_solver_cmp_zero_width!(test_ne_zero_width, $solver, ne, Solver::false_bv);
+            crate::test_solver_cmp_zero_width!(test_slt_zero_width, $solver, slt, Solver::false_bv);
+            crate::test_solver_cmp_zero_width!(test_sgt_zero_width, $solver, sgt, Solver::false_bv);
+            crate::test_solver_cmp_zero_width!(test_ult_zero_width, $solver, ult, Solver::false_bv);
+            crate::test_solver_cmp_zero_width!(test_ugt_zero_width, $solver, ugt, Solver::false_bv);
+        }
+    };
+}

--- a/xlsynth-g8r/src/lib.rs
+++ b/xlsynth-g8r/src/lib.rs
@@ -13,6 +13,7 @@ pub mod dce;
 pub mod dslx_stitch_pipeline;
 pub mod emit_netlist;
 pub mod emitted_netlist_parser;
+pub mod equiv;
 pub mod fanout;
 pub mod find_structures;
 pub mod fraig;


### PR DESCRIPTION
This pull request adds a generic solver interface that could be used to abstract solvers accessed by both binary or FFI.
Binary interface through easy_smt is also added.

commit-id:6684c5bd

---

**Stack**:
- #420
- #419
- #415
- #413
- #412
- #411
- #410
- #409
- #408
- #407
- #406
- #405
- #404
- #403 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*