### PR TITLE
Add XLS IR package and function validators

### DIFF
--- a/xlsynth-g8r/src/xls_ir/ir_validate.rs
+++ b/xlsynth-g8r/src/xls_ir/ir_validate.rs
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Validation routines for XLS IR packages and functions.
+
+use std::collections::HashSet;
+
+use super::ir::{self, Fn, NodePayload, Package, PackageMember, Type};
+use super::ir_utils::operands;
+
+/// Errors that can arise during validation of XLS IR structures.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ValidationError {
+    /// Two package members share the same name.
+    DuplicateMemberName(String),
+    /// The `top` attribute references a missing function.
+    MissingTopFunction(String),
+    /// A node references an undefined operand (index out of bounds).
+    OperandOutOfBounds {
+        func: String,
+        node_index: usize,
+        operand: usize,
+    },
+    /// A node references an operand defined after the node.
+    OperandUsesUndefined {
+        func: String,
+        node_index: usize,
+        operand: usize,
+    },
+    /// A function's return node is missing.
+    MissingReturnNode(String),
+    /// A function's declared return type doesn't match the return node type.
+    ReturnTypeMismatch {
+        func: String,
+        expected: Type,
+        actual: Type,
+    },
+    /// A node's text id does not match its position in the node list.
+    UnexpectedTextId {
+        func: String,
+        node_index: usize,
+        expected: usize,
+        actual: usize,
+    },
+    /// The function refers to another function that does not exist in the
+    /// package.
+    UnknownCallee { func: String, callee: String },
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidationError::DuplicateMemberName(name) => {
+                write!(f, "duplicate member name '{}'", name)
+            }
+            ValidationError::MissingTopFunction(name) => {
+                write!(f, "top function '{}' not found", name)
+            }
+            ValidationError::OperandOutOfBounds {
+                func,
+                node_index,
+                operand,
+            } => {
+                write!(
+                    f,
+                    "function '{}' node {} references operand {} out of bounds",
+                    func, node_index, operand
+                )
+            }
+            ValidationError::OperandUsesUndefined {
+                func,
+                node_index,
+                operand,
+            } => {
+                write!(
+                    f,
+                    "function '{}' node {} uses operand {} before definition",
+                    func, node_index, operand
+                )
+            }
+            ValidationError::MissingReturnNode(func) => {
+                write!(f, "function '{}' missing return node", func)
+            }
+            ValidationError::ReturnTypeMismatch {
+                func,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "function '{}' return type mismatch: expected {}, got {}",
+                    func, expected, actual
+                )
+            }
+            ValidationError::UnexpectedTextId {
+                func,
+                node_index,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "function '{}' node {} has text id {}, expected {}",
+                    func, node_index, actual, expected
+                )
+            }
+            ValidationError::UnknownCallee { func, callee } => {
+                write!(
+                    f,
+                    "function '{}' references undefined callee '{}'",
+                    func, callee
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+/// Validates an entire package, ensuring all member names are unique, the top
+/// function (if set) exists, and all contained functions are valid.
+pub fn validate_package(p: &Package) -> Result<(), ValidationError> {
+    let mut names = HashSet::new();
+    for member in &p.members {
+        let name = match member {
+            PackageMember::Function(f) => &f.name,
+            PackageMember::Block { func, .. } => &func.name,
+        };
+        if !names.insert(name.clone()) {
+            return Err(ValidationError::DuplicateMemberName(name.clone()));
+        }
+    }
+
+    if let Some(top) = &p.top_name {
+        if !names.contains(top) {
+            return Err(ValidationError::MissingTopFunction(top.clone()));
+        }
+    }
+
+    for member in &p.members {
+        match member {
+            PackageMember::Function(f) => validate_fn(f, p)?,
+            PackageMember::Block { func, .. } => validate_fn(func, p)?,
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates a function within the context of its parent package.
+pub fn validate_fn(f: &Fn, parent: &Package) -> Result<(), ValidationError> {
+    for (i, node) in f.nodes.iter().enumerate() {
+        // Ensure text ids are sequential and match indices.
+        if node.text_id != i {
+            return Err(ValidationError::UnexpectedTextId {
+                func: f.name.clone(),
+                node_index: i,
+                expected: i,
+                actual: node.text_id,
+            });
+        }
+
+        // Ensure all operands refer to already defined nodes.
+        for op in operands(&node.payload) {
+            if op.index >= f.nodes.len() {
+                return Err(ValidationError::OperandOutOfBounds {
+                    func: f.name.clone(),
+                    node_index: i,
+                    operand: op.index,
+                });
+            }
+            if op.index >= i {
+                return Err(ValidationError::OperandUsesUndefined {
+                    func: f.name.clone(),
+                    node_index: i,
+                    operand: op.index,
+                });
+            }
+        }
+
+        // Validate cross-package references.
+        match &node.payload {
+            NodePayload::Invoke { to_apply, .. } => {
+                if !package_has_fn(parent, to_apply) {
+                    return Err(ValidationError::UnknownCallee {
+                        func: f.name.clone(),
+                        callee: to_apply.clone(),
+                    });
+                }
+            }
+            NodePayload::CountedFor { body, .. } => {
+                if !package_has_fn(parent, body) {
+                    return Err(ValidationError::UnknownCallee {
+                        func: f.name.clone(),
+                        callee: body.clone(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let ret_node_ref = f
+        .ret_node_ref
+        .ok_or_else(|| ValidationError::MissingReturnNode(f.name.clone()))?;
+    let ret_node = f.get_node(ret_node_ref);
+    if ret_node.ty != f.ret_ty {
+        return Err(ValidationError::ReturnTypeMismatch {
+            func: f.name.clone(),
+            expected: f.ret_ty.clone(),
+            actual: ret_node.ty.clone(),
+        });
+    }
+
+    Ok(())
+}
+
+fn package_has_fn(p: &Package, name: &str) -> bool {
+    p.members.iter().any(|m| match m {
+        PackageMember::Function(f) => f.name == name,
+        PackageMember::Block { func, .. } => func.name == name,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::xls_ir::ir_parser::Parser;
+
+    #[test]
+    fn validate_package_ok() {
+        let ir = r#"
+        package test
+
+        fn foo(x: bits[1]) -> bits[1] {
+          ret add.2: bits[1] = add(x, x)
+        }
+        "#;
+        let mut parser = Parser::new(ir);
+        let pkg = parser.parse_package().unwrap();
+        validate_package(&pkg).unwrap();
+    }
+
+    #[test]
+    fn undefined_operand_fails() {
+        let ir = r#"
+        package test
+
+        fn foo(x: bits[1]) -> bits[1] {
+          tmp.2: bits[1] = add(x, x)
+          ret neg.3: bits[1] = neg(tmp.2)
+        }
+        "#;
+        let mut parser = Parser::new(ir);
+        let mut pkg = parser.parse_package().unwrap();
+        {
+            let f = pkg
+                .members
+                .iter_mut()
+                .find_map(|m| match m {
+                    PackageMember::Function(f) => Some(f),
+                    _ => None,
+                })
+                .unwrap();
+            // Make node 1 reference a future node (index 2).
+            if let NodePayload::Binop(_, ref mut a, _) = f.nodes[2].payload {
+                *a = ir::NodeRef { index: 2 };
+            }
+        }
+        let f = pkg
+            .members
+            .iter()
+            .find_map(|m| match m {
+                PackageMember::Function(f) => Some(f),
+                _ => None,
+            })
+            .unwrap();
+        assert!(matches!(
+            validate_fn(f, &pkg),
+            Err(ValidationError::OperandUsesUndefined { .. })
+        ));
+    }
+
+    #[test]
+    fn return_type_mismatch_fails() {
+        let ir = r#"
+        package test
+
+        fn foo(x: bits[1]) -> bits[1] {
+          ret add.2: bits[1] = add(x, x)
+        }
+        "#;
+        let mut parser = Parser::new(ir);
+        let mut pkg = parser.parse_package().unwrap();
+        {
+            let f = pkg
+                .members
+                .iter_mut()
+                .find_map(|m| match m {
+                    PackageMember::Function(f) => Some(f),
+                    _ => None,
+                })
+                .unwrap();
+            f.ret_ty = Type::Bits(2);
+        }
+        let f = pkg
+            .members
+            .iter()
+            .find_map(|m| match m {
+                PackageMember::Function(f) => Some(f),
+                _ => None,
+            })
+            .unwrap();
+        assert!(matches!(
+            validate_fn(f, &pkg),
+            Err(ValidationError::ReturnTypeMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn text_id_mismatch_fails() {
+        let ir = r#"
+        package test
+
+        fn foo(x: bits[1]) -> bits[1] {
+          ret add.2: bits[1] = add(x, x)
+        }
+        "#;
+        let mut parser = Parser::new(ir);
+        let mut pkg = parser.parse_package().unwrap();
+        {
+            let f = pkg
+                .members
+                .iter_mut()
+                .find_map(|m| match m {
+                    PackageMember::Function(f) => Some(f),
+                    _ => None,
+                })
+                .unwrap();
+            f.nodes[1].text_id = 42;
+        }
+        let f = pkg
+            .members
+            .iter()
+            .find_map(|m| match m {
+                PackageMember::Function(f) => Some(f),
+                _ => None,
+            })
+            .unwrap();
+        assert!(matches!(
+            validate_fn(f, &pkg),
+            Err(ValidationError::UnexpectedTextId { .. })
+        ));
+    }
+
+    #[test]
+    fn unknown_callee_fails() {
+        let ir = r#"
+        package test
+
+        fn foo(x: bits[8]) -> bits[8] {
+          ret r: bits[8] = invoke(x, to_apply=bar, id=2)
+        }
+        "#;
+        let mut parser = Parser::new(ir);
+        let pkg = parser.parse_package().unwrap();
+        let f = pkg.get_top().unwrap();
+        assert!(matches!(
+            validate_fn(f, &pkg),
+            Err(ValidationError::UnknownCallee { .. })
+        ));
+    }
+}

--- a/xlsynth-g8r/src/xls_ir/mod.rs
+++ b/xlsynth-g8r/src/xls_ir/mod.rs
@@ -9,6 +9,7 @@ pub mod ir_eval;
 pub mod ir_node_env;
 pub mod ir_parser;
 pub mod ir_utils;
+pub mod ir_validate;
 pub mod ir_verify;
 pub mod localized_eco;
 pub mod node_hashing;


### PR DESCRIPTION
## Summary
- add `ir_validate` module for XLS IR with `validate_package` and `validate_fn`
- check operand definitions, return types, text IDs, and cross-package references
- cover validators with unit tests

## Testing
- `pre-commit run --all-files`
- `cargo test -p xlsynth-g8r xls_ir::ir_validate::tests::validate_package_ok -- --nocapture`
- `cargo test -p xlsynth-g8r xls_ir::ir_validate::tests::return_type_mismatch_fails -- --nocapture`
- `cargo test -p xlsynth-g8r xls_ir::ir_validate::tests::unknown_callee_fails -- --nocapture`
- `cargo fuzz build` *(fails: build timed out)*

------
https://chatgpt.com/codex/tasks/task_i_68b0ecc36958832395c2103f52d97bb5