### PR TITLE
Make prove-quickcheck more robust

### DIFF
--- a/xlsynth/src/lib.rs
+++ b/xlsynth/src/lib.rs
@@ -242,6 +242,31 @@ pub fn mangle_dslx_name(module: &str, name: &str) -> Result<String, XlsynthError
     xls_mangle_dslx_name(module, name)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Indicates the calling convention used by a DSLX function for mangling.
+pub enum DslxCallingConvention {
+    /// Normal DSLX function (no implicit token parameter in the mangled name).
+    Normal,
+    /// DSLX function that has an implicit token parameter; mangled name is
+    /// prefixed with `__itok`.
+    ImplicitToken,
+}
+
+/// Mangles a DSLX function name according to the given calling convention.
+/// This wraps `mangle_dslx_name` and applies the implicit-token prefix when
+/// `DslxCallingConvention::ImplicitToken` is specified.
+pub fn mangle_dslx_name_with_calling_convention(
+    module: &str,
+    name: &str,
+    cc: DslxCallingConvention,
+) -> Result<String, XlsynthError> {
+    let base = mangle_dslx_name(module, name)?;
+    Ok(match cc {
+        DslxCallingConvention::Normal => base,
+        DslxCallingConvention::ImplicitToken => format!("__itok{}", base),
+    })
+}
+
 fn x_path_to_rs_filename(path: &std::path::Path) -> String {
     let mut out = path.file_stem().unwrap().to_str().unwrap().to_string();
     out.push_str(".rs");


### PR DESCRIPTION
Make prove-quickcheck more robust by falling back to itok mangled vesions when the wrapper isn't available

In the original XLS system, it seems that each quickcheck function will be individually translated by converting to an individual module with this function as the entry point. This will trigger the system to generate a wrapper (likely by `WrapEntryIfImplicitToken`) that fixes the activation bit to 1.

In our implementation, we do not convert into single function package. Then, our quickcheck functions may not get the wrapper functions. Thus, the lookup of the ordinary function name will fail.

The fix now lookup both the ones with or without implicit token and use our mechanism of fixing such bits.