### PR TITLE
Use native-tls in build.rs's artifact download.

### DIFF
--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -14,7 +14,7 @@ links = "xlsynth"
 libc = "0.2"
 
 [build-dependencies]
-ureq = { version = "3", default-features = false, features = ["rustls"] }
+ureq = { version = "3", default-features = false, features = ["native-tls"] }
 flate2 = "1.0"
 tar = "0.4"
 sha2 = "0.10"


### PR DESCRIPTION
This will hopefully make the build work even if it's on a VM behind a MITM
proxy (assuming the proxy's cert is installed on the machine).
