### PR TITLE
Add gv-read-stats driver command

### DIFF
--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -57,6 +57,17 @@ xlsynth-driver gv2ir \
 - Optional flags:
   - `--dff_cells <CSV>` – comma-separated list of DFF cell names to treat as identity (D->Q).
 
+### `gv-read-stats`: netlist statistics
+
+Reads a gate-level netlist (optionally gzipped) and prints summary statistics such as
+instance counts, net counts, memory usage, parse time, and per-cell instance histogram.
+
+```shell
+xlsynth-driver gv-read-stats my_module.gv.gz
+```
+
+This command has no flags.
+
 ### `ir2g8r`: IR to gate-level representation
 
 Converts an XLS IR file to an `xlsynth_g8r::GateFn` (i.e. a gate-level netlist in AIG form).

--- a/xlsynth-driver/src/gv_read_stats.rs
+++ b/xlsynth-driver/src/gv_read_stats.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::ArgMatches;
+use std::path::Path;
+use xlsynth_g8r::netlist::stats;
+
+pub fn handle_gv_read_stats(matches: &ArgMatches) {
+    let netlist_path = matches
+        .get_one::<String>("netlist")
+        .expect("netlist path is required");
+    match stats::read_netlist_stats(Path::new(netlist_path)) {
+        Ok(s) => {
+            println!("Instances: {}", s.num_instances);
+            println!("Nets: {}", s.num_nets);
+            println!("Approx. memory: {} bytes", s.memory_bytes);
+            println!("Parse time: {} ms", s.parse_duration.as_millis());
+            println!("Cell counts:");
+            for (cell, count) in s.cell_counts {
+                println!("  {cell}: {count}");
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -45,6 +45,7 @@ mod flag_defaults;
 mod g8r2v;
 mod g8r_equiv;
 mod gv2ir;
+mod gv_read_stats;
 mod ir2combo;
 mod ir2delayinfo;
 mod ir2gates;
@@ -860,6 +861,16 @@ fn main() {
                 )
         )
         .subcommand(
+            clap::Command::new("gv-read-stats")
+                .about("Reads a gate-level netlist and prints summary statistics")
+                .arg(
+                    clap::Arg::new("netlist")
+                        .help("Input gate-level netlist (.gv or .gv.gz)")
+                        .required(true)
+                        .index(1),
+                ),
+        )
+        .subcommand(
             clap::Command::new("g8r2v")
                 .about("Converts a .g8r or .g8rbin file to a .ugv netlist on stdout, optionally adding a clock port as the first input.")
                 .arg(
@@ -1304,6 +1315,8 @@ fn main() {
         lib2proto::handle_lib2proto(matches);
     } else if let Some(matches) = matches.subcommand_matches("gv2ir") {
         gv2ir::handle_gv2ir(matches);
+    } else if let Some(matches) = matches.subcommand_matches("gv-read-stats") {
+        gv_read_stats::handle_gv_read_stats(matches);
     } else if let Some(matches) = matches.subcommand_matches("g8r2v") {
         if let Err(e) = g8r2v::handle_g8r2v(matches) {
             report_cli_error::report_cli_error_and_exit(&e, None, vec![]);

--- a/xlsynth-driver/tests/invoke_test.rs
+++ b/xlsynth-driver/tests/invoke_test.rs
@@ -6059,6 +6059,39 @@ fn test_prover_all_with_timeout_indefinite() {
     assert_eq!(tasks[1]["outcome"].as_str(), Some("Timeout"));
 }
 
+#[test]
+fn test_gv_read_stats_basic() {
+    let netlist = r#"module top(a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  wire w;
+  INV i0 (.A(a), .Y(w));
+  INV i1 (.A(w), .Y(y));
+endmodule
+"#;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let gv_path = temp_dir.path().join("test.gv");
+    std::fs::write(&gv_path, netlist).unwrap();
+
+    let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
+    let output = Command::new(command_path)
+        .arg("gv-read-stats")
+        .arg(gv_path.to_str().unwrap())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Instances: 2"), "{}", stdout);
+    assert!(stdout.contains("INV"), "{}", stdout);
+}
+
 #[cfg(feature = "enable-fake-task")]
 #[test]
 fn test_prover_any_with_timeout_indefinite() {

--- a/xlsynth-g8r/src/netlist/mod.rs
+++ b/xlsynth-g8r/src/netlist/mod.rs
@@ -3,3 +3,4 @@
 pub mod gatefn_from_netlist;
 pub mod integrity;
 pub mod parse;
+pub mod stats;

--- a/xlsynth-g8r/src/netlist/stats.rs
+++ b/xlsynth-g8r/src/netlist/stats.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compute summary statistics for gate-level netlists.
+
+use crate::netlist::parse::{
+    Net, NetIndex, NetRef, NetlistInstance, NetlistModule, NetlistPort, Parser as NetlistParser,
+    PortId, TokenScanner,
+};
+use anyhow::{Result, anyhow};
+use flate2::read::GzDecoder;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
+use std::mem::size_of;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// Summary statistics for a parsed netlist.
+#[derive(Debug)]
+pub struct NetlistStats {
+    pub num_instances: usize,
+    pub num_nets: usize,
+    pub memory_bytes: usize,
+    pub cell_counts: Vec<(String, usize)>,
+    pub parse_duration: Duration,
+}
+
+fn open_reader(path: &Path) -> Result<Box<dyn Read>> {
+    let file = File::open(path)?;
+    let is_gz = path.extension().map(|e| e == "gz").unwrap_or(false);
+    if is_gz {
+        Ok(Box::new(GzDecoder::new(file)))
+    } else {
+        Ok(Box::new(file))
+    }
+}
+
+fn line_lookup(path: &Path) -> Box<dyn Fn(u32) -> Option<String>> {
+    let path = path.to_path_buf();
+    let is_gz = path.extension().map(|e| e == "gz").unwrap_or(false);
+    Box::new(move |lineno| {
+        let file = File::open(&path).ok()?;
+        if is_gz {
+            let gz = GzDecoder::new(file);
+            let reader = BufReader::new(gz);
+            reader
+                .lines()
+                .nth((lineno - 1) as usize)
+                .and_then(|r| r.ok())
+        } else {
+            let reader = BufReader::new(file);
+            reader
+                .lines()
+                .nth((lineno - 1) as usize)
+                .and_then(|r| r.ok())
+        }
+    })
+}
+
+/// Reads and parses the netlist at `path`, returning summary statistics.
+pub fn read_netlist_stats(path: &Path) -> Result<NetlistStats> {
+    let reader = open_reader(path)?;
+    let lookup = line_lookup(path);
+    let scanner = TokenScanner::with_line_lookup(reader, lookup);
+    let mut parser: NetlistParser<Box<dyn Read>> = NetlistParser::new(scanner);
+    let start = Instant::now();
+    let modules = parser.parse_file().map_err(|e| anyhow!(e.message))?;
+    let parse_duration = start.elapsed();
+
+    let num_instances: usize = modules.iter().map(|m| m.instances.len()).sum();
+    let num_nets = parser.nets.len();
+
+    let mut counts: HashMap<PortId, usize> = HashMap::new();
+    for m in &modules {
+        for inst in &m.instances {
+            *counts.entry(inst.type_name).or_insert(0) += 1;
+        }
+    }
+
+    let mut cell_counts: Vec<(String, usize)> = counts
+        .into_iter()
+        .map(|(sym, count)| {
+            let name = parser
+                .interner
+                .resolve(sym)
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            (name, count)
+        })
+        .collect();
+    cell_counts.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+
+    let memory_bytes = estimate_memory_bytes(&parser, &modules);
+
+    Ok(NetlistStats {
+        num_instances,
+        num_nets,
+        memory_bytes,
+        cell_counts,
+        parse_duration,
+    })
+}
+
+fn estimate_memory_bytes<R: Read + 'static>(
+    parser: &NetlistParser<R>,
+    modules: &[NetlistModule],
+) -> usize {
+    let mut memory_bytes = parser.nets.capacity() * size_of::<Net>();
+    for m in modules {
+        memory_bytes += size_of::<NetlistModule>();
+        memory_bytes += m.ports.capacity() * size_of::<NetlistPort>();
+        memory_bytes += m.wires.capacity() * size_of::<NetIndex>();
+        memory_bytes += m.instances.capacity() * size_of::<NetlistInstance>();
+        for inst in &m.instances {
+            memory_bytes += inst.connections.capacity() * size_of::<(PortId, NetRef)>();
+        }
+    }
+    memory_bytes += parser.interner.len() * size_of::<String>();
+    for (_sym, s) in parser.interner.clone().into_iter() {
+        memory_bytes += s.len();
+    }
+    memory_bytes
+}


### PR DESCRIPTION
## Summary
- add `gv-read-stats` subcommand to xlsynth-driver
- implement netlist statistics reader in xlsynth-g8r
- document and test reading stats from gate-level netlists
- factor memory usage computation into helper routine

## Testing
- `cargo test -p xlsynth-driver --test invoke_test test_gv_read_stats_basic`
- `cargo test -p xlsynth-test-helpers check_all_rust_files_for_spdx`
- `pre-commit run --all-files`
- `cargo fuzz build` *(fails: could not find `prove_gate_fn_equiv_z3`)*

------
https://chatgpt.com/codex/tasks/task_i_68ab977d95448323af6fa9d9adca9b2e