### PR TITLE
Revert "Use native TLS cert verifier when downloading files in build.rs (#502)"

### DIFF
--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -14,7 +14,7 @@ links = "xlsynth"
 libc = "0.2"
 
 [build-dependencies]
-ureq = { version = "3", default-features = false, features = ["rustls", "platform-verifier"] }
+ureq = { version = "3", default-features = false, features = ["rustls"] }
 flate2 = "1.0"
 tar = "0.4"
 sha2 = "0.10"

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -207,21 +207,7 @@ fn download_file_via_https(
     url: &str,
     dest: &std::path::Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use ureq::config::Config;
-    use ureq::tls::{RootCerts, TlsConfig};
-
-    // Use the OS trust store so that if, for example, this build is occurring on
-    // a VM behind a MITM proxy, the download will still work.
-    let agent = Config::builder()
-        .tls_config(
-            TlsConfig::builder()
-                .root_certs(RootCerts::PlatformVerifier)
-                .build(),
-        )
-        .build()
-        .new_agent();
-
-    let response = agent.get(url).call()?;
+    let response = ureq::get(url).call()?;
     if response.status() != 200 {
         return Err(format!("Failed to download {}: HTTP {}", url, response.status()).into());
     }


### PR DESCRIPTION
This reverts commit 88b8928fe3777e991ef4332df906ed848a41aa5b.

Reverting this because the platform-verifier feature complicates linking this
crate, making it harder to use on some systems.

Systems behind a TLS MITM proxy can download the files manually using the new
JSON metadata from baba3cf4bb711cbc1cb2faf25b502070685a2522.
