### PR TITLE
Fix parsing of boolector get-value results

### DIFF
--- a/xlsynth-g8r/src/equiv/bitwuzla_backend.rs
+++ b/xlsynth-g8r/src/equiv/bitwuzla_backend.rs
@@ -750,7 +750,13 @@ impl Solver for Bitwuzla {
                     ty,
                 ))
             },
-            BitVec::ZeroWidth => panic!("Cannot get value of zero-width bitvector"),
+            BitVec::ZeroWidth => {
+                if matches!(ty, ir::Type::Token) {
+                    Ok(xlsynth::IrValue::make_token())
+                } else {
+                    panic!("Cannot get value of zero-width bitvector for type {:?}", ty)
+                }
+            }
         }
     }
 

--- a/xlsynth-g8r/src/equiv/boolector_backend.rs
+++ b/xlsynth-g8r/src/equiv/boolector_backend.rs
@@ -277,7 +277,13 @@ impl Solver for Boolector {
                     ty,
                 ))
             },
-            BitVec::ZeroWidth => panic!("Cannot get value of zero-width bitvector"),
+            BitVec::ZeroWidth => {
+                if matches!(ty, ir::Type::Token) {
+                    Ok(xlsynth::IrValue::make_token())
+                } else {
+                    panic!("Cannot get value of zero-width bitvector for type {:?}", ty)
+                }
+            }
         }
     }
 

--- a/xlsynth-g8r/src/equiv/easy_smt_backend.rs
+++ b/xlsynth-g8r/src/equiv/easy_smt_backend.rs
@@ -349,7 +349,13 @@ impl Solver for EasySmtSolver {
                     ty,
                 ))
             }
-            BitVec::ZeroWidth => panic!("Cannot get value of zero-width bitvector"),
+            BitVec::ZeroWidth => {
+                if matches!(ty, ir::Type::Token) {
+                    Ok(xlsynth::IrValue::make_token())
+                } else {
+                    panic!("Cannot get value of zero-width bitvector for type {:?}", ty)
+                }
+            }
         }
     }
 

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -315,6 +315,9 @@ extern "C" {
         values: *const *const CIrValue,
     ) -> *mut CIrValue;
 
+    // Create a token value
+    pub fn xls_value_make_token() -> *mut CIrValue;
+
     /// Returns an error:
     /// * if the elements do not all have the same type, or
     /// * if the array is empty (because then we cannot determine the element

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -7,8 +7,8 @@ use crate::{
         xls_bits_make_sbits, xls_bits_make_ubits, xls_bits_to_debug_str, xls_bits_to_string,
         xls_format_preference_from_string, xls_value_eq, xls_value_free, xls_value_get_bits,
         xls_value_get_element, xls_value_get_element_count, xls_value_make_array,
-        xls_value_make_sbits, xls_value_make_tuple, xls_value_make_ubits, xls_value_to_string,
-        xls_value_to_string_format_preference,
+        xls_value_make_sbits, xls_value_make_token, xls_value_make_tuple, xls_value_make_ubits,
+        xls_value_to_string, xls_value_to_string_format_preference,
     },
     xls_parse_typed_value,
     xlsynth_error::XlsynthError,
@@ -267,6 +267,10 @@ pub struct IrValue {
 }
 
 impl IrValue {
+    pub fn make_token() -> Self {
+        xls_value_make_token()
+    }
+
     pub fn make_tuple(elements: &[IrValue]) -> Self {
         xls_value_make_tuple(elements)
     }

--- a/xlsynth/src/lib_support.rs
+++ b/xlsynth/src/lib_support.rs
@@ -199,6 +199,12 @@ pub(crate) fn xls_value_make_sbits(value: i64, bit_count: usize) -> Result<IrVal
     Ok(IrValue { ptr: result })
 }
 
+pub(crate) fn xls_value_make_token() -> IrValue {
+    let result = unsafe { xlsynth_sys::xls_value_make_token() };
+    assert!(!result.is_null());
+    IrValue { ptr: result }
+}
+
 pub(crate) fn xls_value_make_tuple(elements: &[IrValue]) -> IrValue {
     unsafe {
         let elements_ptrs: Vec<*const CIrValue> =


### PR DESCRIPTION
Boolector is using true/false as their one-bit bitvector value, which isn't parsed correctly before. This pull request fixes it.

commit-id:01ed342e

---

**Stack**:
- #451
- #450
- #449
- #446
- #445
- #444
- #443 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*