### PR TITLE
Add a test case that shows invariant assertions being added/elided via codegen option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Install protobuf compiler
         run: |
-          wget https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
+          curl -L --retry 5 --retry-delay 2 --retry-connrefused -o protoc-29.1-linux-x86_64.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
           unzip protoc-29.1-linux-x86_64.zip -d protoc
           sudo mv protoc/bin/protoc /usr/local/bin/protoc
           sudo mv protoc /tmp/  # Move these out of the way to not interfere with build.
@@ -168,7 +168,7 @@ jobs:
       - name: Download and set up Boolector
         run: |
           mkdir -p boolector_libs
-          wget -O boolector_libs/libboolector.so https://github.com/xlsynth/boolector-build/releases/download/boolector-debian10-171b2783200bf9f7636f3e595587ee822a0a6d07/libboolector-debian10.so
+          curl -L --retry 5 --retry-delay 2 --retry-connrefused -o boolector_libs/libboolector.so https://github.com/xlsynth/boolector-build/releases/download/boolector-debian10-171b2783200bf9f7636f3e595587ee822a0a6d07/libboolector-debian10.so
           sudo cp boolector_libs/libboolector.so /usr/lib/
           sudo ldconfig
           echo "Listing /usr/lib for libboolector.so:"
@@ -219,7 +219,7 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -y --no-install-recommends python3 python3-pip wget unzip git sudo build-essential pkg-config libssl-dev cmake libz3-dev
+          apt-get install -y --no-install-recommends python3 python3-pip curl wget unzip git sudo build-essential pkg-config libssl-dev cmake libz3-dev
           pip3 install -r requirements.txt
 
       - name: Set up Python + pre-commit
@@ -266,7 +266,7 @@ jobs:
 
       - name: Install protobuf compiler
         run: |
-          wget https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
+          curl -L --retry 5 --retry-delay 2 --retry-connrefused -o protoc-29.1-linux-x86_64.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
           unzip protoc-29.1-linux-x86_64.zip -d protoc
           mv protoc/bin/protoc /usr/local/bin/protoc
           mv protoc /tmp/
@@ -302,7 +302,7 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
           # Install prerequisites for llvm.sh and libc++ installation
-          apt-get install -y --no-install-recommends wget gnupg lsb-release software-properties-common
+          apt-get install -y --no-install-recommends curl wget gnupg lsb-release software-properties-common
           cd /tmp/
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -356,7 +356,7 @@ jobs:
 
       - name: Install protobuf compiler
         run: |
-          wget https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-osx-aarch_64.zip
+          curl -L --retry 5 --retry-delay 2 --retry-connrefused -o protoc-29.1-osx-aarch_64.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-osx-aarch_64.zip
           unzip protoc-29.1-osx-aarch_64.zip -d protoc
           sudo mv protoc/bin/protoc /usr/local/bin/protoc
           sudo mv protoc /tmp/
@@ -420,8 +420,8 @@ jobs:
 
       - name: Install protobuf compiler
         run: |
-          yum install -y wget unzip
-          wget https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
+          yum install -y curl unzip
+          curl -L --retry 5 --retry-delay 2 --retry-connrefused -o protoc-29.1-linux-x86_64.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
           unzip protoc-29.1-linux-x86_64.zip -d protoc
           mv protoc/bin/protoc /usr/local/bin/protoc
           mv protoc /tmp/  # Move these out of the way to not interfere with build.
@@ -495,7 +495,7 @@ jobs:
 
       - name: Install protobuf compiler
         run: |
-          wget https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
+          curl -L --retry 5 --retry-delay 2 --retry-connrefused -o protoc-29.1-linux-x86_64.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip
           unzip protoc-29.1-linux-x86_64.zip -d protoc
           sudo mv protoc/bin/protoc /usr/local/bin/protoc
           sudo mv protoc /tmp/  # Move these out of the way to not interfere with build.
@@ -520,7 +520,7 @@ jobs:
       - name: Install libc++ from llvm-18
         run: |
           sudo apt-get update
-          sudo apt-get install -y wget gnupg
+          sudo apt-get install -y curl wget gnupg
           cd /tmp/
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -610,7 +610,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev build-essential meson
+          sudo apt-get install -y curl pkg-config libssl-dev build-essential meson
 
       - name: Install protobuf compiler
         run: |
@@ -620,7 +620,7 @@ jobs:
       - name: Download and set up Boolector
         run: |
           mkdir -p boolector_libs
