### PR TITLE
Expose IrBits comparison helpers

### DIFF
--- a/xlsynth/src/ir_value.rs
+++ b/xlsynth/src/ir_value.rs
@@ -38,6 +38,17 @@ impl IrBits {
         Self::from_raw(result)
     }
 
+    fn assert_matching_bit_count(&self, other: &IrBits) {
+        let self_count = self.get_bit_count();
+        let other_count = other.get_bit_count();
+        assert!(
+            self_count == other_count,
+            "Bit width mismatch: left bits[{}] vs right bits[{}]",
+            self_count,
+            other_count
+        );
+    }
+
     /// Converts a `&[bool]` slice into an IR `Bits` value.
     ///
     /// ```
@@ -205,6 +216,46 @@ impl IrBits {
 
     pub fn xor(&self, rhs: &IrBits) -> IrBits {
         self.apply_binary_op(rhs, xlsynth_sys::xls_bits_xor)
+    }
+
+    pub fn ult(&self, other: &IrBits) -> bool {
+        self.assert_matching_bit_count(other);
+        unsafe { xlsynth_sys::xls_bits_ult(self.ptr, other.ptr) }
+    }
+
+    pub fn ule(&self, other: &IrBits) -> bool {
+        self.assert_matching_bit_count(other);
+        unsafe { xlsynth_sys::xls_bits_ule(self.ptr, other.ptr) }
+    }
+
+    pub fn ugt(&self, other: &IrBits) -> bool {
+        self.assert_matching_bit_count(other);
+        unsafe { xlsynth_sys::xls_bits_ugt(self.ptr, other.ptr) }
+    }
+
+    pub fn uge(&self, other: &IrBits) -> bool {
+        self.assert_matching_bit_count(other);
+        unsafe { xlsynth_sys::xls_bits_uge(self.ptr, other.ptr) }
+    }
+
+    pub fn slt(&self, other: &IrBits) -> bool {
+        self.assert_matching_bit_count(other);
+        unsafe { xlsynth_sys::xls_bits_slt(self.ptr, other.ptr) }
+    }
+
+    pub fn sle(&self, other: &IrBits) -> bool {
+        self.assert_matching_bit_count(other);
+        unsafe { xlsynth_sys::xls_bits_sle(self.ptr, other.ptr) }
+    }
+
+    pub fn sgt(&self, other: &IrBits) -> bool {
+        self.assert_matching_bit_count(other);
+        unsafe { xlsynth_sys::xls_bits_sgt(self.ptr, other.ptr) }
+    }
+
+    pub fn sge(&self, other: &IrBits) -> bool {
+        self.assert_matching_bit_count(other);
+        unsafe { xlsynth_sys::xls_bits_sge(self.ptr, other.ptr) }
     }
 }
 

--- a/xlsynth/tests/ir_bits_test.rs
+++ b/xlsynth/tests/ir_bits_test.rs
@@ -72,3 +72,27 @@ fn conversions_shifts_and_slices() -> Result<(), XlsynthError> {
 
     Ok(())
 }
+
+#[test]
+fn comparison_methods_require_matching_widths() -> Result<(), XlsynthError> {
+    let small = IrBits::make_ubits(4, 0b0011)?;
+    let medium = IrBits::make_ubits(4, 0b0100)?;
+    let wide = IrBits::make_ubits(8, 0b0000_0100)?;
+
+    assert!(small.ult(&medium));
+    assert!(medium.ugt(&small));
+    assert!(small.ule(&small));
+    assert!(medium.uge(&small));
+
+    let negative = IrBits::make_sbits(4, -1)?;
+    let positive = IrBits::make_sbits(4, 1)?;
+    assert!(negative.slt(&positive));
+    assert!(positive.sgt(&negative));
+    assert!(negative.sle(&negative));
+    assert!(positive.sge(&negative));
+
+    let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| small.ult(&wide)));
+    assert!(panic_result.is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
* add a width consistency assertion and expose unsigned/signed comparison helpers on `IrBits`
* refresh the `ir_bits_test` coverage to exercise the new comparison methods and mismatched-width behavior

## Testing
* cargo test -p xlsynth
* pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_i_68c8dbd204708323804ad2fd4d3cdae3