### PR TITLE
Bump DSO to v0.0.212, introduce parametric query API, use in stitch command

### DIFF
--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.0.211";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.0.212";
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 3;
 
 struct DsoInfo {

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -224,6 +224,11 @@ pub struct CDslxModuleMember {
 }
 
 #[repr(C)]
+pub struct CDslxFunction {
+    _private: [u8; 0], // Ensures the struct cannot be instantiated
+}
+
+#[repr(C)]
 pub struct CScheduleAndCodegenResult {
     _private: [u8; 0], // Ensures the struct cannot be instantiated
 }
@@ -1392,6 +1397,14 @@ extern "C" {
         error_out: *mut *mut std::os::raw::c_char,
         name_out: *mut *mut std::os::raw::c_char,
     ) -> bool;
+
+    pub fn xls_dslx_module_member_get_function(
+        member: *const CDslxModuleMember,
+    ) -> *mut CDslxFunction;
+    pub fn xls_dslx_function_is_parametric(function: *const CDslxFunction) -> bool;
+    pub fn xls_dslx_function_get_identifier(
+        function: *const CDslxFunction,
+    ) -> *mut std::os::raw::c_char;
 }
 
 pub const DSLX_STDLIB_PATH: &str = env!("DSLX_STDLIB_PATH");

--- a/xlsynth/src/dslx.rs
+++ b/xlsynth/src/dslx.rs
@@ -184,6 +184,7 @@ pub enum MatchableModuleMember {
     StructDef(StructDef),
     TypeAlias(TypeAlias),
     ConstantDef(ConstantDef),
+    Function(Function),
 }
 
 impl ModuleMember {
@@ -217,6 +218,13 @@ impl ModuleMember {
                 Some(MatchableModuleMember::ConstantDef(ConstantDef {
                     parent: self.parent.clone(),
                     ptr: constant_def,
+                }))
+            }
+            ModuleMemberKind::Function => {
+                let func_ptr = unsafe { sys::xls_dslx_module_member_get_function(self.ptr) };
+                Some(MatchableModuleMember::Function(Function {
+                    parent: self.parent.clone(),
+                    ptr: func_ptr,
                 }))
             }
             _ => None,
@@ -570,6 +578,25 @@ impl TypeAlias {
             parent: self.parent.clone(),
             ptr: unsafe { sys::xls_dslx_type_alias_get_type_annotation(self.ptr) },
         }
+    }
+}
+
+/// Wrapper for a DSLX function definition.
+pub struct Function {
+    parent: Rc<TypecheckedModulePtr>,
+    ptr: *mut sys::CDslxFunction,
+}
+
+impl Function {
+    pub fn get_identifier(&self) -> String {
+        unsafe {
+            let c_str = sys::xls_dslx_function_get_identifier(self.ptr);
+            crate::c_str_to_rust(c_str)
+        }
+    }
+
+    pub fn is_parametric(&self) -> bool {
+        unsafe { sys::xls_dslx_function_is_parametric(self.ptr) }
     }
 }
 

--- a/xlsynth/src/dslx_bridge.rs
+++ b/xlsynth/src/dslx_bridge.rs
@@ -171,6 +171,9 @@ pub fn convert_imported_module(
             dslx::MatchableModuleMember::ConstantDef(constant_def) => {
                 convert_constant(&constant_def, &type_info, builder)?
             }
+            dslx::MatchableModuleMember::Function(function) => {
+                continue;
+            }
         }
     }
 


### PR DESCRIPTION
We wanted the stitch command to check that the `_cycle\d+` suffixed functions are concrete and not parametric.