### PR TITLE
Expose libxls bits helpers via IrBits

### DIFF
--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -388,6 +388,7 @@ extern "C" {
     pub fn xls_bits_eq(bits: *const CIrBits, other: *const CIrBits) -> bool;
     pub fn xls_bits_to_debug_string(bits: *const CIrBits) -> *mut std::os::raw::c_char;
     pub fn xls_bits_add(lhs: *const CIrBits, rhs: *const CIrBits) -> *mut CIrBits;
+    pub fn xls_bits_sub(lhs: *const CIrBits, rhs: *const CIrBits) -> *mut CIrBits;
     pub fn xls_bits_umul(lhs: *const CIrBits, rhs: *const CIrBits) -> *mut CIrBits;
     pub fn xls_bits_smul(lhs: *const CIrBits, rhs: *const CIrBits) -> *mut CIrBits;
     pub fn xls_bits_negate(bits: *const CIrBits) -> *mut CIrBits;
@@ -406,6 +407,24 @@ extern "C" {
     // start, int64_t width);
 
     pub fn xls_bits_width_slice(bits: *const CIrBits, start: i64, width: i64) -> *mut CIrBits;
+
+    pub fn xls_bits_to_bytes(
+        bits: *const CIrBits,
+        error_out: *mut *mut std::os::raw::c_char,
+        bytes_out: *mut *mut u8,
+        byte_count_out: *mut libc::size_t,
+    ) -> bool;
+    pub fn xls_bytes_free(bytes: *mut u8);
+    pub fn xls_bits_to_uint64(
+        bits: *const CIrBits,
+        error_out: *mut *mut std::os::raw::c_char,
+        value_out: *mut u64,
+    ) -> bool;
+    pub fn xls_bits_to_int64(
+        bits: *const CIrBits,
+        error_out: *mut *mut std::os::raw::c_char,
+        value_out: *mut i64,
+    ) -> bool;
 
     pub fn xls_package_free(package: *mut CIrPackage);
     pub fn xls_c_str_free(c_str: *mut std::os::raw::c_char);

--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -4,7 +4,8 @@ use xlsynth_sys::{CIrBits, CIrValue};
 
 use crate::{
     lib_support::{
-        xls_bits_make_sbits, xls_bits_make_ubits, xls_bits_to_debug_str, xls_bits_to_string,
+        xls_bits_make_sbits, xls_bits_make_ubits, xls_bits_to_bytes, xls_bits_to_debug_str,
+        xls_bits_to_int64, xls_bits_to_string, xls_bits_to_uint64,
         xls_format_preference_from_string, xls_value_eq, xls_value_free, xls_value_get_bits,
         xls_value_get_element, xls_value_get_element_count, xls_value_make_array,
         xls_value_make_sbits, xls_value_make_token, xls_value_make_tuple, xls_value_make_ubits,
@@ -68,8 +69,25 @@ impl IrBits {
         format!("bits[{}]:{}", self.get_bit_count(), value)
     }
 
+    pub fn to_u64(&self) -> Result<u64, XlsynthError> {
+        xls_bits_to_uint64(self.ptr)
+    }
+
+    pub fn to_i64(&self) -> Result<i64, XlsynthError> {
+        xls_bits_to_int64(self.ptr)
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, XlsynthError> {
+        xls_bits_to_bytes(self.ptr)
+    }
+
     pub fn add(&self, rhs: &IrBits) -> IrBits {
         let result = unsafe { xlsynth_sys::xls_bits_add(self.ptr, rhs.ptr) };
+        IrBits { ptr: result }
+    }
+
+    pub fn sub(&self, rhs: &IrBits) -> IrBits {
+        let result = unsafe { xlsynth_sys::xls_bits_sub(self.ptr, rhs.ptr) };
         IrBits { ptr: result }
     }
 
@@ -200,6 +218,14 @@ impl std::ops::Add for IrBits {
 
     fn add(self, rhs: Self) -> Self::Output {
         IrBits::add(&self, &rhs)
+    }
+}
+
+impl std::ops::Sub for IrBits {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        IrBits::sub(&self, &rhs)
     }
 }
 

--- a/xlsynth/src/lib_support.rs
+++ b/xlsynth/src/lib_support.rs
@@ -277,6 +277,35 @@ pub(crate) fn xls_bits_to_string(
     Ok(unsafe { c_str_to_rust(c_str_out) })
 }
 
+pub(crate) fn xls_bits_to_bytes(p: *const CIrBits) -> Result<Vec<u8>, XlsynthError> {
+    unsafe {
+        let mut error_out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let mut bytes_out: *mut u8 = std::ptr::null_mut();
+        let mut byte_count_out: usize = 0;
+        let success =
+            xlsynth_sys::xls_bits_to_bytes(p, &mut error_out, &mut bytes_out, &mut byte_count_out);
+        if !success {
+            return Err(XlsynthError(c_str_to_rust(error_out)));
+        }
+        let slice = std::slice::from_raw_parts(bytes_out, byte_count_out);
+        let vec = slice.to_vec();
+        xlsynth_sys::xls_bytes_free(bytes_out);
+        Ok(vec)
+    }
+}
+
+pub(crate) fn xls_bits_to_uint64(p: *const CIrBits) -> Result<u64, XlsynthError> {
+    let mut value_out: u64 = 0;
+    xls_ffi_call!(xlsynth_sys::xls_bits_to_uint64, p; value_out)?;
+    Ok(value_out)
+}
+
+pub(crate) fn xls_bits_to_int64(p: *const CIrBits) -> Result<i64, XlsynthError> {
+    let mut value_out: i64 = 0;
+    xls_ffi_call!(xlsynth_sys::xls_bits_to_int64, p; value_out)?;
+    Ok(value_out)
+}
+
 pub(crate) fn xls_value_eq(
     lhs: *const CIrValue,
     rhs: *const CIrValue,

--- a/xlsynth/tests/ir_bits_test.rs
+++ b/xlsynth/tests/ir_bits_test.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use xlsynth::{IrBits, XlsynthError};
+
+#[test]
+fn arith_and_logic_ops() -> Result<(), XlsynthError> {
+    let a = IrBits::make_ubits(8, 0b0001_1010)?; // 26
+    let b = IrBits::make_ubits(8, 0b0000_0011)?; // 3
+
+    assert_eq!(a.clone(), a.clone());
+    assert_ne!(a.clone(), b.clone());
+    assert!(a.get_bit(1)?);
+
+    let sum = a.add(&b);
+    assert_eq!(sum.to_u64()?, 29);
+
+    let diff = a.sub(&b);
+    assert_eq!(diff.to_u64()?, 23);
+
+    let and = a.and(&b);
+    assert_eq!(and.to_u64()?, 0b0000_0010);
+
+    let or = a.or(&b);
+    assert_eq!(or.to_u64()?, 0b0001_1011);
+
+    let xor = a.xor(&b);
+    assert_eq!(xor.to_u64()?, 0b0001_1001);
+
+    let not_a = a.not();
+    assert_eq!(not_a.to_u64()?, 0b1110_0101);
+
+    let neg = a.negate();
+    let abs = neg.abs();
+    assert_eq!(abs, a);
+
+    let umul = a.umul(&b);
+    assert_eq!(umul.to_u64()?, 78);
+
+    let smul = a.smul(&b);
+    assert_eq!(smul.to_u64()?, 78);
+
+    Ok(())
+}
+
+#[test]
+fn conversions_shifts_and_slices() -> Result<(), XlsynthError> {
+    let bits = IrBits::make_sbits(8, -2)?;
+    assert_eq!(bits.to_i64()?, -2);
+    assert_eq!(bits.to_u64()?, 0xFE);
+    assert!(!bits.get_bit(0)?);
+    assert!(bits.get_bit(1)?);
+
+    let bytes = bits.to_bytes()?;
+    assert_eq!(bytes, vec![0xFE]);
+
+    let wide = IrBits::make_ubits(16, 0xABCD)?;
+    assert_eq!(wide.to_bytes()?, vec![0xCD, 0xAB]);
+
+    let shll = bits.shll(2);
+    assert_eq!(shll.to_u64()?, (0xFEu64 << 2) & 0xFF);
+
+    let shrl = bits.shrl(2);
+    assert_eq!(shrl.to_u64()?, 0xFE >> 2);
+
+    let shra = bits.shra(2);
+    assert_eq!(shra.to_i64()?, -1);
+
+    let slice = wide.width_slice(8, 8);
+    assert_eq!(slice.to_u64()?, 0xAB);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- expose remaining `xls_bits_*` functions in FFI
- add idiomatic `IrBits` helpers for conversion, subtraction, and byte extraction
- cover `IrBits` operations with tests

## Testing
- `cargo test -p xlsynth`
- `cargo test -p xlsynth-test-helpers check_all_rust_files_for_spdx`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_i_68acefc8066c8323b3f9ee8ea6c07d1e