### PR TITLE
Add IR package verification support

### DIFF
--- a/xlsynth/src/lib_support.rs
+++ b/xlsynth/src/lib_support.rs
@@ -509,6 +509,11 @@ pub(crate) fn xls_package_set_top_by_name(
     Ok(())
 }
 
+pub(crate) fn xls_verify_package(package: *mut CIrPackage) -> Result<(), XlsynthError> {
+    xls_ffi_call_noreturn!(xlsynth_sys::xls_verify_package, package)?;
+    Ok(())
+}
+
 pub(crate) fn xls_package_get_bits_type(package: *mut CIrPackage, bit_count: u64) -> IrType {
     let type_raw = unsafe { xlsynth_sys::xls_package_get_bits_type(package, bit_count as i64) };
     IrType { ptr: type_raw }


### PR DESCRIPTION
## Summary
- wrap the `xls_verify_package` C entry point in the Rust FFI helpers
- expose an `IrPackage::verify` method so callers can validate packages
- add unit tests that exercise package verification success and failure paths

## Testing
- cargo test -p xlsynth

------
https://chatgpt.com/codex/tasks/task_i_68bf33e7bae483239f62e7c924caed21