### PR TITLE
Various enhancements to ir_fuzz.rs.

### DIFF
--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gatify.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gatify.rs
@@ -3,7 +3,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use xlsynth_g8r::ir2gate::gatify;
-use xlsynth_pir::ir_fuzz::{generate_ir_fn, FuzzSample};
+use xlsynth_pir::ir_fuzz::{FuzzSample, generate_ir_fn};
 use xlsynth_pir::ir_parser;
 
 fuzz_target!(|sample: FuzzSample| {
@@ -11,8 +11,8 @@ fuzz_target!(|sample: FuzzSample| {
     let _ = std::env::var("XLSYNTH_TOOLS")
         .expect("XLSYNTH_TOOLS environment variable must be set for fuzzing.");
 
-    // Skip empty operation lists or empty input bits
-    if sample.ops.is_empty() || sample.input_bits == 0 {
+    // Skip empty operation lists
+    if sample.ops.is_empty() {
         return;
     }
 
@@ -20,7 +20,7 @@ fuzz_target!(|sample: FuzzSample| {
 
     // Generate IR function from fuzz input
     let mut package = xlsynth::IrPackage::new("fuzz_test").unwrap();
-    if let Err(e) = generate_ir_fn(sample.input_bits, sample.ops, &mut package, None) {
+    if let Err(e) = generate_ir_fn(sample.ops, &mut package, None) {
         log::info!("Error generating IR function: {}", e);
         return;
     }

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_eval_interp_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_eval_interp_equiv.rs
@@ -3,13 +3,13 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use xlsynth_pir::ir_eval::{eval_fn, FnEvalResult};
-use xlsynth_pir::ir_fuzz::{generate_ir_fn, FuzzBinop, FuzzOp, FuzzSampleWithArgs, FuzzUnop};
+use xlsynth_pir::ir_eval::{FnEvalResult, eval_fn};
+use xlsynth_pir::ir_fuzz::{FuzzBinop, FuzzOp, FuzzSampleWithArgs, FuzzUnop, generate_ir_fn};
 use xlsynth_pir::{ir, ir_parser};
 
 fuzz_target!(|with: FuzzSampleWithArgs| {
     // Skip degenerate base cases as in other targets.
-    if with.sample.ops.is_empty() || with.sample.input_bits == 0 {
+    if with.sample.ops.is_empty() {
         // Early return on degenerate generator inputs (see FUZZ.md for target policy).
         return;
     }
@@ -52,7 +52,7 @@ fuzz_target!(|with: FuzzSampleWithArgs| {
         })
         .collect();
     let mut pkg = xlsynth::IrPackage::new("fuzz_pkg").expect("IrPackage::new should not fail");
-    let ir_fn = match generate_ir_fn(with.sample.input_bits, filtered_ops, &mut pkg, None) {
+    let ir_fn = match generate_ir_fn(filtered_ops, &mut pkg, None) {
         Ok(f) => f,
         Err(_) => {
             // Generator can yield edge cases that are not useful here; skip.

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
@@ -3,7 +3,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use xlsynth_g8r::check_equivalence;
-use xlsynth_pir::ir_fuzz::{generate_ir_fn, FuzzSample};
+use xlsynth_pir::ir_fuzz::{FuzzSample, generate_ir_fn};
 use xlsynth_pir::ir_parser;
 #[cfg(feature = "has-bitwuzla")]
 use xlsynth_prover::bitwuzla_backend::{Bitwuzla, BitwuzlaOptions};
@@ -62,7 +62,7 @@ fuzz_target!(|sample: FuzzSample| {
         panic!("XLSYNTH_TOOLS environment variable must be set for fuzzing.");
     }
 
-    if sample.ops.is_empty() || sample.input_bits == 0 {
+    if sample.ops.is_empty() {
         return;
     }
 
@@ -70,7 +70,7 @@ fuzz_target!(|sample: FuzzSample| {
 
     // Build an XLS IR package from the fuzz sample
     let mut pkg = xlsynth::IrPackage::new("fuzz_pkg").unwrap();
-    if let Err(e) = generate_ir_fn(sample.input_bits, sample.ops.clone(), &mut pkg, None) {
+    if let Err(e) = generate_ir_fn(sample.ops.clone(), &mut pkg, None) {
         log::info!("IR generation failed: {}", e);
         return;
     }

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_rebase_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_rebase_equiv.rs
@@ -5,9 +5,11 @@ use libfuzzer_sys::fuzz_target;
 
 use xlsynth_pir::ir_fuzz::{FuzzSampleSameTypedPair, generate_ir_fn};
 use xlsynth_pir::ir_validate::validate_fn;
+use xlsynth_pir::prove_equiv_via_toolchain::{
+    ToolchainEquivResult, prove_ir_fn_equiv_via_toolchain,
+};
 use xlsynth_pir::simple_rebase::rebase_onto;
 use xlsynth_pir::{ir, ir_parser};
-use xlsynth_pir::prove_equiv_via_toolchain::{prove_ir_fn_equiv_via_toolchain, ToolchainEquivResult};
 
 fn max_text_id(f: &ir::Fn) -> usize {
     f.nodes.iter().map(|n| n.text_id).max().unwrap_or(0)
@@ -21,11 +23,7 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
     }
 
     // Skip degenerate samples early.
-    if pair.first.ops.is_empty()
-        || pair.second.ops.is_empty()
-        || pair.first.input_bits == 0
-        || pair.second.input_bits == 0
-    {
+    if pair.first.ops.is_empty() || pair.second.ops.is_empty() {
         // Degenerate generator inputs (no ops or zero-width inputs) are not
         // informative for this property.
         return;
@@ -35,12 +33,7 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
 
     // 1) Build orig IR from the first sample
     let mut pkg_orig = xlsynth::IrPackage::new("fuzz_pkg_orig").unwrap();
-    if let Err(_) = generate_ir_fn(
-        pair.first.input_bits,
-        pair.first.ops.clone(),
-        &mut pkg_orig,
-        None,
-    ) {
+    if let Err(_) = generate_ir_fn(pair.first.ops.clone(), &mut pkg_orig, None) {
         // Generator can produce temporarily unsupported constructs; not a sample
         // failure.
         return;
@@ -48,12 +41,7 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
 
     // 2) Build desired IR from the second sample
     let mut pkg_desired = xlsynth::IrPackage::new("fuzz_pkg_desired").unwrap();
-    if let Err(_) = generate_ir_fn(
-        pair.second.input_bits,
-        pair.second.ops.clone(),
-        &mut pkg_desired,
-        None,
-    ) {
+    if let Err(_) = generate_ir_fn(pair.second.ops.clone(), &mut pkg_desired, None) {
         // Generator can produce temporarily unsupported constructs; not a sample
         // failure.
         return;

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_same_sig_pair.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_same_sig_pair.rs
@@ -4,15 +4,11 @@
 
 use libfuzzer_sys::fuzz_target;
 use xlsynth::{IrPackage, IrType};
-use xlsynth_pir::ir_fuzz::{generate_ir_fn, FuzzSampleSameTypedPair};
+use xlsynth_pir::ir_fuzz::{FuzzSampleSameTypedPair, generate_ir_fn};
 
 fuzz_target!(|pair: FuzzSampleSameTypedPair| {
     // Skip degenerate samples early.
-    if pair.first.ops.is_empty()
-        || pair.second.ops.is_empty()
-        || pair.first.input_bits == 0
-        || pair.second.input_bits == 0
-    {
+    if pair.first.ops.is_empty() || pair.second.ops.is_empty() {
         // Degenerate generator inputs (no ops or zero-width inputs) are not
         // interesting for this target and can arise frequently. We intentionally
         // skip rather than crash to avoid biasing the corpus toward trivial cases.
@@ -23,12 +19,7 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
 
     let mut pkg1 =
         IrPackage::new("first").expect("IrPackage::new should not fail; treat as infra error");
-    let func1 = match generate_ir_fn(
-        pair.first.input_bits,
-        pair.first.ops.clone(),
-        &mut pkg1,
-        None,
-    ) {
+    let func1 = match generate_ir_fn(pair.first.ops.clone(), &mut pkg1, None) {
         Ok(f) => f,
         Err(_) => {
             // The generator can produce constructs not yet supported; skip such cases.
@@ -38,12 +29,7 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
 
     let mut pkg2 =
         IrPackage::new("second").expect("IrPackage::new should not fail; treat as infra error");
-    let func2 = match generate_ir_fn(
-        pair.second.input_bits,
-        pair.second.ops.clone(),
-        &mut pkg2,
-        None,
-    ) {
+    let func2 = match generate_ir_fn(pair.second.ops.clone(), &mut pkg2, None) {
         Ok(f) => f,
         Err(_) => {
             // The generator can produce constructs not yet supported; skip such cases.


### PR DESCRIPTION
Enhancements:
* Multiple parameters are supported.
* Limits are placed on the total number of elements (recursive) in an array/tuple. Previously, the number could be exponentially large resulting in exponentially large graphs when generating pairs of functions with the same signature because the second matching function is concievably built element-by-element.
* Types are tracked more precisely with FuzzOps. This is required to count the number of elements in an array/tuple.
