### PR TITLE
Add help messages for assertion semantics

### DIFF
--- a/xlsynth-driver/src/ir_equiv.rs
+++ b/xlsynth-driver/src/ir_equiv.rs
@@ -335,9 +335,8 @@ pub fn handle_ir_equiv(matches: &clap::ArgMatches, config: &Option<ToolchainConf
     let lhs_path = std::path::Path::new(lhs);
     let rhs_path = std::path::Path::new(rhs);
     let assertion_semantics = matches
-        .get_one::<String>("assertion_semantics")
-        .map(|s| s.parse().unwrap())
-        .unwrap_or(AssertionSemantics::Same);
+        .get_one::<AssertionSemantics>("assertion_semantics")
+        .unwrap_or(&AssertionSemantics::Same);
 
     let solver: Option<SolverChoice> = matches
         .get_one::<String>("solver")
@@ -381,7 +380,7 @@ pub fn handle_ir_equiv(matches: &clap::ArgMatches, config: &Option<ToolchainConf
                     flatten_aggregates,
                     &drop_params,
                     strategy,
-                    assertion_semantics,
+                    *assertion_semantics,
                 );
             }
             #[cfg(feature = "has-easy-smt")]
@@ -406,7 +405,7 @@ pub fn handle_ir_equiv(matches: &clap::ArgMatches, config: &Option<ToolchainConf
                     flatten_aggregates,
                     &drop_params,
                     strategy,
-                    assertion_semantics,
+                    *assertion_semantics,
                 );
             }
             #[cfg(feature = "has-bitwuzla")]
@@ -425,7 +424,7 @@ pub fn handle_ir_equiv(matches: &clap::ArgMatches, config: &Option<ToolchainConf
                     flatten_aggregates,
                     &drop_params,
                     strategy,
-                    assertion_semantics,
+                    *assertion_semantics,
                 );
             }
             #[cfg(feature = "has-boolector")]
@@ -435,7 +434,7 @@ pub fn handle_ir_equiv(matches: &clap::ArgMatches, config: &Option<ToolchainConf
                     eprintln!("Error: --lhs_fixed_implicit_activation and --rhs_fixed_implicit_activation are not supported for boolector-legacy solver");
                     std::process::exit(1);
                 }
