### PR TITLE
Handle additional pure node payloads in eval_pure

### DIFF
--- a/xlsynth-g8r/src/xls_ir/ir_eval.rs
+++ b/xlsynth-g8r/src/xls_ir/ir_eval.rs
@@ -50,6 +50,146 @@ fn eval_pure(n: &ir::Node, env: &HashMap<ir::NodeRef, IrValue>) -> IrValue {
                 _ => panic!("Unsupported binop: {:?}", binop),
             }
         }
+        ir::NodePayload::Unop(unop, ref operand) => {
+            let operand_value: &IrValue = env.get(operand).unwrap();
+            let operand_bits = operand_value.to_bits().unwrap();
+            match unop {
+                ir::Unop::Neg => {
+                    let r = operand_bits.negate();
+                    IrValue::from_bits(&r)
+                }
+                ir::Unop::Not => {
+                    let r = operand_bits.not();
+                    IrValue::from_bits(&r)
+                }
+                ir::Unop::Identity => operand_value.clone(),
+                ir::Unop::OrReduce => {
+                    let mut result = false;
+                    for i in 0..operand_bits.get_bit_count() {
+                        if operand_bits.get_bit(i).unwrap() {
+                            result = true;
+                            break;
+                        }
+                    }
+                    IrValue::bool(result)
+                }
+                ir::Unop::AndReduce => {
+                    let mut result = true;
+                    for i in 0..operand_bits.get_bit_count() {
+                        if !operand_bits.get_bit(i).unwrap() {
+                            result = false;
+                            break;
+                        }
+                    }
+                    IrValue::bool(result)
+                }
+                ir::Unop::XorReduce => {
+                    let mut result = false;
+                    for i in 0..operand_bits.get_bit_count() {
+                        if operand_bits.get_bit(i).unwrap() {
+                            result = !result;
+                        }
+                    }
+                    IrValue::bool(result)
+                }
+                ir::Unop::Reverse => panic!("Unsupported unop: reverse"),
+            }
+        }
+        ir::NodePayload::Tuple(ref elements) => {
+            let values: Vec<IrValue> = elements
+                .iter()
+                .map(|e| env.get(e).unwrap().clone())
+                .collect();
+            IrValue::make_tuple(&values)
+        }
+        ir::NodePayload::TupleIndex { tuple, index } => {
+            let tuple_value: &IrValue = env.get(&tuple).unwrap();
+            tuple_value.get_element(index).unwrap()
+        }
+        ir::NodePayload::Array(ref elements) => {
+            let values: Vec<IrValue> = elements
+                .iter()
+                .map(|e| env.get(e).unwrap().clone())
+                .collect();
+            IrValue::make_array(&values).unwrap()
+        }
+        ir::NodePayload::ArrayIndex {
+            array,
+            ref indices,
+            assumed_in_bounds: _,
+        } => {
+            let mut value = env.get(&array).unwrap().clone();
+            for idx_ref in indices {
+                let idx = env.get(idx_ref).unwrap().to_u64().unwrap() as usize;
+                value = value.get_element(idx).unwrap();
+            }
+            value
+        }
+        ir::NodePayload::DynamicBitSlice {
+            ref arg,
+            ref start,
+            width,
+        } => {
+            let arg_bits: IrBits = env.get(arg).unwrap().to_bits().unwrap();
+            let start_bits: IrBits = env.get(start).unwrap().to_bits().unwrap();
+            let start_i = start_bits.to_u64().unwrap() as i64;
+            let r = arg_bits.width_slice(start_i, width as i64);
+            IrValue::from_bits(&r)
+        }
+        ir::NodePayload::BitSlice {
+            ref arg,
+            start,
+            width,
+        } => {
+            let arg_bits: IrBits = env.get(arg).unwrap().to_bits().unwrap();
+            let r = arg_bits.width_slice(start as i64, width as i64);
+            IrValue::from_bits(&r)
+        }
+        ir::NodePayload::Nary(op, ref operands) => {
+            let mut iter = operands.iter();
+            let first = env.get(iter.next().unwrap()).unwrap();
+            let mut acc = first.to_bits().unwrap();
+            match op {
+                ir::NaryOp::And => {
+                    for operand in iter {
+                        let bits = env.get(operand).unwrap().to_bits().unwrap();
+                        acc = acc.and(&bits);
+                    }
+                    IrValue::from_bits(&acc)
+                }
+                ir::NaryOp::Or => {
+                    for operand in iter {
+                        let bits = env.get(operand).unwrap().to_bits().unwrap();
+                        acc = acc.or(&bits);
+                    }
+                    IrValue::from_bits(&acc)
+                }
+                ir::NaryOp::Xor => {
+                    for operand in iter {
+                        let bits = env.get(operand).unwrap().to_bits().unwrap();
+                        acc = acc.xor(&bits);
+                    }
+                    IrValue::from_bits(&acc)
+                }
+                ir::NaryOp::Nand => {
+                    for operand in iter {
+                        let bits = env.get(operand).unwrap().to_bits().unwrap();
+                        acc = acc.and(&bits);
+                    }
+                    let r = acc.not();
+                    IrValue::from_bits(&r)
+                }
+                ir::NaryOp::Nor => {
+                    for operand in iter {
+                        let bits = env.get(operand).unwrap().to_bits().unwrap();
+                        acc = acc.or(&bits);
+                    }
+                    let r = acc.not();
+                    IrValue::from_bits(&r)
+                }
+                ir::NaryOp::Concat => panic!("Unsupported nary op: concat"),
+            }
+        }
         ir::NodePayload::GetParam(..) | _ => panic!("Cannot evaluate node as pure: {:?}", n),
     }
 }
