### PR TITLE
Expose bits equality on IrBits

### DIFF
--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -57,6 +57,10 @@ impl IrBits {
         Ok(bit)
     }
 
+    pub fn equals(&self, rhs: &IrBits) -> bool {
+        unsafe { xlsynth_sys::xls_bits_eq(self.ptr, rhs.ptr) }
+    }
+
     pub fn to_string_fmt(&self, format: IrFormatPreference, include_bit_count: bool) -> String {
         let fmt_pref: xlsynth_sys::XlsFormatPreference =
             xls_format_preference_from_string(format.to_string()).unwrap();
@@ -175,7 +179,7 @@ impl Drop for IrBits {
 
 impl std::cmp::PartialEq for IrBits {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { xlsynth_sys::xls_bits_eq(self.ptr, other.ptr) }
+        self.equals(other)
     }
 }
 

--- a/xlsynth/tests/ir_bits_test.rs
+++ b/xlsynth/tests/ir_bits_test.rs
@@ -7,6 +7,8 @@ fn arith_and_logic_ops() -> Result<(), XlsynthError> {
     let a = IrBits::make_ubits(8, 0b0001_1010)?; // 26
     let b = IrBits::make_ubits(8, 0b0000_0011)?; // 3
 
+    assert!(a.equals(&a));
+    assert!(!a.equals(&b));
     assert_eq!(a.clone(), a.clone());
     assert_ne!(a.clone(), b.clone());
     assert!(a.get_bit(1)?);


### PR DESCRIPTION
## Summary
- expose `xls_bits_eq` on `IrBits` via a new `equals` method
- use the method for `PartialEq`
- test equality behavior

## Testing
- `cargo test -p xlsynth --test ir_bits_test`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_i_68acfb1f19bc8323957dc089fcbd8a72