### PR TITLE
[g8r:ir_parse] Fix spacing assumptions for assume_in_bounds attribute and add attribute to array_update

### DIFF
--- a/xlsynth-g8r/src/ir_equiv_boolector.rs
+++ b/xlsynth-g8r/src/ir_equiv_boolector.rs
@@ -739,6 +739,7 @@ pub fn ir_fn_to_boolector(
                 array,
                 value,
                 indices,
+                assumed_in_bounds: _,
             } => {
                 assert_eq!(
                     indices.len(),

--- a/xlsynth-g8r/src/xls_ir/ir.rs
+++ b/xlsynth-g8r/src/xls_ir/ir.rs
@@ -340,6 +340,7 @@ pub enum NodePayload {
         array: NodeRef,
         value: NodeRef,
         indices: Vec<NodeRef>,
+        assumed_in_bounds: bool,
     },
     ArrayIndex {
         array: NodeRef,
@@ -566,15 +567,17 @@ impl NodePayload {
                 array,
                 value,
                 indices,
+                assumed_in_bounds,
             } => format!(
-                "array_update({}, {}, {})",
+                "array_update({}, {}, {}, assumed_in_bounds={})",
                 get_name(*array),
                 get_name(*value),
                 indices
                     .iter()
                     .map(|n| get_name(*n))
                     .collect::<Vec<String>>()
-                    .join(", ")
+                    .join(", "),
+                assumed_in_bounds
             ),
             NodePayload::ArrayIndex {
                 array,
@@ -882,6 +885,7 @@ impl Fn {
                         array,
                         value,
                         indices,
+                        assumed_in_bounds: _,
                     } => array == &node_ref || value == &node_ref || indices.contains(&node_ref),
                     ArrayIndex { array, indices, .. } => {
                         array == &node_ref || indices.contains(&node_ref)

--- a/xlsynth-g8r/src/xls_ir/ir_utils.rs
+++ b/xlsynth-g8r/src/xls_ir/ir_utils.rs
@@ -28,6 +28,7 @@ pub fn operands(payload: &NodePayload) -> Vec<NodeRef> {
             array,
             value,
             indices,
+            assumed_in_bounds: _,
         } => {
             let mut deps = vec![*array, *value];
             deps.extend(indices.iter().cloned());


### PR DESCRIPTION
## Summary
- support `array_index` assumed_in_bounds attribute without needing a space
- add `assumed_in_bounds` parsing for `array_update`
- include the entire line for token errors
- add regression tests for array_index and array_update without spaces

## Testing
- `cargo check --workspace`
- `cargo fuzz build`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_i_68702369afb88323b8767576fe0b2527