-                if assertion_semantics != AssertionSemantics::Same {
+                if *assertion_semantics != AssertionSemantics::Same {
                     eprintln!(
                         "Error: --assertion_semantics is not supported for boolector-legacy solver"
                     );

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -64,6 +64,8 @@ use clap::{Arg, ArgAction};
 use once_cell::sync::Lazy;
 use report_cli_error::report_cli_error_and_exit;
 use serde::Deserialize;
+use xlsynth_g8r::equiv::prove_equiv::AssertionSemantics;
+use xlsynth_g8r::equiv::prove_quickcheck::QuickCheckAssertionSemantics;
 
 static DEFAULT_ADDER_MAPPING: Lazy<String> =
     Lazy::new(|| xlsynth_g8r::ir2gate_utils::AdderMapping::default().to_string());
@@ -83,6 +85,7 @@ trait AppExt {
     fn add_ir2g8r_flags(self) -> Self;
 }
 
+// TODO: Change flags from using strings to using clap::ValueEnum.
 impl AppExt for clap::Command {
     fn add_delay_model_arg(self) -> Self {
         (self as clap::Command).arg(
@@ -546,7 +549,7 @@ fn main() {
                         .long("assertion-semantics")
                         .value_name("SEMANTICS")
                         .help("Assertion semantics")
-                        .value_parser(["ignore", "never", "same", "assume", "implies"])
+                        .value_parser(clap::value_parser!(AssertionSemantics))
                         .default_value("same")
                         .action(ArgAction::Set),
                 )
@@ -794,9 +797,9 @@ fn main() {
                     clap::Arg::new("assertion_semantics")
                         .long("assertion-semantics")
                         .value_name("SEM")
-                        .help("Assertion semantics: ignore | never | assume")
-                        .value_parser(["ignore", "never", "assume"])
-                        .default_value("never")
+                        .help("Assertion semantics")
+                        .value_parser(clap::value_parser!(QuickCheckAssertionSemantics))
+                        .default_value("ignore")
                         .action(clap::ArgAction::Set),
                 ),
         )

--- a/xlsynth-driver/src/prove_quickcheck.rs
+++ b/xlsynth-driver/src/prove_quickcheck.rs
@@ -130,9 +130,8 @@ pub fn handle_prove_quickcheck(matches: &clap::ArgMatches, config: &Option<Toolc
 
     // Assertion semantics.
     let assertion_semantics = matches
-        .get_one::<String>("assertion_semantics")
-        .map(|s| s.parse().unwrap())
-        .unwrap_or(QuickCheckAssertionSemantics::Assume);
+        .get_one::<QuickCheckAssertionSemantics>("assertion_semantics")
+        .unwrap_or(&QuickCheckAssertionSemantics::Ignore);
 
     // Helper closure that runs proof for a given solver type.
     fn run_for_solver<S: Solver>(
@@ -217,7 +216,7 @@ pub fn handle_prove_quickcheck(matches: &clap::ArgMatches, config: &Option<Toolc
                 &quickchecks,
                 &ir_text_result,
                 module_name,
-                assertion_semantics,
+                *assertion_semantics,
             );
         }
         #[cfg(feature = "has-bitwuzla")]
@@ -229,7 +228,7 @@ pub fn handle_prove_quickcheck(matches: &clap::ArgMatches, config: &Option<Toolc
                 &quickchecks,
                 &ir_text_result,
                 module_name,
-                assertion_semantics,
+                *assertion_semantics,
             );
         }
         #[cfg(feature = "has-easy-smt")]
@@ -246,7 +245,7 @@ pub fn handle_prove_quickcheck(matches: &clap::ArgMatches, config: &Option<Toolc
                 &quickchecks,
                 &ir_text_result,
                 module_name,
-                assertion_semantics,
+                *assertion_semantics,
             );
         }
     }

--- a/xlsynth-g8r/src/equiv/prove_equiv.rs
+++ b/xlsynth-g8r/src/equiv/prove_equiv.rs
@@ -924,27 +924,31 @@ pub enum EquivResult {
 ///  2. **Failure condition** – negation of the success condition; if *any*
 ///     model satisfies this predicate, the checker must report a
 ///     counter-example.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, clap::ValueEnum)]
 pub enum AssertionSemantics {
     /// Ignore all assertions.
+    ///
     /// 1. Success: `r_l == r_r`
     /// 2. Failure: `r_l != r_r`
     Ignore,
 
     /// Both sides must succeed and produce the same result – they can **never**
     /// fail.
+    ///
     /// 1. Success: `s_l ∧ s_r ∧ (r_l == r_r)`
     /// 2. Failure: `¬s_l ∨ ¬s_r ∨ (r_l != r_r)`
     Never,
 
     /// The two sides must fail in exactly the same way **or** both succeed with
     /// equal results.
+    ///
     /// 1. Success: `(¬s_l ∧ ¬s_r) ∨ (s_l ∧ s_r ∧ (r_l == r_r))`
     /// 2. Failure: `(s_l ⊕ s_r) ∨ (s_l ∧ s_r ∧ (r_l != r_r))`
     Same,
 
     /// We *assume* both sides do not fail. In other words, we only check that
     /// if they do succeed, their results must be equal.
+    ///
     /// 1. Success: `¬(s_l ∧ s_r) ∨ (r_l == r_r)`  (equivalently, `(s_l ∧ s_r) →
     ///    r_l == r_r`)
     /// 2. Failure: `s_l ∧ s_r ∧ (r_l != r_r)`
@@ -952,6 +956,7 @@ pub enum AssertionSemantics {
 
     /// If the left succeeds, the right must also succeed and match the
     /// result; if the left fails, the right is unconstrained.
+    ///
     /// 1. Success: `¬s_l ∨ (s_r ∧ (r_l == r_r))`
     /// 2. Failure: `s_l ∧ (¬s_r ∨ (r_l != r_r))`
     Implies,

--- a/xlsynth-g8r/src/equiv/prove_quickcheck.rs
+++ b/xlsynth-g8r/src/equiv/prove_quickcheck.rs
@@ -9,23 +9,14 @@ use crate::equiv::{
 
 use crate::equiv::prove_equiv::FnOutput;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub enum QuickCheckAssertionSemantics {
+    /// Assertions are just dropped entirely
     Ignore,
+    /// Prove that assertion conditions can never fire
     Never,
+    /// Assume that assertion conditions hold to try to help complete the proof
     Assume,
-}
-
-impl std::str::FromStr for QuickCheckAssertionSemantics {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "ignore" => Ok(QuickCheckAssertionSemantics::Ignore),
-            "never" => Ok(QuickCheckAssertionSemantics::Never),
-            "assume" => Ok(QuickCheckAssertionSemantics::Assume),
-            _ => Err(format!("invalid assertion semantics: {}", s)),
-        }
-    }
 }
 
 /// Result of proving that a boolean-returning function is always `true`.


### PR DESCRIPTION
In the future, we should probably change all such flags to use . This pull request only do this for assertion semantics