@@ -93,5 +233,138 @@ mod tests {
         };
         let v: IrValue = eval_pure(&n, &env);
         assert_eq!(v, IrValue::make_ubits(32, 3).unwrap());
+    }
+
+    #[test]
+    fn test_eval_pure_unop_not() {
+        let env = hashmap!(
+            ir::NodeRef { index: 1 } => IrValue::make_ubits(4, 0b0101).unwrap(),
+        );
+        let n = ir::Node {
+            text_id: 2,
+            name: None,
+            ty: ir::Type::Bits(4),
+            payload: ir::NodePayload::Unop(ir::Unop::Not, ir::NodeRef { index: 1 }),
+            pos: None,
+        };
+        let v: IrValue = eval_pure(&n, &env);
+        assert_eq!(v, IrValue::make_ubits(4, 0b1010).unwrap());
+    }
+
+    #[test]
+    fn test_eval_pure_tuple() {
+        let env = hashmap!(
+            ir::NodeRef { index: 1 } => IrValue::make_ubits(8, 1).unwrap(),
+            ir::NodeRef { index: 2 } => IrValue::make_ubits(8, 2).unwrap(),
+        );
+        let n = ir::Node {
+            text_id: 3,
+            name: None,
+            ty: ir::Type::Tuple(vec![
+                Box::new(ir::Type::Bits(8)),
+                Box::new(ir::Type::Bits(8)),
+            ]),
+            payload: ir::NodePayload::Tuple(vec![
+                ir::NodeRef { index: 1 },
+                ir::NodeRef { index: 2 },
+            ]),
+            pos: None,
+        };
+        let v: IrValue = eval_pure(&n, &env);
+        assert_eq!(
+            v,
+            IrValue::make_tuple(&[
+                IrValue::make_ubits(8, 1).unwrap(),
+                IrValue::make_ubits(8, 2).unwrap(),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_eval_pure_array_index() {
+        let array_val = IrValue::make_array(&[
+            IrValue::make_ubits(8, 0).unwrap(),
+            IrValue::make_ubits(8, 1).unwrap(),
+            IrValue::make_ubits(8, 2).unwrap(),
+        ])
+        .unwrap();
+        let env = hashmap!(
+            ir::NodeRef { index: 1 } => array_val,
+            ir::NodeRef { index: 2 } => IrValue::make_ubits(32, 1).unwrap(),
+        );
+        let n = ir::Node {
+            text_id: 4,
+            name: None,
+            ty: ir::Type::Bits(8),
+            payload: ir::NodePayload::ArrayIndex {
+                array: ir::NodeRef { index: 1 },
+                indices: vec![ir::NodeRef { index: 2 }],
+                assumed_in_bounds: true,
+            },
+            pos: None,
+        };
+        let v: IrValue = eval_pure(&n, &env);
+        assert_eq!(v, IrValue::make_ubits(8, 1).unwrap());
+    }
+
+    #[test]
+    fn test_eval_pure_bit_slice() {
+        let env = hashmap!(
+            ir::NodeRef { index: 1 } => IrValue::make_ubits(8, 0b11110000).unwrap(),
+        );
+        let n = ir::Node {
+            text_id: 5,
+            name: None,
+            ty: ir::Type::Bits(4),
+            payload: ir::NodePayload::BitSlice {
+                arg: ir::NodeRef { index: 1 },
+                start: 4,
+                width: 4,
+            },
+            pos: None,
+        };
+        let v: IrValue = eval_pure(&n, &env);
+        assert_eq!(v, IrValue::make_ubits(4, 0b1111).unwrap());
+    }
+
+    #[test]
+    fn test_eval_pure_dynamic_bit_slice() {
+        let env = hashmap!(
+            ir::NodeRef { index: 1 } => IrValue::make_ubits(8, 0b11110000).unwrap(),
+            ir::NodeRef { index: 2 } => IrValue::make_ubits(8, 4).unwrap(),
+        );
+        let n = ir::Node {
+            text_id: 6,
+            name: None,
+            ty: ir::Type::Bits(4),
+            payload: ir::NodePayload::DynamicBitSlice {
+                arg: ir::NodeRef { index: 1 },
+                start: ir::NodeRef { index: 2 },
+                width: 4,
+            },
+            pos: None,
+        };
+        let v: IrValue = eval_pure(&n, &env);
+        assert_eq!(v, IrValue::make_ubits(4, 0b1111).unwrap());
+    }
+
+    #[test]
+    fn test_eval_pure_nary_or() {
+        let env = hashmap!(
+            ir::NodeRef { index: 1 } => IrValue::make_ubits(4, 0b0101).unwrap(),
+            ir::NodeRef { index: 2 } => IrValue::make_ubits(4, 0b1010).unwrap(),
+        );
+        let n = ir::Node {
+            text_id: 7,
+            name: None,
+            ty: ir::Type::Bits(4),
+            payload: ir::NodePayload::Nary(
+                ir::NaryOp::Or,
+                vec![ir::NodeRef { index: 1 }, ir::NodeRef { index: 2 }],
+            ),
+            pos: None,
+        };
+        let v: IrValue = eval_pure(&n, &env);
+        assert_eq!(v, IrValue::make_ubits(4, 0b1111).unwrap());
     }
 }


### PR DESCRIPTION
## Summary
- extend `eval_pure` to handle additional pure node payloads such as `Unop`, `Tuple`, `Array`, `DynamicBitSlice`, `BitSlice`, and `Nary`
- add unit tests exercising the new `eval_pure` cases

## Testing
- `cargo test -p xlsynth-g8r`
- `cargo fuzz build --features with-z3-built`


------
https://chatgpt.com/codex/tasks/task_i_68ad4b8d069083238cd2babc0ab65c37