### PR TITLE
Fix memory leak in backends and add more backends to the fuzzer.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -603,7 +603,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev build-essential
+          sudo apt-get install -y pkg-config libssl-dev build-essential meson
 
       - name: Install protobuf compiler
         run: |
@@ -622,6 +622,11 @@ jobs:
           ls -l /usr/lib/libboolector.so
           ldconfig -p | grep boolector
 
+      - name: Install Z3 binary
+        run: |
+          sudo apt-get install -y z3
+
+
       - name: Download xlsynth tools for fuzzing
         run: |
           pip3 install -r requirements.txt
@@ -637,7 +642,7 @@ jobs:
         run: |
           cargo install cargo-fuzz
           cd xlsynth-g8r/fuzz
-          cargo fuzz run fuzz_ir_opt_equiv -- -max_total_time=10
+          cargo fuzz run fuzz_ir_opt_equiv --features with-z3-binary-test -- -max_total_time=10
 
       - name: Build and run fuzz_gatify for 10 seconds
         env:

--- a/xlsynth-g8r/fuzz/Cargo.toml
+++ b/xlsynth-g8r/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ env_logger = "0.11"
 xlsynth = { path = "../../xlsynth", version = "0.0.165" }
 rand = "0.8"
 xlsynth-test-helpers = { path = "../../xlsynth-test-helpers" }
-xlsynth-g8r = { path = "../../xlsynth-g8r", features = ["with-boolector-system", "with-z3-system"] }
+xlsynth-g8r = { path = "../../xlsynth-g8r", features = ["with-bitwuzla-built", "with-boolector-system", "with-z3-system"] }
 
 [lib]
 name = "xlsynth_g8r_fuzz"
@@ -66,3 +66,12 @@ name = "fuzz_gate_fn_aiger_roundtrip"
 path = "fuzz_targets/fuzz_gate_fn_aiger_roundtrip.rs"
 test = false
 doc = false
+
+[features]
+# No default optional features; required solver integrations are always enabled via dependency specification above.
+default = []
+has-easy-smt = []
+# Forward selected optional solver/testing features to xlsynth-g8r so callers can enable them on this crate.
+with-boolector-binary-test = ["has-easy-smt", "xlsynth-g8r/with-boolector-binary-test"]
+with-bitwuzla-binary-test = ["has-easy-smt", "xlsynth-g8r/with-bitwuzla-binary-test"]
+with-z3-binary-test = ["has-easy-smt", "xlsynth-g8r/with-z3-binary-test"]

--- a/xlsynth-g8r/src/equiv/bitwuzla_backend.rs
+++ b/xlsynth-g8r/src/equiv/bitwuzla_backend.rs
@@ -44,7 +44,7 @@ use bitwuzla_sys::{
     bitwuzla_mk_const, bitwuzla_mk_term1, bitwuzla_mk_term1_indexed1, bitwuzla_mk_term1_indexed2,
     bitwuzla_mk_term2, bitwuzla_mk_term3, bitwuzla_new, bitwuzla_options_delete,
     bitwuzla_options_new, bitwuzla_pop, bitwuzla_push, bitwuzla_set_option,
-    bitwuzla_set_option_mode, bitwuzla_term_manager_new, bitwuzla_term_manager_release,
+    bitwuzla_set_option_mode, bitwuzla_term_manager_delete, bitwuzla_term_manager_new,
     bitwuzla_term_to_string, bitwuzla_term_value_get_str,
 };
 
@@ -71,7 +71,8 @@ impl Drop for RawBitwuzla {
     fn drop(&mut self) {
         unsafe {
             bitwuzla_delete(self.raw);
-            bitwuzla_term_manager_release(self.term_manager);
+            // Bitwuzla doesn't require us to release the terms prior to calling the delete.
+            bitwuzla_term_manager_delete(self.term_manager);
         };
     }
 }

--- a/xlsynth-g8r/src/equiv/boolector_backend.rs
+++ b/xlsynth-g8r/src/equiv/boolector_backend.rs
@@ -13,13 +13,14 @@ use boolector_sys::{
     BTOR_OPT_INCREMENTAL, BTOR_OPT_MODEL_GEN, BoolectorNode, Btor, BtorOption, boolector_add,
     boolector_and, boolector_assert, boolector_bitvec_sort, boolector_bv_assignment,
     boolector_concat, boolector_cond, boolector_const, boolector_consth, boolector_delete,
-    boolector_eq, boolector_free_bv_assignment, boolector_mul, boolector_nand, boolector_ne,
-    boolector_neg, boolector_new, boolector_nor, boolector_not, boolector_one, boolector_or,
-    boolector_pop, boolector_push, boolector_sat, boolector_sdiv, boolector_set_opt,
-    boolector_sext, boolector_sgt, boolector_sgte, boolector_slice, boolector_sll, boolector_slt,
-    boolector_slte, boolector_sra, boolector_srem, boolector_srl, boolector_sub, boolector_udiv,
-    boolector_uext, boolector_ugt, boolector_ugte, boolector_ult, boolector_ulte,
-    boolector_unsigned_int, boolector_urem, boolector_var, boolector_xor, boolector_zero,
+    boolector_eq, boolector_free_bv_assignment, boolector_get_refs, boolector_mul, boolector_nand,
+    boolector_ne, boolector_neg, boolector_new, boolector_nor, boolector_not, boolector_one,
+    boolector_or, boolector_pop, boolector_push, boolector_release_all, boolector_sat,
+    boolector_sdiv, boolector_set_opt, boolector_sext, boolector_sgt, boolector_sgte,
+    boolector_slice, boolector_sll, boolector_slt, boolector_slte, boolector_sra, boolector_srem,
+    boolector_srl, boolector_sub, boolector_udiv, boolector_uext, boolector_ugt, boolector_ugte,
+    boolector_ult, boolector_ulte, boolector_unsigned_int, boolector_urem, boolector_var,
+    boolector_xor, boolector_zero,
 };
 
 use crate::{
@@ -42,7 +43,13 @@ impl RawBtor {
 
 impl Drop for RawBtor {
     fn drop(&mut self) {
-        unsafe { boolector_delete(self.raw) };
+        unsafe {
+            // Boolector requires us to call `boolector_release_all` before
+            // calling `boolector_delete`.
+            boolector_release_all(self.raw);
+            assert_eq!(boolector_get_refs(self.raw) as i32, 0);
+            boolector_delete(self.raw)
+        };
     }
 }
 


### PR DESCRIPTION
There has been some incorrect usages of boolector and bitwuzla's FFI API. The terms and the solver needs to be correctly released and freed.

This pull request also adds boolector binary backend and easy_smt backend to the fuzzer. The legacy boolector backend is NOT fuzzed.

---

**Stack**:
- #426
- #420
- #432 ⬅
- #431


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*