### PR TITLE
Fix the publish script to download the prove_quickcheck_main binary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python3 -V
           pip3 install --break-system-packages requests
-          python3 download_release.py -p arm64 -o xlsynth_tools
+          python3 download_release.py -p arm64 -o xlsynth_tools --binaries=dslx_interpreter_main,ir_converter_main,codegen_main,opt_main,check_ir_equivalence_main,dslx_fmt,typecheck_main,prove_quickcheck_main
 
       - name: Install protobuf compiler
         run: |


### PR DESCRIPTION
This is needed after introducing the tests for quickchecks.