### PR TITLE
Fix result printing bugs

### DIFF
--- a/xlsynth-driver/src/ir_equiv.rs
+++ b/xlsynth-driver/src/ir_equiv.rs
@@ -291,12 +291,16 @@ fn run_equiv_check<S: Solver>(
             std::process::exit(0);
         }
         EquivResult::Disproved {
-            inputs: cex,
-            outputs: (lhs_bits, rhs_bits),
+            lhs_inputs,
+            rhs_inputs,
+            lhs_output,
+            rhs_output,
         } => {
-            println!("failure: Solver found counterexample: {:?}", cex);
-            println!("    output LHS: {:?}", lhs_bits);
-            println!("    output RHS: {:?}", rhs_bits);
+            println!("failure: Solver found counterexample:");
+            println!("  inputs LHS: {:?}", lhs_inputs);
+            println!("  inputs RHS: {:?}", rhs_inputs);
+            println!("  output LHS: {:?}", lhs_output);
+            println!("  output RHS: {:?}", rhs_output);
             std::process::exit(1);
         }
     }

--- a/xlsynth-driver/src/prove_quickcheck.rs
+++ b/xlsynth-driver/src/prove_quickcheck.rs
@@ -164,10 +164,9 @@ pub fn handle_prove_quickcheck(matches: &clap::ArgMatches, config: &Option<Toolc
                 }
                 BoolPropertyResult::Disproved { inputs, output } => {
                     all_passed = false;
-                    println!(
-                        "QuickCheck '{}' disproved – counter-example: inputs={:?} output={} ",
-                        qc_name, inputs, output
-                    );
+                    println!("QuickCheck '{}' disproved", qc_name);
+                    println!("  Inputs: {:?}", inputs);
+                    println!("  Output: {:?}", output);
                 }
             }
         }

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
@@ -28,13 +28,13 @@ fn validate_equiv_result(
     match ext_equiv {
         Ok(()) => {
             // External tool says equivalent – solver must prove equivalence.
-            if let EquivResult::Disproved { inputs: cex, .. } = solver_result {
+            if let EquivResult::Disproved { lhs_inputs, rhs_inputs, .. } = solver_result {
                 log::info!("==== IR disagreement detected ====");
                 log::info!("Original IR:\n{}", orig_ir);
                 log::info!("Optimized IR:\n{}", opt_ir);
                 panic!(
-                    "Disagreement: external tool says equivalent, but {} solver disproves: {:?}",
-                    solver_name, cex
+                    "Disagreement: external tool says equivalent, but {} solver disproves: lhs_inputs={:?} rhs_inputs={:?}",
+                    solver_name, lhs_inputs, rhs_inputs
                 );
             }
         }

--- a/xlsynth-g8r/src/bin/check-ir-equivalence.rs
+++ b/xlsynth-g8r/src/bin/check-ir-equivalence.rs
@@ -75,23 +75,21 @@ fn main_has_bitwuzla(args: Args) {
             );
         }
         EquivResult::Disproved {
-            inputs: cex,
-            outputs: (lhs_val, rhs_val),
+            lhs_inputs,
+            rhs_inputs,
+            lhs_output,
+            rhs_output,
         } => {
             println!(
                 "Equivalence result (bitwuzla): DISPROVED (took {:?})",
                 bitwuzla_elapsed
             );
-            println!("Counterexample inputs:");
-            let values: Vec<_> = cex.iter().cloned().collect();
-            if values.len() == 1 {
-                println!("  {}", values[0]);
-            } else {
-                println!("  {:?}", values);
-            }
+            println!("failure: Solver found counterexample:");
+            println!("  inputs LHS: {:?}", lhs_inputs);
+            println!("  inputs RHS: {:?}", rhs_inputs);
             // Report outputs for the counterexample
-            println!("Output LHS: {}", lhs_val);
-            println!("Output RHS: {}", rhs_val);
+            println!("  output LHS: {:?}", lhs_output);
+            println!("  output RHS: {:?}", rhs_output);
         }
     }
 

--- a/xlsynth-g8r/src/equiv/prove_quickcheck.rs
+++ b/xlsynth-g8r/src/equiv/prove_quickcheck.rs
@@ -3,7 +3,7 @@
 use xlsynth::IrValue;
 
 use crate::equiv::{
-    prove_equiv::{IrFn, get_fn_inputs, ir_to_smt},
+    prove_equiv::{AssertionViolation, IrFn, get_fn_inputs, ir_to_smt},
     solver_interface::{BitVec, Response, Solver},
 };
 
@@ -31,7 +31,7 @@ pub enum BoolPropertyResult {
     Disproved {
         /// Concrete input values leading to failure. Kept in the same order as
         /// the function parameters after potential implicit-token handling.
-        inputs: Vec<IrValue>,
+        inputs: Vec<(String, IrValue)>,
         /// Concrete (possibly failing) output value observed for the
         /// counter-example.
         output: FnOutput,
@@ -111,10 +111,17 @@ where
         Response::Unsat => BoolPropertyResult::Proved,
         Response::Sat => {
             // Extract counter-example values.
-            let inputs: Vec<IrValue> = smt_fn
-                .inputs
+            let inputs: Vec<(String, IrValue)> = smt_fn
+                .fn_ref
+                .params
                 .iter()
-                .map(|i| solver.get_value(&i.bitvec, &i.ir_type).unwrap())
+                .zip(smt_fn.inputs.iter())
+                .map(|(p, i)| {
+                    (
+                        p.name.clone(),
+                        solver.get_value(&i.bitvec, &i.ir_type).unwrap(),
+                    )
+                })
                 .collect();
 
             // Determine if any assertion violated and build FnOutput accordingly
@@ -130,16 +137,16 @@ where
                 }
             }
 
-            let output: FnOutput = match violation {
-                Some((msg, lbl)) => FnOutput::AssertionViolation {
-                    message: msg,
-                    label: lbl,
-                },
-                None => FnOutput::Value(
-                    solver
+            let output: FnOutput = {
+                FnOutput {
+                    value: solver
                         .get_value(&smt_fn.output.bitvec, &smt_fn.output.ir_type)
                         .unwrap(),
-                ),
+                    assertion_violation: violation.map(|(msg, lbl)| AssertionViolation {
+                        message: msg,
+                        label: lbl,
+                    }),
+                }
             };
 
             BoolPropertyResult::Disproved { inputs, output }
@@ -211,8 +218,20 @@ mod test_utils {
         let res = super::prove_ir_fn_always_true::<S>(solver_config, &ir_fn, sem);
         match res {
             BoolPropertyResult::Disproved { output, .. } => match (expect_violation, output) {
-                (true, FnOutput::AssertionViolation { .. }) => {}
-                (false, FnOutput::Value(_)) => {}
+                (
+                    true,
+                    FnOutput {
+                        assertion_violation: Some(_),
+                        ..
+                    },
+                ) => {}
+                (
+                    false,
+                    FnOutput {
+                        assertion_violation: None,
+                        ..
+                    },
+                ) => {}
                 (true, other) => panic!("Expected AssertionViolation, got {:?}", other),
                 (false, other) => panic!("Expected Value, got {:?}", other),
             },
@@ -257,6 +276,60 @@ mod test_utils {
             ret p: (token, bits[1]) = tuple(assert.3, literal.2, id=4)
         }
     "#;
+
+    /// Ensure that counter-example input ordering matches function parameter
+    /// order.
+    ///
+    /// This mirrors the ordering check performed in
+    /// `prove_equiv::test_utils::test_counterexample_input_order`,
+    /// but for the QuickCheck path where we prove a single function is always
+    /// true. We create a trivially falsifiable function with multiple
+    /// parameters of differing widths and confirm that the returned
+    /// `inputs` vector from `BoolPropertyResult::Disproved` preserves the
+    /// declared parameter order and widths.
+    pub fn test_counterexample_input_order<S: Solver>(solver_config: &S::Config) {
+        // Intentionally not always-true: returns param `c`, so setting c=0 falsifies
+        // the property.
+        let ir_text = r#"
+            fn f(a: bits[8], b: bits[4], c: bits[1]) -> bits[1] {
+                ret pc: bits[1] = identity(c, id=1)
+            }
+        "#;
+
+        let mut parser = Parser::new(ir_text);
+        let f = parser.parse_fn().expect("Failed to parse IR function");
+        let ir_fn = IrFn {
+            fn_ref: &f,
+            fixed_implicit_activation: false,
+        };
+
+        let res = super::prove_ir_fn_always_true::<S>(
+            solver_config,
+            &ir_fn,
+            QuickCheckAssertionSemantics::Ignore,
+        );
+
+        match res {
+            BoolPropertyResult::Disproved { inputs, .. } => {
+                assert_eq!(inputs.len(), f.params.len());
+                for (idx, param) in f.params.iter().enumerate() {
+                    assert_eq!(
+                        inputs[idx].0, param.name,
+                        "param name mismatch at index {idx}"
+                    );
+                    assert_eq!(
+                        inputs[idx].1.bit_count().unwrap(),
+                        param.ty.bit_count(),
+                        "param bit width mismatch at index {idx}"
+                    );
+                }
+            }
+            other => panic!(
+                "Expected Disproved result with counterexample, got {:?}",
+                other
+            ),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -388,6 +461,12 @@ macro_rules! quickcheck_test_with_solver {
                     QuickCheckAssertionSemantics::Never,
                     true,
                 );
+            }
+
+            // New: ensure counterexample input ordering matches parameter order.
+            #[test]
+            fn counterexample_input_order() {
+                test_utils::test_counterexample_input_order::<$solver_type>($solver_config);
             }
         }
     };


### PR DESCRIPTION
Fix print order for the function input in proof results (fixes #456). Always print the value no matter assertion happens or not (fixes #457).