-          wget -O boolector_libs/libboolector.so https://github.com/xlsynth/boolector-build/releases/download/boolector-debian10-171b2783200bf9f7636f3e595587ee822a0a6d07/libboolector-debian10.so
+          curl -L --retry 5 --retry-delay 2 --retry-connrefused -o boolector_libs/libboolector.so https://github.com/xlsynth/boolector-build/releases/download/boolector-debian10-171b2783200bf9f7636f3e595587ee822a0a6d07/libboolector-debian10.so
           sudo cp boolector_libs/libboolector.so /usr/lib/
           sudo ldconfig
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install protobuf compiler
         run: |
-          wget https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-osx-aarch_64.zip
+          curl -L --retry 5 --retry-delay 2 --retry-connrefused -o protoc-29.1-osx-aarch_64.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-osx-aarch_64.zip
           unzip protoc-29.1-osx-aarch_64.zip -d protoc
           sudo mv protoc/bin/protoc /usr/local/bin/protoc
           sudo mv protoc /tmp/

--- a/xlsynth-driver/src/dslx_stitch_pipeline.rs
+++ b/xlsynth-driver/src/dslx_stitch_pipeline.rs
@@ -49,6 +49,18 @@ pub fn handle_dslx_stitch_pipeline(matches: &ArgMatches, config: &Option<Toolcha
         .and_then(|cg| cg.add_invariant_assertions)
         .unwrap_or(crate::flag_defaults::CODEGEN_ADD_INVARIANT_ASSERTIONS);
 
+    // Determine whether to emit array-index bounds checking (default true).
+    let array_index_bounds_checking = matches
+        .get_one::<String>("array_index_bounds_checking")
+        .map(|s| s == "true")
+        .or_else(|| {
+            config
+                .as_ref()
+                .and_then(|c| c.codegen.as_ref())
+                .and_then(|cg| cg.array_index_bounds_checking)
+        })
+        .unwrap_or(crate::flag_defaults::CODEGEN_ARRAY_INDEX_BOUNDS_CHECKING);
+
     let flop_inputs = matches
         .get_one::<String>("flop_inputs")
         .map(|s| s == "true")
@@ -72,6 +84,7 @@ pub fn handle_dslx_stitch_pipeline(matches: &ArgMatches, config: &Option<Toolcha
         reset_opt,
         reset_active_low,
         add_invariant_assertions,
+        array_index_bounds_checking,
     );
     match result {
         Ok(sv) => println!("{}", sv),

--- a/xlsynth-driver/src/dslx_stitch_pipeline.rs
+++ b/xlsynth-driver/src/dslx_stitch_pipeline.rs
@@ -19,7 +19,7 @@ pub fn handle_dslx_stitch_pipeline(matches: &ArgMatches, config: &Option<Toolcha
     let use_system_verilog = matches
         .get_one::<String>("use_system_verilog")
         .map(|s| s == "true")
-        .unwrap_or(true);
+        .unwrap_or(crate::flag_defaults::CODEGEN_USE_SYSTEM_VERILOG);
     let verilog_version = if use_system_verilog {
         VerilogVersion::SystemVerilog
     } else {
@@ -41,14 +41,22 @@ pub fn handle_dslx_stitch_pipeline(matches: &ArgMatches, config: &Option<Toolcha
         .map(|s| s == "true")
         .unwrap_or(false);
 
+    // Determine whether to add invariant assertions based on toolchain config
+    // (default false).
+    let add_invariant_assertions = config
+        .as_ref()
+        .and_then(|c| c.codegen.as_ref())
+        .and_then(|cg| cg.add_invariant_assertions)
+        .unwrap_or(crate::flag_defaults::CODEGEN_ADD_INVARIANT_ASSERTIONS);
+
     let flop_inputs = matches
         .get_one::<String>("flop_inputs")
         .map(|s| s == "true")
-        .unwrap_or(true);
+        .unwrap_or(crate::flag_defaults::CODEGEN_FLOP_INPUTS);
     let flop_outputs = matches
         .get_one::<String>("flop_outputs")
         .map(|s| s == "true")
-        .unwrap_or(true);
+        .unwrap_or(crate::flag_defaults::CODEGEN_FLOP_OUTPUTS);
     let result = xlsynth_g8r::dslx_stitch_pipeline::stitch_pipeline(
         &dslx,
         std::path::Path::new(input),
@@ -63,6 +71,7 @@ pub fn handle_dslx_stitch_pipeline(matches: &ArgMatches, config: &Option<Toolcha
         output_valid_signal_opt,
         reset_opt,
         reset_active_low,
+        add_invariant_assertions,
     );
     match result {
         Ok(sv) => println!("{}", sv),

--- a/xlsynth-driver/src/dslx_stitch_pipeline.rs
+++ b/xlsynth-driver/src/dslx_stitch_pipeline.rs
@@ -69,22 +69,26 @@ pub fn handle_dslx_stitch_pipeline(matches: &ArgMatches, config: &Option<Toolcha
         .get_one::<String>("flop_outputs")
         .map(|s| s == "true")
         .unwrap_or(crate::flag_defaults::CODEGEN_FLOP_OUTPUTS);
+    let options = xlsynth_g8r::dslx_stitch_pipeline::StitchPipelineOptions {
+        verilog_version,
+        explicit_stages: stage_list,
+        stdlib_path: paths.stdlib_path.as_deref(),
+        search_paths: path_refs.clone(),
+        flop_inputs,
+        flop_outputs,
+        input_valid_signal: input_valid_signal_opt,
+        output_valid_signal: output_valid_signal_opt,
+        reset_signal: reset_opt,
+        reset_active_low,
+        add_invariant_assertions,
+        array_index_bounds_checking,
+    };
+
     let result = xlsynth_g8r::dslx_stitch_pipeline::stitch_pipeline(
         &dslx,
         std::path::Path::new(input),
         top,
-        verilog_version,
-        stage_list.as_ref().map(|v| v.as_slice()),
-        paths.stdlib_path.as_deref(),
-        &path_refs,
-        flop_inputs,
-        flop_outputs,
-        input_valid_signal_opt,
-        output_valid_signal_opt,
-        reset_opt,
-        reset_active_low,
-        add_invariant_assertions,
-        array_index_bounds_checking,
+        &options,
     );
     match result {
         Ok(sv) => println!("{}", sv),

--- a/xlsynth-driver/src/flag_defaults.rs
+++ b/xlsynth-driver/src/flag_defaults.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Central definition of default flag values we expect the external
+//! `codegen_main` tool to use. Keeping them here lets us use these
+//! values consistently across the driver code and test that they stay
+//! in sync with the underlying tool implementation.
+//!
+//! NOTE: The single source of truth is still the external tool — these
+//! constants must reflect its behaviour. See the unit test at the
+//! bottom of this file which automatically checks that the values
+//! match the defaults reported by `codegen_main --helpfull` so we do
+//! not silently diverge.
+
+// -- Codegen flag defaults
+
+/// If true, `codegen_main` inserts runtime assertions that check IR-level
+/// invariants (e.g. that a priority selector's one-hot input really is
+/// one-hot). Corresponds to `--add_invariant_assertions`.  Help output snippet:
+///
+/// ```text
+/// --add_invariant_assertions ... default: true;
+/// ```
+pub const CODEGEN_ADD_INVARIANT_ASSERTIONS: bool = true;
+
+/// Whether to emit an additional `idle` output signal that indicates no active
+/// transaction is flowing through the pipeline.  `--add_idle_output`.
+pub const CODEGEN_ADD_IDLE_OUTPUT: bool = false;
+
+/// Emit bounds checks for array index operations –
+/// `--array_index_bounds_checking`.
+pub const CODEGEN_ARRAY_INDEX_BOUNDS_CHECKING: bool = true;
+
+/// When true, Verilog generation uses SystemVerilog features.
+/// `--use_system_verilog`.
+pub const CODEGEN_USE_SYSTEM_VERILOG: bool = true;
+
+/// Flop (register) all module inputs, `--flop_inputs` (pipeline generator).
+pub const CODEGEN_FLOP_INPUTS: bool = true;
+
+/// Flop (register) all module outputs, `--flop_outputs` (pipeline generator).
+pub const CODEGEN_FLOP_OUTPUTS: bool = true;
+
+// -- Tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+    use std::process::Command;
+
+    /// Panics if preconditions are not met.
+    fn get_codegen_help() -> String {
+        let tool_path = std::env::var("XLSYNTH_TOOLS")
+            .expect("XLSYNTH_TOOLS environment variable must be set for tests");
+
+        let codegen_main_path = std::path::Path::new(&tool_path).join("codegen_main");
+        assert!(
+            codegen_main_path.exists(),
+            "codegen_main not found at {:?}",
+            codegen_main_path
+        );
+
+        let output = Command::new(&codegen_main_path)
+            .arg("--helpfull")
+            .output()
+            .expect("failed to run codegen_main");
+
+        // absl::flags exits with code 1 after printing help; accept 0 or 1.
+        assert!(
+            matches!(output.status.code(), Some(0) | Some(1)),
+            "unexpected exit code {:?}",
+            output.status
+        );
+
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    /// Extracts the default boolean value for `--<flag_name>` from the help
+    /// text. Panics if the flag or its default is not found.
+    fn extract_default(help: &str, flag_name: &str) -> bool {
+        // Regex in DOTALL mode – match everything lazily until we see a
+        // "default: true;" or "default: false;" capture group.
+        let pattern = format!(r"--{}[\s\S]*?default: (true|false);", flag_name);
+        let re = Regex::new(&pattern).expect("invalid regex");
+        let caps = re.captures(help).unwrap_or_else(|| {
+            panic!(
+                "Flag --{} not found in codegen_main --helpfull output",
+                flag_name
+            )
+        });
+        &caps[1] == "true"
+    }
+
+    #[test]
+    fn defaults_match_codegen_main() {
+        let help = get_codegen_help();
+
+        let checks: &[(&str, bool)] = &[
+            ("add_invariant_assertions", CODEGEN_ADD_INVARIANT_ASSERTIONS),
+            ("add_idle_output", CODEGEN_ADD_IDLE_OUTPUT),
+            (
+                "array_index_bounds_checking",
+                CODEGEN_ARRAY_INDEX_BOUNDS_CHECKING,
+            ),
+            ("use_system_verilog", CODEGEN_USE_SYSTEM_VERILOG),
+            ("flop_inputs", CODEGEN_FLOP_INPUTS),
+            ("flop_outputs", CODEGEN_FLOP_OUTPUTS),
+        ];
+
+        for (flag, expected) in checks {
+            let actual = extract_default(&help, flag);
+            assert_eq!(
+                actual, *expected,
+                "Default mismatch for flag '--{}': expected {}, got {}",
+                flag, expected, actual
+            );
+        }
+    }
+}

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -390,6 +390,10 @@ fn main() {
                 .add_bool_arg(
                     "flop_outputs",
                     "Whether to insert output pipeline flops (default true)",
+                )
+                .add_bool_arg(
+                    "array_index_bounds_checking",
+                    "Whether to emit array index bounds checking",
                 ),
         )
         .subcommand(

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -41,6 +41,7 @@ mod dslx2sv_types;
 mod dslx_equiv;
 mod dslx_g8r_stats;
 mod dslx_stitch_pipeline;
+mod flag_defaults;
 mod g8r2v;
 mod g8r_equiv;
 mod gv2ir;

--- a/xlsynth-driver/src/toolchain_config.rs
+++ b/xlsynth-driver/src/toolchain_config.rs
@@ -26,6 +26,7 @@ pub struct CodegenConfig {
     pub gate_format: Option<String>,
     pub assert_format: Option<String>,
     pub use_system_verilog: Option<bool>,
+    pub add_invariant_assertions: Option<bool>,
 }
 
 /// Helper for extracting the DSLX standard library path from the command line

--- a/xlsynth-driver/src/toolchain_config.rs
+++ b/xlsynth-driver/src/toolchain_config.rs
@@ -27,6 +27,7 @@ pub struct CodegenConfig {
     pub assert_format: Option<String>,
     pub use_system_verilog: Option<bool>,
     pub add_invariant_assertions: Option<bool>,
+    pub array_index_bounds_checking: Option<bool>,
 }
 
 /// Helper for extracting the DSLX standard library path from the command line

--- a/xlsynth-driver/tests/invoke_test.rs
+++ b/xlsynth-driver/tests/invoke_test.rs
@@ -535,6 +535,7 @@ fn test_dslx2pipeline_with_reset_signal() {
         .arg("asap7")
         .arg("--flop_inputs=true")
         .arg("--flop_outputs=true")
+        .arg("--use_system_verilog=false")
         .arg("--input_valid_signal=input_valid")
         .arg("--output_valid_signal=output_valid")
         .arg("--reset=rst_n")
@@ -560,20 +561,10 @@ fn test_dslx2pipeline_with_reset_signal() {
     log::info!("stderr: {}", stderr);
     xlsynth_test_helpers::assert_valid_sv(&stdout);
 
-    // Define the path for the new golden file
-    let golden_path = std::path::Path::new("tests/test_dslx2pipeline_with_reset_signal.golden.sv");
-
-    if std::env::var("XLSYNTH_UPDATE_GOLDEN").is_ok() {
-        println!("INFO: Updating golden file: {}", golden_path.display());
-        std::fs::write(golden_path, &stdout).expect("Failed to write golden file");
-    } else {
-        let golden_sv = std::fs::read_to_string(golden_path).expect("Failed to read golden file");
-        assert_eq!(
-            stdout.trim(),
-            golden_sv.trim(),
-            "Golden file mismatch. Run with XLSYNTH_UPDATE_GOLDEN=1 to update."
-        );
-    }
+    compare_golden_sv(
+        &stdout,
+        "tests/test_dslx2pipeline_with_reset_signal.golden.sv",
+    );
 }
 
 #[test_case(true; "reset_datapath")]
@@ -594,6 +585,7 @@ fn test_dslx2pipeline_reset_data_path(reset_dp: bool) {
         .arg("asap7")
         .arg("--flop_inputs=true")
         .arg("--flop_outputs=true")
+        .arg("--use_system_verilog=false")
         .arg("--input_valid_signal=input_valid")
         .arg("--output_valid_signal=output_valid")
         .arg("--reset=rst_n")
@@ -622,18 +614,7 @@ fn test_dslx2pipeline_reset_data_path(reset_dp: bool) {
     } else {
         "tests/test_dslx2pipeline_reset_data_path_false.golden.sv"
     };
-    let golden_path = std::path::Path::new(golden_name);
-    if std::env::var("XLSYNTH_UPDATE_GOLDEN").is_ok() {
-        println!("INFO: Updating golden file: {}", golden_path.display());
-        std::fs::write(golden_path, &stdout).expect("Failed to write golden file");
-    } else {
-        let golden_sv = std::fs::read_to_string(golden_path).expect("Failed to read golden file");
-        assert_eq!(
-            stdout.trim(),
-            golden_sv.trim(),
-            "Golden file mismatch. Run with XLSYNTH_UPDATE_GOLDEN=1 to update."
-        );
-    }
+    compare_golden_sv(&stdout, golden_name);
 }
 
 #[test_case(true; "with_tool_path")]
@@ -1735,7 +1716,9 @@ fn test_ir2pipeline_subcommand(use_tool_path: bool, optimize: bool) {
         .arg("--top")
         .arg("my_main")
         .arg("--delay_model")
-        .arg("unit");
+        .arg("unit")
+        .arg("--flop_inputs=false")
+        .arg("--flop_outputs=false");
 
     if optimize {
         cmd.arg("--opt=true");
@@ -1756,25 +1739,10 @@ fn test_ir2pipeline_subcommand(use_tool_path: bool, optimize: bool) {
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    xlsynth_test_helpers::assert_valid_sv(&stdout);
-
-    if !use_tool_path {
-        // Compare against golden for runtime API path.
-        let golden_path =
-            std::path::Path::new("tests/test_ir2pipeline_identity_pipeline.golden.sv");
-        if std::env::var("XLSYNTH_UPDATE_GOLDEN").is_ok() {
-            println!("INFO: Updating golden file: {}", golden_path.display());
-            std::fs::write(golden_path, &stdout).expect("Failed to write golden file");
-        } else {
-            let golden_sv =
-                std::fs::read_to_string(golden_path).expect("Failed to read golden file");
-            assert_eq!(
-                stdout.trim(),
-                golden_sv.trim(),
-                "Golden file mismatch. Run with XLSYNTH_UPDATE_GOLDEN=1 to update."
-            );
-        }
-    }
+    compare_golden_sv(
+        &stdout,
+        "tests/test_ir2pipeline_identity_pipeline.golden.sv",
+    );
 }
 
 #[test]
@@ -3169,6 +3137,8 @@ fn test_run_verilog_pipeline_basic_add1() {
         .arg("dslx2pipeline")
         .arg("--pipeline_stages")
         .arg("1")
+        .arg("--flop_inputs=false")
+        .arg("--flop_outputs=false")
         .arg("--delay_model")
         .arg("asap7")
         .arg("--dslx_input_file")
@@ -3233,6 +3203,8 @@ fn test_run_verilog_pipeline_wave_dump() {
         .arg("dslx2pipeline")
         .arg("--pipeline_stages")
         .arg("1")
+        .arg("--flop_inputs=false")
+        .arg("--flop_outputs=false")
         .arg("--delay_model")
         .arg("asap7")
         .arg("--dslx_input_file")
@@ -4067,4 +4039,76 @@ fn run_dslx_equiv_enum_in_bound_for_solver(solver: &str, expect_supported: bool)
 #[test_case::test_case("toolchain", false; "enum_in_bound_toolchain_unsupported")]
 fn test_dslx_equiv_enum_in_bound_solver_matrix(solver: &str, expect_supported: bool) {
     run_dslx_equiv_enum_in_bound_for_solver(solver, expect_supported);
+}
+
+// Checks that invariant assertions are emitted (or not) for the
+// dslx-stitch-pipeline subcommand when the `add_invariant_assertions` option is
+// toggled via the toolchain configuration. We use a simple two-stage pipeline
+// where the first stage contains a `priority_sel` so that the optimiser can
+// prove the associated invariants and gemit the assertion.
+#[test_case(true; "with_invariant_assertions")]
+#[test_case(false; "without_invariant_assertions")]
+fn test_dslx_stitch_pipeline_priority_sel_invariant(add_inv: bool) {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    // Two-stage pipeline: cycle0 performs a priority-select using a *dynamic*
+    // selector provided as an input to the pipeline. This prevents
+    // constant-propagation from eliminating the priority_sel node (and
+    // therefore its assertion).
+    let dslx = r#"fn f_cycle0(x0: u3, x4: u6) -> u6 {
+    {
+        let x6: u6 = match x0 {
+            u3:0x3 | u3:0x4 => x4,
+            u3:0x2 => u6:0x2a,
+            _ => u6:0x8,
+        };
+        x6
+    }
+}
+
+fn f_cycle1(x: u6) -> u6 {
+    x
+}"#;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let dslx_path = temp_dir.path().join("prio.x");
+    std::fs::write(&dslx_path, dslx).unwrap();
+
+    // Write out toolchain.toml with (1) external tool path and (2) the invariant
+    // flag.
+    let toolchain_toml_base = if add_inv {
+        "[toolchain]\n[toolchain.codegen]\nadd_invariant_assertions = true\n"
+    } else {
+        "[toolchain]\n[toolchain.codegen]\nadd_invariant_assertions = false\n"
+    };
+    let toolchain_toml_contents = add_tool_path_value(toolchain_toml_base);
+    let toolchain_path = temp_dir.path().join("xlsynth-toolchain.toml");
+    std::fs::write(&toolchain_path, toolchain_toml_contents).unwrap();
+
+    // Invoke the driver.
+    let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
+    let output = std::process::Command::new(command_path)
+        .arg("--toolchain")
+        .arg(toolchain_path.to_str().unwrap())
+        .arg("dslx-stitch-pipeline")
+        .arg("--dslx_input_file")
+        .arg(dslx_path.to_str().unwrap())
+        .arg("--dslx_top")
+        .arg("f")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "command failed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let has_asserts = stdout.to_lowercase().contains("assert");
+    if add_inv {
+        assert!(has_asserts, "Expected invariant assertions in generated Verilog when add_invariant_assertions=true, but none were found. stdout: {}", stdout);
+    } else {
+        assert!(!has_asserts, "Did not expect invariant assertions when add_invariant_assertions=false, but some were found. stdout: {}", stdout);
+    }
 }

--- a/xlsynth-driver/tests/test_dslx2pipeline_array_index_bounds_checking_enum_cast_false.golden.sv
+++ b/xlsynth-driver/tests/test_dslx2pipeline_array_index_bounds_checking_enum_cast_false.golden.sv
@@ -1,0 +1,26 @@
+module __enum_index__main(
+  input wire clk,
+  input wire [1:0] sel,
+  input wire [127:0] arr,
+  output wire [31:0] out
+);
+  wire [31:0] arr_unflattened[4];
+  assign arr_unflattened[0] = arr[31:0];
+  assign arr_unflattened[1] = arr[63:32];
+  assign arr_unflattened[2] = arr[95:64];
+  assign arr_unflattened[3] = arr[127:96];
+
+  // ===== Pipe stage 0:
+  wire p0_literal_26_comb;
+  wire [2:0] p0_concat_29_comb;
+  wire [2:0] p0_literal_27_comb;
+  wire [2:0] p0_add_31_comb;
+  wire [31:0] p0_array_index_32_comb;
+  assign p0_literal_26_comb = 1'h0;
+  assign p0_concat_29_comb = {p0_literal_26_comb, sel};
+  assign p0_literal_27_comb = 3'h1;
+  assign p0_add_31_comb = p0_concat_29_comb + p0_literal_27_comb;
+  assign p0_array_index_32_comb = arr_unflattened[p0_add_31_comb];
+  assign out = p0_array_index_32_comb;
+endmodule
+

--- a/xlsynth-driver/tests/test_dslx2pipeline_array_index_bounds_checking_enum_cast_true.golden.sv
+++ b/xlsynth-driver/tests/test_dslx2pipeline_array_index_bounds_checking_enum_cast_true.golden.sv
@@ -1,0 +1,26 @@
+module __enum_index__main(
+  input wire clk,
+  input wire [1:0] sel,
+  input wire [127:0] arr,
+  output wire [31:0] out
+);
+  wire [31:0] arr_unflattened[4];
+  assign arr_unflattened[0] = arr[31:0];
+  assign arr_unflattened[1] = arr[63:32];
+  assign arr_unflattened[2] = arr[95:64];
+  assign arr_unflattened[3] = arr[127:96];
+
+  // ===== Pipe stage 0:
+  wire p0_literal_26_comb;
+  wire [2:0] p0_concat_29_comb;
+  wire [2:0] p0_literal_27_comb;
+  wire [2:0] p0_add_31_comb;
+  wire [31:0] p0_array_index_32_comb;
+  assign p0_literal_26_comb = 1'h0;
+  assign p0_concat_29_comb = {p0_literal_26_comb, sel};
+  assign p0_literal_27_comb = 3'h1;
+  assign p0_add_31_comb = p0_concat_29_comb + p0_literal_27_comb;
+  assign p0_array_index_32_comb = arr_unflattened[p0_add_31_comb > 3'h3 ? 2'h3 : p0_add_31_comb[1:0]];
+  assign out = p0_array_index_32_comb;
+endmodule
+

--- a/xlsynth-driver/tests/test_dslx_stitch_pipeline_array_index_bounds_checking_enum_cast_false.golden.sv
+++ b/xlsynth-driver/tests/test_dslx_stitch_pipeline_array_index_bounds_checking_enum_cast_false.golden.sv
@@ -1,0 +1,63 @@
+module foo_cycle0(
+  input wire [1:0] sel,
+  input wire [127:0] arr,
+  output wire [31:0] out
+);
+  wire [31:0] arr_unflattened[4];
+  assign arr_unflattened[0] = arr[31:0];
+  assign arr_unflattened[1] = arr[63:32];
+  assign arr_unflattened[2] = arr[95:64];
+  assign arr_unflattened[3] = arr[127:96];
+  wire literal_15;
+  wire [2:0] concat_16;
+  wire [2:0] literal_17;
+  wire [2:0] add_18;
+  wire [31:0] array_index_19;
+  assign literal_15 = 1'h0;
+  assign concat_16 = {literal_15, sel};
+  assign literal_17 = 3'h1;
+  assign add_18 = concat_16 + literal_17;
+  assign array_index_19 = arr_unflattened[add_18];
+  assign out = array_index_19;
+endmodule
+
+module foo_cycle1(
+  input wire [31:0] x,
+  output wire [31:0] out
+);
+  assign out = x;
+endmodule
+module foo(
+  input wire clk,
+  input wire [1:0] sel,
+  input wire [127:0] arr,
+  output wire [31:0] out
+);
+  reg [127:0] p0_arr;
+  reg [1:0] p0_sel;
+  always @ (posedge clk) begin
+    p0_arr <= arr;
+    p0_sel <= sel;
+  end
+  wire [31:0] stage_0_out_comb;
+  foo_cycle0 stage_0 (
+    .sel(p0_sel),
+    .arr(p0_arr),
+    .out(stage_0_out_comb)
+  );
+  reg [31:0] p1_x;
+  always @ (posedge clk) begin
+    p1_x <= stage_0_out_comb;
+  end
+  wire [31:0] stage_1_out_comb;
+  foo_cycle1 stage_1 (
+    .x(p1_x),
+    .out(stage_1_out_comb)
+  );
+  reg [31:0] p2_out;
+  always @ (posedge clk) begin
+    p2_out <= stage_1_out_comb;
+  end
+  assign out = p2_out;
+endmodule
+

--- a/xlsynth-driver/tests/test_dslx_stitch_pipeline_array_index_bounds_checking_enum_cast_true.golden.sv
+++ b/xlsynth-driver/tests/test_dslx_stitch_pipeline_array_index_bounds_checking_enum_cast_true.golden.sv
@@ -1,0 +1,63 @@
+module foo_cycle0(
+  input wire [1:0] sel,
+  input wire [127:0] arr,
+  output wire [31:0] out
+);
+  wire [31:0] arr_unflattened[4];
+  assign arr_unflattened[0] = arr[31:0];
+  assign arr_unflattened[1] = arr[63:32];
+  assign arr_unflattened[2] = arr[95:64];
+  assign arr_unflattened[3] = arr[127:96];
+  wire literal_15;
+  wire [2:0] concat_16;
+  wire [2:0] literal_17;
+  wire [2:0] add_18;
+  wire [31:0] array_index_19;
+  assign literal_15 = 1'h0;
+  assign concat_16 = {literal_15, sel};
+  assign literal_17 = 3'h1;
+  assign add_18 = concat_16 + literal_17;
+  assign array_index_19 = arr_unflattened[add_18 > 3'h3 ? 2'h3 : add_18[1:0]];
+  assign out = array_index_19;
+endmodule
+
+module foo_cycle1(
+  input wire [31:0] x,
+  output wire [31:0] out
+);
+  assign out = x;
+endmodule
+module foo(
+  input wire clk,
+  input wire [1:0] sel,
+  input wire [127:0] arr,
+  output wire [31:0] out
+);
+  reg [127:0] p0_arr;
+  reg [1:0] p0_sel;
+  always @ (posedge clk) begin
+    p0_arr <= arr;
+    p0_sel <= sel;
+  end
+  wire [31:0] stage_0_out_comb;
+  foo_cycle0 stage_0 (
+    .sel(p0_sel),
+    .arr(p0_arr),
+    .out(stage_0_out_comb)
+  );
+  reg [31:0] p1_x;
+  always @ (posedge clk) begin
+    p1_x <= stage_0_out_comb;
+  end
+  wire [31:0] stage_1_out_comb;
+  foo_cycle1 stage_1 (
+    .x(p1_x),
+    .out(stage_1_out_comb)
+  );
+  reg [31:0] p2_out;
+  always @ (posedge clk) begin
+    p2_out <= stage_1_out_comb;
+  end
+  assign out = p2_out;
+endmodule
+

--- a/xlsynth-g8r/src/dslx_stitch_pipeline/common.rs
+++ b/xlsynth-g8r/src/dslx_stitch_pipeline/common.rs
@@ -8,6 +8,7 @@ pub(crate) struct PipelineCfg<'a> {
     pub(crate) ir: &'a xlsynth::ir_package::IrPackage,
     pub(crate) verilog_version: VerilogVersion,
     pub(crate) add_invariant_assertions: bool,
+    pub(crate) array_index_bounds_checking: bool,
 }
 
 /// One port in a stage module (flattened).

--- a/xlsynth-g8r/src/dslx_stitch_pipeline/common.rs
+++ b/xlsynth-g8r/src/dslx_stitch_pipeline/common.rs
@@ -7,6 +7,7 @@ use crate::verilog_version::VerilogVersion;
 pub(crate) struct PipelineCfg<'a> {
     pub(crate) ir: &'a xlsynth::ir_package::IrPackage,
     pub(crate) verilog_version: VerilogVersion,
+    pub(crate) add_invariant_assertions: bool,
 }
 
 /// One port in a stage module (flattened).

--- a/xlsynth-g8r/src/dslx_stitch_pipeline/mod.rs
+++ b/xlsynth-g8r/src/dslx_stitch_pipeline/mod.rs
@@ -202,6 +202,11 @@ use_system_verilog: {sv}"#,
         "\nadd_invariant_assertions: {}",
         cfg.add_invariant_assertions
     ));
+    // Emit array-index bounds checking option explicitly for determinism.
+    codegen.push_str(&format!(
+        "\narray_index_bounds_checking: {}",
+        cfg.array_index_bounds_checking
+    ));
     let result = schedule_and_codegen(&opt, sched, &codegen)?;
     let sv_text = result.get_verilog_text()?;
 
@@ -293,6 +298,7 @@ pub fn stitch_pipeline(
     reset_signal: Option<&str>,
     reset_active_low: bool,
     add_invariant_assertions: bool,
+    array_index_bounds_checking: bool,
 ) -> Result<String, xlsynth::XlsynthError> {
     if (input_valid_signal.is_some() || output_valid_signal.is_some()) && reset_signal.is_none() {
         return Err(xlsynth::XlsynthError(
@@ -314,6 +320,7 @@ pub fn stitch_pipeline(
         ir: &ir,
         verilog_version,
         add_invariant_assertions,
+        array_index_bounds_checking,
     };
 
     let stages = discover_stage_names(&ir, path, top, explicit_stages)?;
@@ -407,6 +414,7 @@ mod tests {
             None,
             false,
             false,
+            true,
         )
         .unwrap();
         // Validate generated SV.
@@ -449,6 +457,7 @@ fn foo_cycle1(s: S) -> u32 { s.a + s.b }
             None,
             false,
             false,
+            true,
         )
         .unwrap();
 
@@ -473,6 +482,7 @@ fn foo_cycle1(s: S) -> u32 { s.a + s.b }
             None,
             false,
             false,
+            true,
         )
         .unwrap();
         compare_golden_sv(&result, "tests/goldens/one.golden.sv");
@@ -498,6 +508,7 @@ fn foo_cycle1(s: S) -> u32 { s.a + s.b }
             Some("rst_n"),
             true, // Use active-low reset to match simulation helper expectations.
             false,
+            true,
         )
         .unwrap()
     }
@@ -537,6 +548,7 @@ fn foo_cycle1(a: u64, b: u32) -> u64 { a + b as u64 }"#;
             None,
             false,
             false,
+            true,
         );
         assert!(result.is_err());
         let err = result.unwrap_err().0;

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 const RELEASE_LIB_VERSION_TAG: &str = "v0.0.218";
-const MAX_DOWNLOAD_ATTEMPTS: u32 = 3;
+const MAX_DOWNLOAD_ATTEMPTS: u32 = 6;
 
 struct DsoInfo {
     extension: &'static str,
@@ -152,7 +152,9 @@ fn high_integrity_download_with_retries(
     max_attempts: u32,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut attempts = 0;
-    let mut delay = 1;
+    // Start with a 2-second delay so the total retry window is a bit longer:
+    // 2 + 4 + 8 + 16 + 32 = 62 seconds worst-case (for 6 attempts).
+    let mut delay = 2;
     while attempts < max_attempts {
         attempts += 1;
         match high_integrity_download(url, out_path) {


### PR DESCRIPTION
The option can now be set in the toolchain config toml

We also add checking that our default arguments are the same as those seen in the underlying tool(s) -- but right now we just test vs codegen_main, the facility should be reusable