### PR TITLE
Refactor CLI bool parsing for type_inference_v2

### DIFF
--- a/xlsynth-driver/src/dslx_equiv.rs
+++ b/xlsynth-driver/src/dslx_equiv.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::{get_function_enum_param_domains, parse_uf_spec};
+use crate::common::{get_function_enum_param_domains, parse_uf_spec, resolve_type_inference_v2};
 use crate::ir_equiv::{dispatch_ir_equiv, EquivInputs};
 use crate::parallelism::ParallelismStrategy;
 use crate::solver_choice::SolverChoice;
@@ -173,14 +173,7 @@ pub fn handle_dslx_equiv(matches: &clap::ArgMatches, config: &Option<ToolchainCo
         .as_ref()
         .and_then(|c| c.dslx.as_ref()?.disable_warnings.as_deref());
 
-    let type_inference_v2 = matches
-        .get_one::<String>("type_inference_v2")
-        .map(|s| s == "true")
-        .or_else(|| {
-            config
-                .as_ref()
-                .and_then(|c| c.dslx.as_ref()?.type_inference_v2)
-        });
+    let type_inference_v2 = resolve_type_inference_v2(matches, config);
 
     let assertion_semantics = matches
         .get_one::<String>("assertion_semantics")

--- a/xlsynth-driver/src/dslx_g8r_stats.rs
+++ b/xlsynth-driver/src/dslx_g8r_stats.rs
@@ -2,6 +2,7 @@
 
 use clap::ArgMatches;
 
+use crate::common::resolve_type_inference_v2;
 use crate::toolchain_config::{get_dslx_path, get_dslx_stdlib_path, ToolchainConfig};
 use crate::tools::{run_ir_converter_main, run_opt_main};
 use tempfile::NamedTempFile;
@@ -28,14 +29,7 @@ pub fn handle_dslx_g8r_stats(matches: &ArgMatches, config: &Option<ToolchainConf
         .as_ref()
         .and_then(|c| c.dslx.as_ref()?.disable_warnings.as_deref());
 
-    let type_inference_v2 = matches
-        .get_one::<String>("type_inference_v2")
-        .map(|s| s == "true")
-        .or_else(|| {
-            config
-                .as_ref()
-                .and_then(|c| c.dslx.as_ref()?.type_inference_v2)
-        });
+    let type_inference_v2 = resolve_type_inference_v2(matches, config);
 
     if type_inference_v2 == Some(true) && tool_path.is_none() {
         eprintln!("error: --type_inference_v2 is only supported when using --toolchain (external tool path)");


### PR DESCRIPTION
## Summary
- add shared helpers for parsing boolean CLI flags, including a resolver for the experimental type_inference_v2 flag
- update DSLX-related driver subcommands to use the shared helpers, reducing duplicated parsing code

## Testing
- cargo test -p xlsynth-driver
- pre-commit run --all-files


------
https://chatgpt.com/codex/tasks/task_i_68bbaccc081883238a4b827d92b74137