### PR TITLE
Move ir_fuzz library to xls_ir folder and fix bug

### DIFF
--- a/xlsynth-g8r/Cargo.toml
+++ b/xlsynth-g8r/Cargo.toml
@@ -45,6 +45,7 @@ colored = "3.0.0"
 atty = "0.2"
 bincode = "1.3"
 bitwuzla-sys = { version = "0.8.0", optional = true }
+arbitrary = { version = "1.3", features = ["derive"] }
 
 [dev-dependencies]
 anyhow = "1.0.86"

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_arbitrary.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_arbitrary.rs
@@ -9,6 +9,7 @@ use xlsynth_g8r::prove_gate_fn_equiv_common::EquivResult;
 use xlsynth_g8r::prove_gate_fn_equiv_varisat::{
     prove_gate_fn_equiv as prove_sat, Ctx as VarisatCtx,
 };
+#[cfg(feature = "has-easy-smt")]
 use xlsynth_g8r::prove_gate_fn_equiv_z3::{prove_gate_fn_equiv as prove_z3, Ctx as Z3Ctx};
 use xlsynth_g8r::transforms::{self, transform_trait::TransformDirection};
 use xlsynth_g8r_fuzz::{build_graph, FuzzGraph};
@@ -63,43 +64,49 @@ fuzz_target!(|graph: FuzzGraph| {
         attempts += 1; // Count this attempted (and successful) application
 
         // Cross-check equivalence solvers.
-        let mut varisat_ctx = VarisatCtx::new();
-        let mut z3_ctx = Z3Ctx::new();
-        let sat_orig_cur = prove_sat(&orig_g, &cur_g, &mut varisat_ctx);
-        let z3_orig_cur = prove_z3(&orig_g, &cur_g, &mut z3_ctx);
-        assert_eq!(
-            matches!(sat_orig_cur, EquivResult::Proved),
-            matches!(z3_orig_cur, EquivResult::Proved),
-            "Disagreement between SAT and Z3 on orig vs cur (transform {}): {:?} vs {:?}",
-            t.display_name(),
-            sat_orig_cur,
-            z3_orig_cur
-        );
+        #[cfg(feature = "has-easy-smt")]
+        {
+            let mut varisat_ctx = VarisatCtx::new();
+            let sat_orig_cur = prove_sat(&orig_g, &cur_g, &mut varisat_ctx);
+            let mut z3_ctx = Z3Ctx::new();
+            let z3_orig_cur = prove_z3(&orig_g, &cur_g, &mut z3_ctx);
+            assert_eq!(
+                matches!(sat_orig_cur, EquivResult::Proved),
+                matches!(z3_orig_cur, EquivResult::Proved),
+                "Disagreement between SAT and Z3 on orig vs cur (transform {}): {:?} vs {:?}",
+                t.display_name(),
+                sat_orig_cur,
+                z3_orig_cur
+            );
+        }
 
-        let mut varisat_ctx2 = VarisatCtx::new();
-        let mut z3_ctx2 = Z3Ctx::new();
-        let sat_cur_next = prove_sat(&cur_g, &next_g, &mut varisat_ctx2);
-        let z3_cur_next = prove_z3(&cur_g, &next_g, &mut z3_ctx2);
-        assert_eq!(
-            matches!(sat_cur_next, EquivResult::Proved),
-            matches!(z3_cur_next, EquivResult::Proved),
-            "Disagreement between SAT and Z3 on cur vs next (transform {}): {:?} vs {:?}",
-            t.display_name(),
-            sat_cur_next,
-            z3_cur_next
-        );
+        #[cfg(feature = "has-easy-smt")]
+        {
+            let mut varisat_ctx2 = VarisatCtx::new();
+            let mut z3_ctx2 = Z3Ctx::new();
+            let sat_cur_next = prove_sat(&cur_g, &next_g, &mut varisat_ctx2);
+            let z3_cur_next = prove_z3(&cur_g, &next_g, &mut z3_ctx2);
+            assert_eq!(
+                matches!(sat_cur_next, EquivResult::Proved),
+                matches!(z3_cur_next, EquivResult::Proved),
+                "Disagreement between SAT and Z3 on cur vs next (transform {}): {:?} vs {:?}",
+                t.display_name(),
+                sat_cur_next,
+                z3_cur_next
+            );
 
-        // If the transform is claimed to be always-equivalent, equivalence must hold.
-        if t.always_equivalent() {
-            if !matches!(sat_cur_next, EquivResult::Proved) {
-                log::info!(
-                    "ALWAYS-EQUIV transform {} produced inequivalence; panicking",
-                    t.display_name()
-                );
-                panic!(
-                    "Transform {} is marked always_equivalent but produced inequivalence",
-                    t.display_name()
-                );
+            // If the transform is claimed to be always-equivalent, equivalence must hold.
+            if t.always_equivalent() {
+                if !matches!(sat_cur_next, EquivResult::Proved) {
+                    log::info!(
+                        "ALWAYS-EQUIV transform {} produced inequivalence; panicking",
+                        t.display_name()
+                    );
+                    panic!(
+                        "Transform {} is marked always_equivalent but produced inequivalence",
+                        t.display_name()
+                    );
+                }
             }
         }
 

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gatify.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gatify.rs
@@ -4,7 +4,7 @@
 use libfuzzer_sys::fuzz_target;
 use xlsynth_g8r::ir2gate::gatify;
 use xlsynth_g8r::xls_ir::ir_parser;
-use xlsynth_test_helpers::ir_fuzz::{generate_ir_fn, FuzzSample};
+use xlsynth_g8r::xls_ir::ir_fuzz::{generate_ir_fn, FuzzSample};
 
 fuzz_target!(|sample: FuzzSample| {
     // Check for necessary environment variables first.

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
@@ -14,7 +14,7 @@ use xlsynth_g8r::equiv::prove_equiv::{
     prove_ir_fn_equiv_output_bits_parallel,
 };
 use xlsynth_g8r::xls_ir::ir_parser;
-use xlsynth_test_helpers::ir_fuzz::{FuzzSample, generate_ir_fn};
+use xlsynth_g8r::xls_ir::ir_fuzz::{FuzzSample, generate_ir_fn};
 
 // Insert helper that checks consistency among the external tool, a primary
 // solver result, and an optional per-bit parallel solver result.

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_roundtrip.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_roundtrip.rs
@@ -4,7 +4,7 @@
 use libfuzzer_sys::fuzz_target;
 use xlsynth_g8r::xls_ir::{ir, ir_parser};
 use xlsynth_g8r::xls_ir::structural_similarity::structurally_equivalent_ir;
-use xlsynth_test_helpers::ir_fuzz::{generate_ir_fn, FuzzSample};
+use xlsynth_g8r::xls_ir::ir_fuzz::{generate_ir_fn, FuzzSample};
 
 fuzz_target!(|sample: FuzzSample| {
     // Skip degenerate samples early.

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_same_sig_pair.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_same_sig_pair.rs
@@ -4,7 +4,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use xlsynth::IrPackage;
-use xlsynth_test_helpers::ir_fuzz::{generate_ir_fn, FuzzSampleSameTypedPair};
+use xlsynth_g8r::xls_ir::ir_fuzz::{generate_ir_fn, FuzzSampleSameTypedPair};
 
 fuzz_target!(|pair: FuzzSampleSameTypedPair| {
     // Skip degenerate samples early.

--- a/xlsynth-g8r/src/xls_ir/mod.rs
+++ b/xlsynth-g8r/src/xls_ir/mod.rs
@@ -7,6 +7,7 @@ pub mod edit_distance;
 pub mod ir;
 pub mod ir_deduce;
 pub mod ir_eval;
+pub mod ir_fuzz;
 pub mod ir_node_env;
 pub mod ir_parser;
 pub mod ir_utils;

--- a/xlsynth-test-helpers/src/lib.rs
+++ b/xlsynth-test-helpers/src/lib.rs
@@ -8,8 +8,6 @@ pub use simulate_sv::{
     simulate_pipeline_single_pulse, simulate_pipeline_single_pulse_custom, simulate_sv_flist,
 };
 
-pub mod ir_fuzz;
-
 /// Compare arbitrary text against a golden file on disk, with an opt-in
 /// update mechanism controlled by the XLSYNTH_UPDATE_GOLDEN environment
 /// variable. Uses full-string equality (no trimming) for exactness.


### PR DESCRIPTION
Fixes bug where we could not create slicing with bit counts necessary, underlying storage is now u64 for the bit counts for the fuzz ops.