### PR TITLE
Add a greedy ECO computation algorithm. 

### DIFF
--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -391,6 +391,25 @@ Example:
 xlsynth-driver ir-localized-eco old.opt.ir new.opt.ir \
   --old_ir_top=main --new_ir_top=main \
   --output_dir=eco_out --sanity-samples=10 --sanity-seed=0
+### `greedy-eco`
+
+Computes greedy graph edits to transform an old IR function into a new one, applies those edits to the old function, and emits the patched IR package.
+
+- Positional arguments: `<old.ir> <new.ir>` (both must be package-form IR)
+- Entry-point selection (optional): `--old_ir_top <NAME>` and `--new_ir_top <NAME>`; if omitted, the package `top` or first function is used on each side.
+- Outputs:
+  - `--patched_out <PATH>` – write the patched package IR to this path. If omitted, the patched package IR is printed to stdout.
+  - `--edits_debug_out <PATH>` – write the debug string (`{:#?}`) of the IrEdits to a file (optional).
+
+Example:
+
+```shell
+xlsynth-driver greedy-eco old.opt.ir new.opt.ir \
+  --old_ir_top=main --new_ir_top=main \
+  --patched_out=patched.opt.ir \
+  --edits_debug_out=edits.txt
+```
+
 ```
 
 ### `ir2gates`: IR to GateFn statistics

--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -391,6 +391,8 @@ Example:
 xlsynth-driver ir-localized-eco old.opt.ir new.opt.ir \
   --old_ir_top=main --new_ir_top=main \
   --output_dir=eco_out --sanity-samples=10 --sanity-seed=0
+```
+
 ### `greedy-eco`
 
 Computes greedy graph edits to transform an old IR function into a new one, applies those edits to the old function, and emits the patched IR package.
@@ -408,8 +410,6 @@ xlsynth-driver greedy-eco old.opt.ir new.opt.ir \
   --old_ir_top=main --new_ir_top=main \
   --patched_out=patched.opt.ir \
   --edits_debug_out=edits.txt
-```
-
 ```
 
 ### `ir2gates`: IR to GateFn statistics

--- a/xlsynth-driver/src/greedy_eco.rs
+++ b/xlsynth-driver/src/greedy_eco.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::ArgMatches;
+use std::path::Path;
+use xlsynth_pir::greedy_matching_ged::GreedyMatchSelector;
+use xlsynth_pir::ir_parser::Parser;
+use xlsynth_pir::matching_ged::{apply_function_edits, compute_function_edit};
+
+/// Implements the "greedy-eco" subcommand:
+/// - Reads old/new IR package files
+/// - Computes greedy graph-edit edits to transform old→new
+/// - Applies edits to the old function
+/// - Emits the patched package IR (stdout or --patched_out)
+/// - Optionally writes the debug string of IrEdits to --edits_debug_out
+pub fn handle_greedy_eco(matches: &ArgMatches) {
+    let old_ir_path = Path::new(matches.get_one::<String>("old_ir_file").unwrap());
+    let new_ir_path = Path::new(matches.get_one::<String>("new_ir_file").unwrap());
+
+    let old_ir_text = std::fs::read_to_string(old_ir_path).expect("read old IR should succeed");
+    let new_ir_text = std::fs::read_to_string(new_ir_path).expect("read new IR should succeed");
+
+    let mut old_pkg = Parser::new(&old_ir_text)
+        .parse_and_validate_package()
+        .expect("parse old IR should succeed");
+    let new_pkg = Parser::new(&new_ir_text)
+        .parse_and_validate_package()
+        .expect("parse new IR should succeed");
+
+    let old_top_flag = matches.get_one::<String>("old_ir_top").map(|s| s.as_str());
+    let new_top_flag = matches.get_one::<String>("new_ir_top").map(|s| s.as_str());
+
+    let old_fn = match old_top_flag {
+        Some(name) => old_pkg
+            .get_fn(name)
+            .unwrap_or_else(|| panic!("old package missing function '{}'", name)),
+        None => old_pkg.get_top().expect("old package missing top function"),
+    };
+    let new_fn = match new_top_flag {
+        Some(name) => new_pkg
+            .get_fn(name)
+            .unwrap_or_else(|| panic!("new package missing function '{}'", name)),
+        None => new_pkg.get_top().expect("new package missing top function"),
+    };
+
+    // Compute edits using the greedy selector.
+    let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
+    let edits = compute_function_edit(old_fn, new_fn, &mut selector)
+        .expect("compute_function_edit (greedy) failed");
+
+    // Optionally write the debug string of edits.
+    if let Some(path) = matches.get_one::<String>("edits_debug_out") {
+        let dbg_str = format!("{:#?}\n", edits.edits);
+        std::fs::write(path, dbg_str).expect("write edits_debug_out should succeed");
+    }
+
+    // Apply to old function and splice back into the old package.
+    let patched_fn = apply_function_edits(old_fn, &edits).expect("apply_function_edits failed");
+
+    if let Some(name) = old_top_flag {
+        // Replace the named function in the old package.
+        let slot = old_pkg
+            .get_fn_mut(name)
+            .unwrap_or_else(|| panic!("old package missing function '{}'", name));
+        *slot = patched_fn;
+    } else {
+        // Replace top function.
+        let slot = old_pkg
+            .get_top_mut()
+            .expect("old package missing top function (mut)");
+        *slot = patched_fn;
+    }
+
+    // Emit patched package IR.
+    if let Some(path) = matches.get_one::<String>("patched_out") {
+        std::fs::write(path, format!("{}", old_pkg)).expect("write patched_out should succeed");
+    } else {
+        print!("{}", old_pkg);
+    }
+}

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -45,6 +45,7 @@ mod dslx_stitch_pipeline;
 mod flag_defaults;
 mod g8r2v;
 mod g8r_equiv;
+mod greedy_eco;
 mod gv2ir;
 mod gv_read_stats;
 mod ir2combo;
@@ -973,6 +974,44 @@ fn main() {
                 )
         )
         .subcommand(
+            clap::Command::new("greedy-eco")
+                .about("Computes an ECO based on a greedy graph-edit-distance heurisitic")
+                .arg(
+                    Arg::new("old_ir_file")
+                        .help("The old/original IR file (package)")
+                        .required(true)
+                        .index(1),
+                )
+                .arg(
+                    Arg::new("new_ir_file")
+                        .help("The new/target IR file (package)")
+                        .required(true)
+                        .index(2),
+                )
+                .arg(
+                    Arg::new("old_ir_top")
+                        .long("old_ir_top")
+                        .help("Top-level entry point for the old IR package"),
+                )
+                .arg(
+                    Arg::new("new_ir_top")
+                        .long("new_ir_top")
+                        .help("Top-level entry point for the new IR package"),
+                )
+                .arg(
+                    Arg::new("patched_out")
+                        .long("patched_out")
+                        .value_name("PATH")
+                        .help("Write the patched IR package to PATH; if omitted, prints to stdout"),
+                )
+                .arg(
+                    Arg::new("edits_debug_out")
+                        .long("edits_debug_out")
+                        .value_name("PATH")
+                        .help("Write the debug string of IrEdits to PATH (optional)"),
+                ),
+        )
+        .subcommand(
             clap::Command::new("lib2proto")
                 .about("Converts Liberty file(s) to proto or textproto")
                 .arg(
@@ -1508,6 +1547,8 @@ fn main() {
         ir2gates::handle_ir2gates(matches, &config);
     } else if let Some(matches) = matches.subcommand_matches("ir2g8r") {
         ir2gates::handle_ir2g8r(matches, &config);
+    } else if let Some(matches) = matches.subcommand_matches("greedy-eco") {
+        greedy_eco::handle_greedy_eco(matches);
     } else if let Some(matches) = matches.subcommand_matches("lib2proto") {
         lib2proto::handle_lib2proto(matches);
     } else if let Some(matches) = matches.subcommand_matches("gv2ir") {

--- a/xlsynth-pir/fuzz/Cargo.toml
+++ b/xlsynth-pir/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ cargo-fuzz = true
 libfuzzer-sys = { version = "0.4" }
 log = "0.4"
 env_logger = "0.11"
+blake3 = "1"
 # Local crates
 xlsynth-pir = { path = ".." }
 xlsynth = { path = "../../xlsynth" }
@@ -21,5 +22,17 @@ xlsynth = { path = "../../xlsynth" }
 [[bin]]
 name = "fuzz_ir_verify"
 path = "fuzz_targets/fuzz_ir_verify.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_naive_matching_ged"
+path = "fuzz_targets/fuzz_naive_matching_ged.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_greedy_matching_ged"
+path = "fuzz_targets/fuzz_greedy_matching_ged.rs"
 test = false
 doc = false

--- a/xlsynth-pir/fuzz/FUZZ.md
+++ b/xlsynth-pir/fuzz/FUZZ.md
@@ -26,3 +26,31 @@ Main failure modes surfaced:
 
 - Divergence in acceptance (one verifier accepts while the other rejects).
 - Divergence in coarse error category (e.g., PIR flags NodeTypeMismatch while xlsynth flags a different class).
+
+---
+
+# Graph Edit Distance (GED) Fuzz Target
+
+Thes fuzz targets generates two same-typed random IR functions, computes edits using a matcher, applies those edits to the first function, and asserts the result is isomorphic to the second.
+
+Target names: `fuzz_greedy_matching_ged`, `fuzz_naive_matching_ged`
+
+Run:
+
+```bash
+cargo fuzz run fuzz_greedy_matching_ged
+```
+
+Essential property under test:
+
+- The greedy matcher’s produced edits, when applied, should transform the old function into one isomorphic to the new function (modulo ids/names).
+
+Early returns justification:
+
+- Degenerate generator outputs (empty op lists or zero input width) are skipped; these are not interesting samples for edit computation.
+- Parser errors are skipped; infrastructure/transient parsing failures are not properties of the fuzz sample.
+
+Main failure modes surfaced:
+
+- Incorrect edit planning or application that yields a non-isomorphic result.
+- Crashes or panics during greedy selection or edit conversion.

--- a/xlsynth-pir/fuzz/fuzz_targets/fuzz_greedy_matching_ged.rs
+++ b/xlsynth-pir/fuzz/fuzz_targets/fuzz_greedy_matching_ged.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use log::{debug, info};
+use xlsynth::IrPackage;
+use xlsynth_pir::dce::{get_dead_nodes, remove_dead_nodes};
+use xlsynth_pir::greedy_matching_ged::GreedyMatchSelector;
+use xlsynth_pir::ir_fuzz::{FuzzSampleSameTypedPair, generate_ir_fn};
+use xlsynth_pir::matching_ged::{
+    IrMatchSet, MatchAction, NodeSide, apply_function_edits, compute_function_edit,
+    compute_function_match, convert_match_set_to_edit_set, format_ir_edits, format_match_actions,
+};
+use xlsynth_pir::{ir_parser, node_hashing::functions_structurally_equivalent};
+use xlsynth_pir_fuzz::equiv::{
+    compute_forward_equivalences, compute_reverse_equivalences_to_return,
+};
+
+// Returns the pairs of nodes which are CSE-equivalent between old and new
+// graphs. Only unique pairs are returned. If a node is equivalent to multiple
+// nodes in the other graph then it is not included.
+fn unique_forward_equivalent_pairs(
+    old_fn: &xlsynth_pir::ir::Fn,
+    new_fn: &xlsynth_pir::ir::Fn,
+) -> Vec<(usize, usize)> {
+    let eq = compute_forward_equivalences(old_fn, new_fn);
+    let mut pairs: Vec<(usize, usize)> = Vec::new();
+    for (oi, news) in eq.lhs_to_rhs.iter() {
+        if news.len() != 1 {
+            continue;
+        }
+        let ni: usize = news[0];
+        if let Some(olds) = eq.rhs_to_lhs.get(&ni) {
+            if olds.len() == 1 && olds[0] == *oi {
+                pairs.push((*oi, ni));
+            }
+        }
+    }
+    pairs
+}
+
+// Returns the pairs of nodes which are reverse structurallyequivalent between
+// old and new graphs. Only unique pairs are returned. If a node is equivalent
+// to multiple nodes in the other graph then it is not included.
+fn unique_reverse_equivalent_pairs(
+    old_fn: &xlsynth_pir::ir::Fn,
+    new_fn: &xlsynth_pir::ir::Fn,
+) -> Vec<(usize, usize)> {
+    let eq = compute_reverse_equivalences_to_return(old_fn, new_fn);
+    let mut pairs: Vec<(usize, usize)> = Vec::new();
+    for (oi, news) in eq.lhs_to_rhs.iter() {
+        if news.len() != 1 {
+            continue;
+        }
+        let ni: usize = news[0];
+        if let Some(olds) = eq.rhs_to_lhs.get(&ni) {
+            if olds.len() == 1 && olds[0] == *oi {
+                pairs.push((*oi, ni));
+            }
+        }
+    }
+    pairs
+}
+
+fn assert_equivalent_nodes_are_matched(
+    old_fn: &xlsynth_pir::ir::Fn,
+    new_fn: &xlsynth_pir::ir::Fn,
+    matches: &IrMatchSet,
+) {
+    use std::collections::HashSet;
+    let mut matched_pairs: HashSet<(usize, usize)> = HashSet::new();
+    for m in matches.matches.iter() {
+        if let MatchAction::MatchNodes {
+            old_index,
+            new_index,
+            ..
+        } = m
+        {
+            matched_pairs.insert((usize::from(*old_index), usize::from(*new_index)));
+        }
+    }
+    // Precompute dead node sets (by index) for both functions.
+    let dead_old: std::collections::HashSet<usize> = get_dead_nodes(old_fn)
+        .into_iter()
+        .map(|nr| nr.index)
+        .collect();
+    let dead_new: std::collections::HashSet<usize> = get_dead_nodes(new_fn)
+        .into_iter()
+        .map(|nr| nr.index)
+        .collect();
+
+    // Compute uniquely equivalent pairs (forward) and ensure matches exist,
+    // skipping pairs where either node is dead.
+    let fwd_pairs = unique_forward_equivalent_pairs(old_fn, new_fn);
+    for (oi, ni) in fwd_pairs.into_iter() {
+        if dead_old.contains(&oi) || dead_new.contains(&ni) {
+            continue;
+        }
+        if !matched_pairs.contains(&(oi, ni)) {
+            panic!(
+                "missing MatchNodes for uniquely forward-equivalent pair: {} <-> {}",
+                xlsynth_pir::ir::node_textual_id(old_fn, xlsynth_pir::ir::NodeRef { index: oi }),
+                xlsynth_pir::ir::node_textual_id(new_fn, xlsynth_pir::ir::NodeRef { index: ni }),
+            );
+        }
+    }
+    // Compute uniquely equivalent pairs (reverse) and ensure matches exist.
+    let rev_pairs = unique_reverse_equivalent_pairs(old_fn, new_fn);
+    for (oi, ni) in rev_pairs.into_iter() {
+        if dead_old.contains(&oi) || dead_new.contains(&ni) {
+            continue;
+        }
+        if !matched_pairs.contains(&(oi, ni)) {
+            panic!(
+                "missing MatchNodes for uniquely reverse-equivalent pair: {} <-> {}",
+                xlsynth_pir::ir::node_textual_id(old_fn, xlsynth_pir::ir::NodeRef { index: oi }),
+                xlsynth_pir::ir::node_textual_id(new_fn, xlsynth_pir::ir::NodeRef { index: ni }),
+            );
+        }
+    }
+}
+
+fuzz_target!(|pair: FuzzSampleSameTypedPair| {
+    info!("Sample generated.");
+
+    // Early-return on degenerate inputs.
+    if pair.first.ops.is_empty() || pair.second.ops.is_empty() {
+        return;
+    }
+    info!("Sample is not degenerate.");
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    // Build two XLS IR functions via the C++ bindings
+    let mut pkg1 = IrPackage::new("first").expect("IrPackage::new infra error");
+    let _ = match generate_ir_fn(pair.first.ops.clone(), &mut pkg1, None) {
+        Ok(f) => f,
+        Err(_) => return, // unsupported generator outputs are skipped
+    };
+
+    let mut pkg2 = IrPackage::new("second").expect("IrPackage::new infra error");
+    let _ = match generate_ir_fn(pair.second.ops.clone(), &mut pkg2, None) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+
+    info!("IR function pair generated.");
+
+    // Convert both to text and parse via our Rust parser to obtain xls_ir::ir::Fn
+    let pkg1_text = pkg1.to_string();
+    let parsed1 = match ir_parser::Parser::new(&pkg1_text).parse_and_validate_package() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let old_fn = match parsed1.get_top() {
+        Some(f) => f,
+        None => return,
+    };
+
+    let pkg2_text = pkg2.to_string();
+    let parsed2 = match ir_parser::Parser::new(&pkg2_text).parse_and_validate_package() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let new_fn = match parsed2.get_top() {
+        Some(f) => f,
+        None => return,
+    };
+    info!(
+        "Parsable sample generated. sizes: old={}, new={}",
+        old_fn.nodes.len(),
+        new_fn.nodes.len()
+    );
+    debug!("OLD IR TEXT:\n{}", pkg1_text);
+    debug!("NEW IR TEXT:\n{}", pkg2_text);
+    info!(
+        "old_fn.nodes.len() = {}, new_fn.nodes.len() = {}",
+        old_fn.nodes.len(),
+        new_fn.nodes.len()
+    );
+
+    let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
+    let edits =
+        compute_function_edit(old_fn, new_fn, &mut selector).expect("compute_function_edit Err");
+
+    let patched =
+        apply_function_edits(old_fn, &edits).expect("apply_function_edits returned Err (greedy)");
+    debug!("PATCHED IR TEXT:\n{}", patched);
+    debug!(
+        "IR EDITS ({}):\n{}",
+        edits.edits.len(),
+        format_ir_edits(old_fn, &edits)
+    );
+    assert!(functions_structurally_equivalent(&patched, new_fn));
+
+    // Rerun matching after running DCE. This enables more precise testing of
+    // expected invariants around equivalence.
+    let old_dce = remove_dead_nodes(old_fn);
+    let new_dce = remove_dead_nodes(new_fn);
+    debug!("OLD IR (AFTER DCE):\n{}", old_dce);
+    debug!("NEW IR (AFTER DCE):\n{}", new_dce);
+
+    // Compute matches on DCE'd functions with greedy selector.
+    let mut sel_dce = GreedyMatchSelector::new(&old_dce, &new_dce);
+    let matches = compute_function_match(&old_dce, &new_dce, &mut sel_dce)
+        .expect("compute_function_match Err (AFTER DCE)");
+    debug!(
+        "MATCHES (AFTER DCE) ({}):\n{}",
+        matches.matches.len(),
+        format_match_actions(&old_dce, &new_dce, &matches.matches)
+    );
+    assert_equivalent_nodes_are_matched(&old_dce, &new_dce, &matches);
+
+    // Convert matches to edits and verify isomorphism on editted graph.
+    let edits_dce = convert_match_set_to_edit_set(&old_dce, &new_dce, &matches);
+    let patched_dce = apply_function_edits(&old_dce, &edits_dce)
+        .expect("apply_function_edits returned Err (AFTER DCE)");
+    debug!("PATCHED IR (AFTER DCE):\n{}", patched_dce);
+    assert!(functions_structurally_equivalent(&patched_dce, &new_dce));
+});

--- a/xlsynth-pir/fuzz/fuzz_targets/fuzz_naive_matching_ged.rs
+++ b/xlsynth-pir/fuzz/fuzz_targets/fuzz_naive_matching_ged.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use xlsynth::IrPackage;
+use xlsynth_pir::ir_fuzz::{FuzzSampleSameTypedPair, generate_ir_fn};
+use xlsynth_pir::matching_ged::apply_function_edits;
+use xlsynth_pir::{ir_parser, node_hashing::functions_structurally_equivalent};
+
+fuzz_target!(|pair: FuzzSampleSameTypedPair| {
+    // Skip degenerate samples early.
+    if pair.first.ops.is_empty() || pair.second.ops.is_empty() {
+        return;
+    }
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    // Build two XLS IR functions via the C++ bindings
+    let mut pkg1 = IrPackage::new("first").expect("IrPackage::new infra error");
+    let func1 = match generate_ir_fn(pair.first.ops.clone(), &mut pkg1, None) {
+        Ok(f) => f,
+        Err(_) => return, // unsupported generator outputs are skipped
+    };
+
+    let mut pkg2 = IrPackage::new("second").expect("IrPackage::new infra error");
+    let func2 = match generate_ir_fn(pair.second.ops.clone(), &mut pkg2, None) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+
+    // Convert both to text and parse via our Rust parser to obtain xls_ir::ir::Fn
+    let pkg1_text = pkg1.to_string();
+    let parsed1 = match ir_parser::Parser::new(&pkg1_text).parse_and_validate_package() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let old_fn = match parsed1.get_top() {
+        Some(f) => f,
+        None => return,
+    };
+
+    let pkg2_text = pkg2.to_string();
+    let parsed2 = match ir_parser::Parser::new(&pkg2_text).parse_and_validate_package() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let new_fn = match parsed2.get_top() {
+        Some(f) => f,
+        None => return,
+    };
+
+    // Compute edit distance, apply to old, and verify isomorphism.
+    let mut selector = xlsynth_pir::matching_ged::NaiveMatchSelector::new(old_fn, new_fn);
+    let edits = xlsynth_pir::matching_ged::compute_function_edit(old_fn, new_fn, &mut selector)
+        .expect("compute_function_edit returned Err");
+    let patched = apply_function_edits(old_fn, &edits).expect("apply_function_edits returned Err");
+    assert!(functions_structurally_equivalent(&patched, new_fn));
+});

--- a/xlsynth-pir/fuzz/src/equiv.rs
+++ b/xlsynth-pir/fuzz/src/equiv.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Equivalence utilities used by fuzz targets.
+//!
+//! Provides forward and reverse structural equivalence computations between two
+//! XLS IR functions. Indices are returned as `usize` node indices into the
+//! functions' node vectors. We refer to the two functions as `lhs` and `rhs`.
+
+use std::collections::{HashMap, HashSet};
+
+use xlsynth_pir::dce::get_dead_nodes;
+use xlsynth_pir::ir::Fn;
+use xlsynth_pir::ir::NodeRef;
+use xlsynth_pir::ir_utils::{get_topological, operands};
+use xlsynth_pir::node_hashing::{
+    BwdHash, FwdHash, compute_node_backward_structural_hash, compute_node_structural_hash,
+};
+
+#[derive(Debug, Clone)]
+pub struct Equivalences {
+    pub lhs_to_rhs: HashMap<usize, Vec<usize>>,
+    pub rhs_to_lhs: HashMap<usize, Vec<usize>>,
+}
+
+/// Computes the sets of nodes in `lhs` that are equivalent in the forward
+/// direction (in a common-subexpression sense) to nodes in `rhs` and vice
+/// versa.
+pub fn compute_forward_equivalences(lhs: &Fn, rhs: &Fn) -> Equivalences {
+    // Helper: compute forward structural hashes for all nodes via topo order.
+    fn compute_forward_hashes(f: &Fn) -> Vec<FwdHash> {
+        let order = get_topological(f);
+        let mut hashes: Vec<Option<FwdHash>> = vec![None; f.nodes.len()];
+        for nr in order {
+            let child_hashes: Vec<FwdHash> = operands(&f.get_node(nr).payload)
+                .into_iter()
+                .map(|c| hashes[c.index].expect("child hash must be computed first"))
+                .collect();
+            let h = compute_node_structural_hash(f, nr, &child_hashes);
+            hashes[nr.index] = Some(h);
+        }
+        hashes
+            .into_iter()
+            .map(|o| o.expect("hash must be set"))
+            .collect()
+    }
+
+    let lhs_hashes = compute_forward_hashes(lhs);
+    let rhs_hashes = compute_forward_hashes(rhs);
+
+    // Build reverse indices by hash.
+    let mut by_hash_lhs: HashMap<FwdHash, Vec<usize>> = HashMap::new();
+    for (idx, h) in lhs_hashes.iter().enumerate() {
+        by_hash_lhs.entry(*h).or_default().push(idx);
+    }
+    let mut by_hash_rhs: HashMap<FwdHash, Vec<usize>> = HashMap::new();
+    for (idx, h) in rhs_hashes.iter().enumerate() {
+        by_hash_rhs.entry(*h).or_default().push(idx);
+    }
+
+    // Produce dense maps including keys for nodes with no equivalents (empty vecs).
+    let mut lhs_to_rhs: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (idx, h) in lhs_hashes.iter().enumerate() {
+        let mut v = by_hash_rhs.get(h).cloned().unwrap_or_default();
+        v.sort_unstable();
+        lhs_to_rhs.insert(idx, v);
+    }
+
+    let mut rhs_to_lhs: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (idx, h) in rhs_hashes.iter().enumerate() {
+        let mut v = by_hash_lhs.get(h).cloned().unwrap_or_default();
+        v.sort_unstable();
+        rhs_to_lhs.insert(idx, v);
+    }
+
+    Equivalences {
+        lhs_to_rhs,
+        rhs_to_lhs,
+    }
+}
+
+/// Computes the sets of nodes in `lhs` that are reverse equivalent to nodes in
+/// `rhs` and vice versa. A node is reverse equivalent to another node if it is
+/// structurally identical with respect to the return node. Dead nodes are
+/// ignored.
+pub fn compute_reverse_equivalences_to_return(lhs: &Fn, rhs: &Fn) -> Equivalences {
+    assert!(
+        lhs.ret_node_ref.is_some(),
+        "compute_reverse_equivalences_to_return: old function has no return node"
+    );
+    assert!(
+        rhs.ret_node_ref.is_some(),
+        "compute_reverse_equivalences_to_return: new function has no return node"
+    );
+
+    fn compute_backward_hashes_filter_dead(f: &Fn) -> (Vec<BwdHash>, HashSet<usize>) {
+        let n = f.nodes.len();
+        if n == 0 {
+            return (vec![], HashSet::new());
+        }
+        // Build users with operand slots for the entire graph.
+        let mut users: Vec<Vec<(usize, usize)>> = vec![Vec::new(); n];
+        for (ui, node) in f.nodes.iter().enumerate() {
+            for (slot, dep) in operands(&node.payload).into_iter().enumerate() {
+                users[dep.index].push((ui, slot));
+            }
+        }
+        // Dead set via helper.
+        let dead_set: HashSet<usize> = get_dead_nodes(f).into_iter().map(|nr| nr.index).collect();
+        // Compute backward hashes for all nodes using only live users.
+        let order = get_topological(f);
+        let mut out: Vec<Option<BwdHash>> = vec![None; n];
+        // Sentinel to distinguish the return value as having an implicit user.
+        let ret_index: Option<usize> = f.ret_node_ref.map(|nr| nr.index);
+        let mut ret_sentinel_hasher = blake3::Hasher::new();
+        ret_sentinel_hasher.update(b"__xlsynth_return_sink__");
+        let ret_sentinel = BwdHash(ret_sentinel_hasher.finalize());
+        for nr in order.into_iter().rev() {
+            let i = nr.index;
+            let mut pairs: Vec<(BwdHash, usize)> = Vec::new();
+            for (u, slot) in users[i].iter() {
+                if dead_set.contains(u) {
+                    continue;
+                }
+                let h = out[*u].expect("live user backward hash must be computed before operands");
+                pairs.push((h, *slot));
+            }
+            // Inject a sentinel user for the return node to prevent non-returns
+            // that happen to have no (live) users from being reverse-equivalent
+            // to the return value itself.
+            if ret_index == Some(i) {
+                pairs.push((ret_sentinel, usize::MAX));
+            }
+            out[i] = Some(compute_node_backward_structural_hash(
+                f,
+                NodeRef { index: i },
+                &pairs,
+            ));
+        }
+        let hashes: Vec<BwdHash> = out
+            .into_iter()
+            .map(|o| o.expect("backward hash must be computed for all nodes"))
+            .collect();
+        (hashes, dead_set)
+    }
+
+    let (lhs_bwd, lhs_dead) = compute_backward_hashes_filter_dead(lhs);
+    let (rhs_bwd, rhs_dead) = compute_backward_hashes_filter_dead(rhs);
+
+    // Build reverse indices by backward hash for live nodes only.
+    let mut by_hash_lhs: HashMap<BwdHash, Vec<usize>> = HashMap::new();
+    for (idx, bh) in lhs_bwd.iter().copied().enumerate() {
+        if lhs_dead.contains(&idx) {
+            continue;
+        }
+        by_hash_lhs.entry(bh).or_default().push(idx);
+    }
+    let mut by_hash_rhs: HashMap<BwdHash, Vec<usize>> = HashMap::new();
+    for (idx, bh) in rhs_bwd.iter().copied().enumerate() {
+        if rhs_dead.contains(&idx) {
+            continue;
+        }
+        by_hash_rhs.entry(bh).or_default().push(idx);
+    }
+
+    // Produce dense maps including keys for nodes with no equivalents (empty vecs).
+    let mut lhs_to_rhs: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (idx, bh) in lhs_bwd.iter().copied().enumerate() {
+        let mut v: Vec<usize> = if lhs_dead.contains(&idx) {
+            Vec::new()
+        } else {
+            by_hash_rhs.get(&bh).cloned().unwrap_or_default()
+        };
+        v.sort_unstable();
+        lhs_to_rhs.insert(idx, v);
+    }
+
+    let mut rhs_to_lhs: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (idx, bh) in rhs_bwd.iter().copied().enumerate() {
+        let mut v: Vec<usize> = if rhs_dead.contains(&idx) {
+            Vec::new()
+        } else {
+            by_hash_lhs.get(&bh).cloned().unwrap_or_default()
+        };
+        v.sort_unstable();
+        rhs_to_lhs.insert(idx, v);
+    }
+
+    Equivalences {
+        lhs_to_rhs,
+        rhs_to_lhs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xlsynth_pir::ir::PackageMember;
+    use xlsynth_pir::ir_parser::Parser;
+
+    fn parse_fn(ir: &str) -> Fn {
+        let pkg_text = format!("package p\n\n{}\n", ir);
+        let mut p = Parser::new(&pkg_text);
+        let pkg = p.parse_and_validate_package().unwrap();
+        pkg.members
+            .iter()
+            .find_map(|m| match m {
+                PackageMember::Function(f) => Some(f.clone()),
+                _ => None,
+            })
+            .unwrap()
+    }
+
+    fn index_by_name(f: &Fn, name: &str) -> usize {
+        f.nodes
+            .iter()
+            .position(|n| n.name.as_deref() == Some(name))
+            .expect("node by name not found")
+    }
+
+    #[test]
+    fn forward_equivalences_two_adds_equivalent() {
+        // Two adds with different names are forward-equivalent.
+        let f = parse_fn(
+            r#"fn f(a: bits[8] id=1, b: bits[8] id=2) -> bits[8] {
+  a: bits[8] = param(name=a, id=1)
+  b: bits[8] = param(name=b, id=2)
+  sum1: bits[8] = add(a, b, id=10)
+  sum2: bits[8] = add(a, b, id=11)
+  ret r: bits[8] = identity(sum1, id=12)
+}"#,
+        );
+        let eq = compute_forward_equivalences(&f, &f);
+        let s1 = index_by_name(&f, "sum1");
+        let s2 = index_by_name(&f, "sum2");
+        let v1 = eq.lhs_to_rhs.get(&s1).unwrap();
+        let v2 = eq.lhs_to_rhs.get(&s2).unwrap();
+        assert!(v1.contains(&s1) && v1.contains(&s2));
+        assert!(v2.contains(&s1) && v2.contains(&s2));
+    }
+
+    #[test]
+    fn reverse_equivalences_return_is_unique_even_with_dead_clone() {
+        // Both sides have same params; rhs has a dead node identical to return.
+        // Ensure the dead node is not reverse-equivalent to the return value.
+        let lhs = parse_fn(
+            r#"fn f(a: bits[8] id=1, b: bits[8] id=2) -> bits[8] {
+  a: bits[8] = param(name=a, id=1)
+  b: bits[8] = param(name=b, id=2)
+  sum: bits[8] = add(a, b, id=10)
+  ret r: bits[8] = identity(sum, id=11)
+}"#,
+        );
+        let rhs = parse_fn(
+            r#"fn f(a: bits[8] id=1, b: bits[8] id=2) -> bits[8] {
+  a: bits[8] = param(name=a, id=1)
+  b: bits[8] = param(name=b, id=2)
+  sum: bits[8] = add(a, b, id=20)
+  ret r: bits[8] = identity(sum, id=21)
+  dead_r: bits[8] = identity(dead_sum, id=31)
+}"#,
+        );
+
+        let eq = compute_reverse_equivalences_to_return(&lhs, &rhs);
+        let lhs_ret = lhs.ret_node_ref.unwrap().index;
+        let rhs_ret = rhs.ret_node_ref.unwrap().index;
+        let rhs_dead_r = index_by_name(&rhs, "dead_r");
+
+        // Return must map to return on the other side.
+        assert!(eq.lhs_to_rhs.get(&lhs_ret).unwrap().contains(&rhs_ret));
+        // The dead clone must not map to the return.
+        assert!(eq.rhs_to_lhs.get(&rhs_dead_r).unwrap().is_empty());
+        assert!(!eq.rhs_to_lhs.get(&rhs_dead_r).unwrap().contains(&lhs_ret));
+    }
+}

--- a/xlsynth-pir/fuzz/src/lib.rs
+++ b/xlsynth-pir/fuzz/src/lib.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper library for fuzzing xlsynth-pir. Exposes equivalence utilities used
+//! by fuzz targets and unit tests.
+
+pub mod equiv;

--- a/xlsynth-pir/src/dce.rs
+++ b/xlsynth-pir/src/dce.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dead-code elimination utilities for XLS IR functions.
+
+use crate::ir::{Fn, NodeRef};
+use crate::ir_utils::{operands, remap_payload_with};
+
+/// Returns a list of nodes that are dead (unreachable from the function's
+/// return value by following operand edges).
+///
+/// The returned vector is sorted by node index ascending to ensure
+/// deterministic ordering.
+pub fn get_dead_nodes(f: &Fn) -> Vec<NodeRef> {
+    let n = f.nodes.len();
+    if n == 0 {
+        return Vec::new();
+    }
+
+    // Mark nodes reachable from the return node via operands.
+    let mut live: Vec<bool> = vec![false; n];
+    assert!(
+        f.ret_node_ref.is_some(),
+        "get_dead_nodes: function has no return node"
+    );
+    let ret = f.ret_node_ref.unwrap();
+    let mut stack: Vec<NodeRef> = vec![ret];
+    while let Some(nr) = stack.pop() {
+        if live[nr.index] {
+            continue;
+        }
+        live[nr.index] = true;
+        let node = f.get_node(nr);
+        for dep in operands(&node.payload) {
+            if !live[dep.index] {
+                stack.push(dep);
+            }
+        }
+    }
+
+    // Dead nodes are those never marked live.
+    let mut dead: Vec<NodeRef> = Vec::new();
+    for i in 0..n {
+        if !live[i] {
+            dead.push(NodeRef { index: i });
+        }
+    }
+    dead
+}
+
+/// Returns a new function with dead nodes (unreachable from the return value)
+/// removed and all remaining node indices compacted. Operand references are
+/// remapped to the new indices. GetParam nodes are preserved even if they would
+/// otherwise be considered dead, to satisfy validation rules requiring a
+/// GetParam for each declared parameter.
+pub fn remove_dead_nodes(f: &Fn) -> Fn {
+    let n = f.nodes.len();
+    assert!(n > 0, "remove_dead_nodes: function has no nodes");
+    assert!(
+        f.ret_node_ref.is_some(),
+        "remove_dead_nodes: function has no return node"
+    );
+
+    // Compute liveness from the return.
+    let mut live: Vec<bool> = vec![false; n];
+    let mut stack: Vec<NodeRef> = vec![f.ret_node_ref.unwrap()];
+    while let Some(nr) = stack.pop() {
+        if live[nr.index] {
+            continue;
+        }
+        live[nr.index] = true;
+        let node = f.get_node(nr);
+        for dep in operands(&node.payload) {
+            if !live[dep.index] {
+                stack.push(dep);
+            }
+        }
+    }
+    // Always keep GetParam nodes to satisfy validation rules.
+    for (i, node) in f.nodes.iter().enumerate() {
+        if matches!(node.payload, crate::ir::NodePayload::GetParam(_)) {
+            live[i] = true;
+        }
+    }
+
+    // Build mapping old index -> new index for live nodes.
+    let mut mapping: Vec<Option<usize>> = vec![None; n];
+    let mut next: usize = 0;
+    for i in 0..n {
+        if live[i] {
+            mapping[i] = Some(next);
+            next += 1;
+        }
+    }
+
+    // Remap payloads using the mapping. Only live nodes are copied.
+    let mut new_nodes: Vec<crate::ir::Node> = Vec::with_capacity(next);
+    for (i, node) in f.nodes.iter().enumerate() {
+        if !live[i] {
+            continue;
+        }
+        let remapped_payload = remap_payload_with(&node.payload, |nr: NodeRef| {
+            let ni = mapping[nr.index].expect("live node must not reference a dead operand");
+            NodeRef { index: ni }
+        });
+        new_nodes.push(crate::ir::Node {
+            text_id: node.text_id,
+            name: node.name.clone(),
+            ty: node.ty.clone(),
+            payload: remapped_payload,
+            pos: node.pos.clone(),
+        });
+    }
+
+    // Remap return node.
+    let ret_old = f.ret_node_ref.unwrap().index;
+    let ret_new = mapping[ret_old].expect("return node must be live");
+
+    crate::ir::Fn {
+        name: f.name.clone(),
+        params: f.params.clone(),
+        ret_ty: f.ret_ty.clone(),
+        nodes: new_nodes,
+        ret_node_ref: Some(NodeRef { index: ret_new }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{NaryOp, PackageMember};
+    use crate::ir_parser::Parser;
+    use crate::ir_utils::operands;
+
+    fn parse_fn(ir: &str) -> Fn {
+        let pkg_text = format!("package test\n\n{}\n", ir);
+        let mut p = Parser::new(&pkg_text);
+        let pkg = p.parse_and_validate_package().unwrap();
+        pkg.members
+            .iter()
+            .filter_map(|m| match m {
+                PackageMember::Function(f) => Some(f.clone()),
+                _ => None,
+            })
+            .next()
+            .unwrap()
+    }
+
+    #[test]
+    fn remove_dead_nodes_keeps_params_and_live_graph() {
+        let f = parse_fn(
+            r#"fn f(a: bits[8] id=1, b: bits[8] id=2) -> bits[8] {
+  a: bits[8] = param(name=a, id=1)
+  b: bits[8] = param(name=b, id=2)
+  add.10: bits[8] = add(a, a, id=10)
+  add.11: bits[8] = add(b, b, id=11)
+  ret identity.12: bits[8] = identity(add.10, id=12)
+}
+"#,
+        );
+        let dead = get_dead_nodes(&f);
+        assert!(
+            dead.iter().any(|nr| {
+                let n = &f.nodes[nr.index];
+                matches!(n.payload, crate::ir::NodePayload::Binop(_, _, _)) && n.text_id == 11
+            }),
+            "expected add.11 to be dead"
+        );
+        let g = remove_dead_nodes(&f);
+        // Validate function still has GetParam for both a and b (even if b was dead)
+        let mut seen_params = 0usize;
+        for node in g.nodes.iter() {
+            if matches!(node.payload, crate::ir::NodePayload::GetParam(_)) {
+                seen_params += 1;
+            }
+        }
+        assert_eq!(
+            seen_params, 2,
+            "expected both GetParam nodes to be preserved"
+        );
+        // Ensure return remains and only live path nodes are present besides params.
+        assert!(g.ret_node_ref.is_some());
+        // Ensure no node references are out of bounds post-remap.
+        for i in 0..g.nodes.len() {
+            for dep in operands(&g.nodes[i].payload) {
+                assert!(dep.index < g.nodes.len());
+            }
+        }
+    }
+
+    #[test]
+    fn dead_nodes_unreachable_literal() {
+        let f = parse_fn(
+            r#"fn f() -> bits[1] {
+  u: bits[1] = literal(value=0, id=1)
+  a: bits[1] = literal(value=1, id=2)
+  b: bits[1] = literal(value=0, id=3)
+  and.4: bits[1] = and(a, b, id=4)
+  ret identity.5: bits[1] = identity(and.4, id=5)
+}"#,
+        );
+
+        // Identify the unreachable literal node 'u' as the literal that is not
+        // an operand of the 'and' node.
+        let mut a_ref: Option<NodeRef> = None;
+        let mut b_ref: Option<NodeRef> = None;
+        let mut and_ref: Option<NodeRef> = None;
+        for (i, node) in f.nodes.iter().enumerate() {
+            if let crate::ir::NodePayload::Nary(NaryOp::And, elems) = &node.payload {
+                assert_eq!(elems.len(), 2);
+                and_ref = Some(NodeRef { index: i });
+                a_ref = Some(elems[0]);
+                b_ref = Some(elems[1]);
+            }
+        }
+        let a = a_ref.expect("expected lhs operand");
+        let b = b_ref.expect("expected rhs operand");
+
+        let mut u_ref: Option<NodeRef> = None;
+        for (i, node) in f.nodes.iter().enumerate() {
+            if let crate::ir::NodePayload::Literal(_) = &node.payload {
+                let nr = NodeRef { index: i };
+                if nr != a && nr != b {
+                    u_ref = Some(nr);
+                }
+            }
+        }
+        let u = u_ref.expect("expected unreachable literal");
+
+        let dead = get_dead_nodes(&f);
+        assert!(dead.contains(&u), "unreachable literal should be dead");
+        assert!(!dead.contains(&a));
+        assert!(!dead.contains(&b));
+        assert!(!dead.contains(&and_ref.unwrap()));
+    }
+}

--- a/xlsynth-pir/src/greedy_matching_ged.rs
+++ b/xlsynth-pir/src/greedy_matching_ged.rs
@@ -1,0 +1,979 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Greedy edit-distance computation between two XLS IR functions.
+//! Contains the matching machinery and conversion of matches into concrete
+//! edits.
+
+use crate::matching_ged::{
+    DepGraph, MatchAction, MatchSelector, NewNodeRef, NodeSide, OldNodeRef, ReadyNode,
+    build_dependency_graph,
+};
+use crate::node_hashing::FwdHash;
+use log::{Level, debug, log_enabled, trace};
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::collections::VecDeque;
+
+/// Greedy match selector which tries to produce a minimal-sized graph edit.
+pub struct GreedyMatchSelector {
+    old_graph: DepGraph<OldNodeRef>,
+    new_graph: DepGraph<NewNodeRef>,
+    /// Per-node hash-correspondence indices.
+    old_to_new_by_hash: HashMap<OldNodeRef, Vec<NewNodeRef>>,
+    new_to_old_by_hash: HashMap<NewNodeRef, Vec<OldNodeRef>>,
+    /// Reverse-direction similarity scores for candidate node pairs.
+    reverse_scores: HashMap<(OldNodeRef, NewNodeRef), i32>,
+    ready_old: BTreeSet<OldNodeRef>,
+    ready_new: BTreeSet<NewNodeRef>,
+    /// Mapping from matched old node index to new node index.
+    matched_old_to_new: HashMap<OldNodeRef, NewNodeRef>,
+    /// Nodes that have been handled (matched or added/removed) in old/new.
+    handled_old: BTreeSet<OldNodeRef>,
+    handled_new: BTreeSet<NewNodeRef>,
+}
+
+impl GreedyMatchSelector {
+    /// Score scaling factor used for integer-based similarity.
+    const SCORE_BASE: i32 = 1000;
+    const PERFECT_MATCH_SCORE: i32 = Self::SCORE_BASE * 100;
+
+    /// Returns the best score for any match which includes nodes a or b (which
+    /// is not the match(a, b)) and for which the match is not yet ready. This
+    /// is some measure of the opportunity cost of matching a with b at the
+    /// moment.
+    ///
+    /// best_unready_match_score(a, None) and best_unready_match_score(None, b)
+    /// are the opportunity costs of matching a (b) with any non ready node.
+    fn best_unready_match_score(&self, a: Option<OldNodeRef>, b: Option<NewNodeRef>) -> i32 {
+        match (a, b) {
+            (Some(a_idx), Some(b_idx)) => {
+                assert!(self.ready_old.contains(&a_idx));
+                assert!(self.ready_new.contains(&b_idx));
+                let mut best = 0i32;
+                if let Some(bs) = self.old_to_new_by_hash.get(&a_idx) {
+                    for &b2 in bs.iter() {
+                        if b2 == b_idx
+                            || self.ready_new.contains(&b2)
+                            || self.handled_new.contains(&b2)
+                        {
+                            continue;
+                        }
+                        let v = self.match_score(&a_idx, &b2).1;
+                        if v > best {
+                            best = v;
+                        }
+                    }
+                }
+                if let Some(as_) = self.new_to_old_by_hash.get(&b_idx) {
+                    for &a2 in as_.iter() {
+                        if a2 == a_idx
+                            || self.ready_old.contains(&a2)
+                            || self.handled_old.contains(&a2)
+                        {
+                            continue;
+                        }
+                        let v = self.match_score(&a2, &b_idx).1;
+                        if v > best {
+                            best = v;
+                        }
+                    }
+                }
+                best
+            }
+            (Some(a_idx), None) => {
+                assert!(self.ready_old.contains(&a_idx));
+                let mut best = 0i32;
+                if let Some(bs) = self.old_to_new_by_hash.get(&a_idx) {
+                    for &b2 in bs.iter() {
+                        if self.ready_new.contains(&b2) || self.handled_new.contains(&b2) {
+                            continue;
+                        }
+                        let v = self.match_score(&a_idx, &b2).1;
+                        if v > best {
+                            best = v;
+                        }
+                    }
+                }
+                best
+            }
+            (None, Some(b_idx)) => {
+                assert!(self.ready_new.contains(&b_idx));
+                let mut best = 0i32;
+                if let Some(as_) = self.new_to_old_by_hash.get(&b_idx) {
+                    for &a2 in as_.iter() {
+                        if self.ready_old.contains(&a2) || self.handled_old.contains(&a2) {
+                            continue;
+                        }
+                        let v = self.match_score(&a2, &b_idx).1;
+                        if v > best {
+                            best = v;
+                        }
+                    }
+                }
+                best
+            }
+            (None, None) => unreachable!(
+                "opportunity cost called with (None, None); at least one side must be Some"
+            ),
+        }
+    }
+
+    /// Score for matching a ready old node `a` with a ready new node `b`.
+    fn match_score(&self, a: &OldNodeRef, b: &NewNodeRef) -> (bool, i32) {
+        let fwd = self.forward_match_score(*a, *b);
+        let fwd = if fwd == Self::SCORE_BASE {
+            Self::PERFECT_MATCH_SCORE
+        } else {
+            fwd
+        };
+        let rev = *self.reverse_scores.get(&(*a, *b)).unwrap_or(&0);
+        let rev = if rev == Self::SCORE_BASE {
+            Self::PERFECT_MATCH_SCORE
+        } else {
+            rev
+        };
+        let is_perfect_match = fwd == Self::PERFECT_MATCH_SCORE || rev == Self::PERFECT_MATCH_SCORE;
+        (is_perfect_match, fwd + rev)
+    }
+    fn net_match_score(&self, a: &OldNodeRef, b: &NewNodeRef) -> (bool, i32) {
+        let (is_perfect_match, score) = self.match_score(a, b);
+        (
+            is_perfect_match,
+            score - self.best_unready_match_score(Some(*a), Some(*b)),
+        )
+    }
+
+    fn delete_node_score(&self, _a: &OldNodeRef) -> i32 {
+        0
+    }
+    fn net_delete_node_score(&self, a: &OldNodeRef) -> i32 {
+        self.delete_node_score(a) - self.best_unready_match_score(Some(*a), None)
+    }
+
+    fn add_node_score(&self, _b: &NewNodeRef) -> i32 {
+        0
+    }
+    fn net_add_node_score(&self, b: &NewNodeRef) -> i32 {
+        self.add_node_score(b) - self.best_unready_match_score(None, Some(*b))
+    }
+
+    /// Build a MatchNodes action for (a, b).
+    fn build_match_action(&self, a: &OldNodeRef, b: &NewNodeRef) -> MatchAction {
+        let new_operands = self
+            .new_graph
+            .get_node(*b)
+            .operands
+            .iter()
+            .copied()
+            .collect::<Vec<NewNodeRef>>();
+        MatchAction::MatchNodes {
+            old_index: *a,
+            new_index: *b,
+            new_operands,
+            is_new_return: *b == self.new_graph.return_value,
+        }
+    }
+
+    /// Build a DeleteNode action for old node `a`.
+    fn build_delete_node_action(&self, a: &OldNodeRef) -> MatchAction {
+        MatchAction::DeleteNode { old_index: *a }
+    }
+
+    /// Build an AddNode action for new node `b`.
+    fn build_add_node_action(&self, b: &NewNodeRef) -> MatchAction {
+        MatchAction::AddNode {
+            new_index: *b,
+            is_return: *b == self.new_graph.return_value,
+        }
+    }
+    pub fn new(old: &crate::ir::Fn, new: &crate::ir::Fn) -> Self {
+        let old_graph = build_dependency_graph::<OldNodeRef>(old);
+        let new_graph = build_dependency_graph::<NewNodeRef>(new);
+        // Build hash->indices maps directly from the graphs, then per-node maps.
+        let mut hash_to_old: HashMap<FwdHash, Vec<OldNodeRef>> = HashMap::new();
+        for (idx, node) in old_graph.nodes.iter().enumerate() {
+            hash_to_old
+                .entry(node.structural_hash)
+                .or_default()
+                .push(OldNodeRef(idx));
+        }
+        let mut hash_to_new: HashMap<FwdHash, Vec<NewNodeRef>> = HashMap::new();
+        for (idx, node) in new_graph.nodes.iter().enumerate() {
+            hash_to_new
+                .entry(node.structural_hash)
+                .or_default()
+                .push(NewNodeRef(idx));
+        }
+        let mut old_to_new_by_hash: HashMap<OldNodeRef, Vec<NewNodeRef>> = HashMap::new();
+        for (oi_us, node) in old_graph.nodes.iter().enumerate() {
+            let oi = OldNodeRef(oi_us);
+            let list = hash_to_new
+                .get(&node.structural_hash)
+                .cloned()
+                .unwrap_or_default();
+            old_to_new_by_hash.insert(oi, list);
+        }
+        let mut new_to_old_by_hash: HashMap<NewNodeRef, Vec<OldNodeRef>> = HashMap::new();
+        for (ni_us, node) in new_graph.nodes.iter().enumerate() {
+            let ni = NewNodeRef(ni_us);
+            let list = hash_to_old
+                .get(&node.structural_hash)
+                .cloned()
+                .unwrap_or_default();
+            new_to_old_by_hash.insert(ni, list);
+        }
+        let reverse_scores = compute_reverse_match_scores(&old_graph, &new_graph);
+        Self {
+            old_graph,
+            new_graph,
+            old_to_new_by_hash,
+            new_to_old_by_hash,
+            reverse_scores,
+            ready_old: BTreeSet::new(),
+            ready_new: BTreeSet::new(),
+            matched_old_to_new: HashMap::new(),
+            handled_old: BTreeSet::new(),
+            handled_new: BTreeSet::new(),
+        }
+    }
+
+    /// Computes forward-direction similarity score based on operand matches.
+    /// Returns 0 unless the local shapes of (old_index, new_index) are equal.
+    /// When equal, returns a score which scales with the number of operands
+    /// which match.
+    pub fn forward_match_score(&self, old_index: OldNodeRef, new_index: NewNodeRef) -> i32 {
+        let old_ops: Vec<usize> = self
+            .old_graph
+            .get_node(old_index)
+            .operands
+            .iter()
+            .copied()
+            .map(|i| usize::from(i))
+            .collect();
+        let new_ops: Vec<usize> = self
+            .new_graph
+            .get_node(new_index)
+            .operands
+            .iter()
+            .copied()
+            .map(|i| usize::from(i))
+            .collect();
+
+        assert!(
+            old_ops.len() == new_ops.len(),
+            "forward_match_score expects equal operand counts for shape-equal nodes"
+        );
+        if old_ops.is_empty() {
+            return Self::SCORE_BASE;
+        }
+
+        let mut matches = 0usize;
+        for (op_old, op_new) in old_ops.iter().zip(new_ops.iter()) {
+            if self
+                .matched_old_to_new
+                .get(&OldNodeRef(*op_old))
+                .map_or(false, |&mapped| mapped == NewNodeRef(*op_new))
+            {
+                matches += 1;
+            }
+        }
+        ((matches as i32) * Self::SCORE_BASE) / (old_ops.len() as i32)
+    }
+
+    fn select_best_action(&mut self) -> Option<(i32, MatchAction)> {
+        if self.ready_old.is_empty() && self.ready_new.is_empty() {
+            return None;
+        }
+
+        let mut best_action: Option<MatchAction> = None;
+        let mut best_score: i32 = i32::MIN;
+
+        // 1) Consider match actions for each ready old against compatible ready new.
+        for &a in self.ready_old.iter() {
+            if let Some(news) = self.old_to_new_by_hash.get(&a) {
+                for &b in news.iter() {
+                    if !self.ready_new.contains(&b) {
+                        continue;
+                    }
+                    let (is_perfect_match, score) = self.net_match_score(&a, &b);
+                    trace!(
+                        "Considering match action: {} <-> {}, score={}, is_perfect_match={}",
+                        self.old_graph.get_node(a).name,
+                        self.new_graph.get_node(b).name,
+                        score,
+                        is_perfect_match
+                    );
+                    if score > best_score {
+                        trace!("New best score: {}", score);
+                        best_score = score;
+                        best_action = Some(self.build_match_action(&a, &b));
+                    }
+                }
+            }
+        }
+
+        // 2) Consider deleting a node from the old graph.
+        for &a in self.ready_old.iter() {
+            let score = self.net_delete_node_score(&a);
+            trace!(
+                "Considering delete node action: {}, score={}",
+                self.old_graph.get_node(a).name,
+                score,
+            );
+            if score > best_score {
+                trace!("New best score: {}", score);
+                best_score = score;
+                best_action = Some(self.build_delete_node_action(&a));
+            }
+        }
+
+        // 3) Consider adding a node to the new graph.
+        for &b in self.ready_new.iter() {
+            let score = self.net_add_node_score(&b);
+            trace!(
+                "Considering add node action: {}, score={}",
+                self.new_graph.get_node(b).name,
+                score,
+            );
+            if score > best_score {
+                trace!("New best score: {}", score);
+                best_score = score;
+                best_action = Some(self.build_add_node_action(&b));
+            }
+        }
+        assert!(best_action.is_some());
+        Some((best_score, best_action.unwrap()))
+    }
+}
+
+impl MatchSelector for GreedyMatchSelector {
+    fn add_ready_node(&mut self, node: ReadyNode) {
+        trace!(
+            "Adding ready node: {:?}",
+            match node.side {
+                NodeSide::Old => format!("old:{}", self.old_graph.nodes[node.index].name),
+                NodeSide::New => format!("new:{}", self.new_graph.nodes[node.index].name),
+            }
+        );
+        match node.side {
+            NodeSide::Old => {
+                self.ready_old.insert(OldNodeRef(node.index));
+            }
+            NodeSide::New => {
+                self.ready_new.insert(NewNodeRef(node.index));
+            }
+        }
+    }
+
+    fn select_next_match(&mut self) -> Option<MatchAction> {
+        trace!("Selecting next match");
+        if log_enabled!(Level::Debug) {
+            let ready_old_names: Vec<String> = self
+                .ready_old
+                .iter()
+                .map(|o| self.old_graph.get_node(*o).name.clone())
+                .collect();
+            let ready_new_names: Vec<String> = self
+                .ready_new
+                .iter()
+                .map(|n| self.new_graph.get_node(*n).name.clone())
+                .collect();
+            trace!("Ready old: [{}]", ready_old_names.join(", "));
+            trace!("Ready new: [{}]", ready_new_names.join(", "));
+        }
+        match self.select_best_action() {
+            Some((score, action)) => {
+                //              println!("best_action (score={:.2}): {:?}", score, action);
+                debug!(
+                    "best_action (score={}): {}",
+                    score,
+                    crate::matching_ged::format_match_action(&action, |side, idx| match side {
+                        NodeSide::Old =>
+                            format!("old:{}", self.old_graph.get_node(OldNodeRef(idx)).name),
+                        NodeSide::New =>
+                            format!("new:{}", self.new_graph.get_node(NewNodeRef(idx)).name),
+                    })
+                );
+                Some(action)
+            }
+            None => {
+                debug!("No best action found");
+                None
+            }
+        }
+    }
+
+    fn update_after_match(&mut self, edit: &MatchAction) {
+        match edit {
+            MatchAction::DeleteNode { old_index } => {
+                self.ready_old.remove(old_index);
+                self.handled_old.insert(*old_index);
+            }
+            MatchAction::AddNode { new_index, .. } => {
+                self.ready_new.remove(new_index);
+                self.handled_new.insert(*new_index);
+            }
+            MatchAction::MatchNodes {
+                old_index,
+                new_index,
+                ..
+            } => {
+                self.ready_old.remove(old_index);
+                self.ready_new.remove(new_index);
+                self.matched_old_to_new.insert(*old_index, *new_index);
+                self.handled_old.insert(*old_index);
+                self.handled_new.insert(*new_index);
+            }
+        }
+    }
+}
+
+/// Computes reverse-direction similarity scores M(A,B) for compatible node
+/// pairs.
+pub fn compute_reverse_match_scores(
+    old_graph: &DepGraph<OldNodeRef>,
+    new_graph: &DepGraph<NewNodeRef>,
+) -> HashMap<(OldNodeRef, NewNodeRef), i32> {
+    // Helper: local shape compatibility via stored structural hash.
+    let shapes_equal = |oi: OldNodeRef, ni: NewNodeRef| {
+        old_graph.get_node(oi).structural_hash == new_graph.get_node(ni).structural_hash
+    };
+
+    // Scores map: best-known M(a,b) so far; initialize implicitly to 0.0 for all
+    // pairs.
+    let mut m_scores: HashMap<(OldNodeRef, NewNodeRef), i32> = HashMap::new();
+
+    // Worklist seeded with all compatible sink pairs (nodes with no users).
+    let mut worklist: VecDeque<(OldNodeRef, NewNodeRef)> = VecDeque::new();
+    let mut on_worklist: HashSet<(OldNodeRef, NewNodeRef)> = HashSet::new();
+    // Just seed the worklist with the return values.
+    worklist.push_back((old_graph.return_value, new_graph.return_value));
+    on_worklist.insert((old_graph.return_value, new_graph.return_value));
+
+    let recompute_score =
+        |a: OldNodeRef, b: NewNodeRef, m: &HashMap<(OldNodeRef, NewNodeRef), i32>| -> i32 {
+            if !shapes_equal(a, b) {
+                return 0;
+            }
+            let z = std::cmp::max(
+                old_graph.get_node(a).users.len(),
+                new_graph.get_node(b).users.len(),
+            );
+            if z == 0 {
+                return GreedyMatchSelector::SCORE_BASE;
+            }
+            let mut sum: i32 = 0;
+            for &(u_a, slot) in old_graph.get_node(a).users.iter() {
+                let mut best: i32 = 0;
+                for &(u_b, slot_b) in new_graph.get_node(b).users.iter() {
+                    if slot_b != slot {
+                        continue;
+                    }
+                    if !shapes_equal(u_a, u_b) {
+                        continue;
+                    }
+                    if let Some(&val) = m.get(&(u_a, u_b)) {
+                        if val > best {
+                            best = val;
+                        }
+                    }
+                }
+                sum += best;
+            }
+            sum / (z as i32)
+        };
+
+    // Process worklist: on improvement, propagate to operand pairs.
+    while let Some((a, b)) = worklist.pop_front() {
+        // Mark as no longer on the worklist so it can be re-enqueued upon future
+        // improvements.
+        on_worklist.remove(&(a, b));
+        let new_score = recompute_score(a, b, &m_scores);
+        let old_score = *m_scores.get(&(a, b)).unwrap_or(&0);
+        if new_score > old_score {
+            m_scores.insert((a, b), new_score);
+
+            // Walk operands in lockstep; if counts match, enqueue compatible pairs.
+            let a_ops: Vec<OldNodeRef> = old_graph.get_node(a).operands.iter().copied().collect();
+            let b_ops: Vec<NewNodeRef> = new_graph.get_node(b).operands.iter().copied().collect();
+            if a_ops.len() == b_ops.len() {
+                for (op_a, op_b) in a_ops.iter().zip(b_ops.iter()) {
+                    if shapes_equal(*op_a, *op_b) && !on_worklist.contains(&(*op_a, *op_b)) {
+                        worklist.push_back((*op_a, *op_b));
+                        on_worklist.insert((*op_a, *op_b));
+                    }
+                }
+            }
+        }
+    }
+
+    // Convert to typed key map for external use.
+    let mut out: HashMap<(OldNodeRef, NewNodeRef), i32> = HashMap::new();
+    for (k, score) in m_scores.into_iter() {
+        out.insert(k, score);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{NodePayload, NodeRef};
+    use crate::ir_parser::Parser;
+    use crate::matching_ged::{
+        IrEdit, MatchAction, NewNodeRef, NodeSide, OldNodeRef, ReadyNode, apply_function_edits,
+        compute_function_edit,
+    };
+
+    fn parse_ir_from_string(s: &str) -> crate::ir::Package {
+        let mut parser = Parser::new(s);
+        parser.parse_and_validate_package().unwrap()
+    }
+
+    #[test]
+    fn compute_returns_adds_and_deletes_for_all_nodes() {
+        let pkg = parse_ir_from_string(
+            r#"package p
+            top fn f(x: bits[8]) -> bits[8] {
+                ret identity.2: bits[8] = identity(x, id=2)
+            }
+            "#,
+        );
+        let lhs = pkg.get_top().unwrap();
+
+        let pkg2 = parse_ir_from_string(
+            r#"package p2
+            top fn f2(x: bits[8]) -> bits[8] {
+                ret identity.2: bits[8] = identity(x, id=2)
+            }
+            "#,
+        );
+        let rhs = pkg2.get_top().unwrap();
+
+        // Use GreedyMatchSelector-based matcher
+        let mut selector = GreedyMatchSelector::new(lhs, rhs);
+        let edits = compute_function_edit(lhs, rhs, &mut selector).unwrap();
+        assert!(edits.edits.is_empty());
+        let patched = apply_function_edits(lhs, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, rhs
+        ));
+    }
+
+    #[test]
+    fn compute_errors_on_mismatched_signatures() {
+        let pkg = parse_ir_from_string(
+            r#"package p
+            top fn f(x: bits[8]) -> bits[8] {
+                ret identity.2: bits[8] = identity(x, id=2)
+            }
+            "#,
+        );
+        let lhs = pkg.get_top().unwrap();
+
+        let pkg2 = parse_ir_from_string(
+            r#"package p2
+            top fn f2(x: bits[9]) -> bits[9] {
+                ret identity.2: bits[9] = identity(x, id=2)
+            }
+            "#,
+        );
+        let rhs = pkg2.get_top().unwrap();
+
+        let mut selector = GreedyMatchSelector::new(lhs, rhs);
+        let result = compute_function_edit(lhs, rhs, &mut selector);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn apply_edits_literal_change_matches_new() {
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[8] {
+                ret literal.1: bits[8] = literal(value=0, id=1)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        let pkg_new = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[8] {
+                ret literal.101: bits[8] = literal(value=1, id=101)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
+        let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
+        let patched = apply_function_edits(old_fn, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, new_fn
+        ));
+    }
+
+    #[test]
+    fn apply_edits_add_identity_of_literal() {
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[1] {
+                ret literal.1: bits[1] = literal(value=0, id=1)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        let pkg_new = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[1] {
+                literal.11: bits[1] = literal(value=1, id=11)
+                ret identity.22: bits[1] = identity(literal.11, id=22)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
+        let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
+        let patched = apply_function_edits(old_fn, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, new_fn
+        ));
+    }
+
+    #[test]
+    fn edit_distance_handles_different_return_nodes() {
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[1] {
+                literal.1: bits[1] = literal(value=1, id=1)
+                ret identity.2: bits[1] = identity(literal.1, id=2)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        // Same nodes, but return points to a different node (the literal).
+        let pkg_new = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[1] {
+                ret literal.1: bits[1] = literal(value=1, id=1)
+                identity.2: bits[1] = identity(literal.1, id=2)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
+        let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
+        let patched = apply_function_edits(old_fn, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, new_fn
+        ));
+    }
+
+    #[test]
+    fn edit_distance_multiple_parameters_identity_wrap() {
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f(a: bits[8] id=1, b: bits[8] id=2) -> bits[8] {
+                ret add.3: bits[8] = add(a, b, id=3)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        // Different structure: wrap the add in an identity, keep params identical.
+        let pkg_new = parse_ir_from_string(
+            r#"package p
+            top fn f(a: bits[8] id=1, b: bits[8] id=2) -> bits[8] {
+                add.103: bits[8] = add(a, b, id=103)
+                ret identity.104: bits[8] = identity(add.103, id=104)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
+        let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
+        let patched = apply_function_edits(old_fn, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, new_fn
+        ));
+    }
+
+    #[test]
+    fn single_operand_substitution_between_adds() {
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f(x: bits[8] id=1, y: bits[8] id=2, z: bits[8] id=3) -> bits[8] {
+                ret add.10: bits[8] = add(x, y, id=10)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        let pkg_new = parse_ir_from_string(
+            r#"package p
+            top fn f(x: bits[8] id=1, y: bits[8] id=2, z: bits[8] id=3) -> bits[8] {
+                ret add.20: bits[8] = add(x, z, id=20)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
+        let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
+
+        assert_eq!(
+            edits.edits.len(),
+            1,
+            "expected exactly one edit, got {:?}",
+            edits.edits
+        );
+        // Verify the edit substitutes to the parameter named 'z'.
+        match edits.edits[0] {
+            IrEdit::SubstituteOperand { new_operand, .. } => {
+                let target_node = old_fn.get_node(new_operand);
+                assert_eq!(target_node.name.as_deref(), Some("z"));
+                assert!(matches!(target_node.payload, NodePayload::GetParam(_)));
+            }
+            ref other => panic!(
+                "expected edit to be an operand substitution, got {:?}",
+                other
+            ),
+        }
+        let patched = apply_function_edits(old_fn, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, new_fn
+        ));
+    }
+
+    #[test]
+    fn multiple_operand_substitutions_in_concat_permutation() {
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f(x: bits[8] id=1, y: bits[8] id=2, z: bits[8] id=3) -> bits[24] {
+                ret concat.10: bits[24] = concat(x, y, z, id=10)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        let pkg_new = parse_ir_from_string(
+            r#"package p
+            top fn f(x: bits[8] id=1, y: bits[8] id=2, z: bits[8] id=3) -> bits[24] {
+                ret concat.20: bits[24] = concat(z, x, y, id=20)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
+        let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
+
+        // Expect exactly three operand substitutions, and patched result is isomorphic.
+        assert_eq!(
+            edits.edits.len(),
+            3,
+            "expected exactly three edits, got {:?}",
+            edits.edits
+        );
+        assert!(
+            edits
+                .edits
+                .iter()
+                .all(|e| matches!(e, IrEdit::SubstituteOperand { .. })),
+            "expected only SubstituteOperand edits, got {:?}",
+            edits.edits
+        );
+
+        let patched = apply_function_edits(old_fn, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, new_fn
+        ));
+    }
+
+    #[test]
+    fn reverse_matches_three_adds_under_or_with_param_permutation() {
+        // Old: or(or(A(w,x), B(x,y)), C(y,z))
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f(w: bits[8] id=1, x: bits[8] id=2, y: bits[8] id=3, z: bits[8] id=4) -> bits[8] {
+                a: bits[8] = add(w, x, id=10)
+                b: bits[8] = add(x, y, id=11)
+                c: bits[8] = add(y, z, id=12)
+                foo: bits[8] = or(a, b, id=13)
+                ret bar: bits[8] = or(foo, b, c, id=14)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        // New: or(or(A'(w,x), C'(y,z)), B'(x,y)) — A stays in inner slot0; B,C swap
+        // levels.
+        let pkg_new = parse_ir_from_string(
+            r#"package p2
+            top fn f2(w: bits[8] id=1, x: bits[8] id=2, y: bits[8] id=3, z: bits[8] id=4) -> bits[8] {
+                a: bits[8] = add(w, x, id=110)
+                b: bits[8] = add(x, y, id=111)
+                c: bits[8] = add(y, z, id=112)
+                foo: bits[8] = or(a, c, id=113)
+                ret bar: bits[8] = or(foo, b, b, id=114)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        // Build dependency graphs and compute reverse matches.
+        let old_graph = crate::matching_ged::build_dependency_graph::<OldNodeRef>(old_fn);
+        let new_graph = crate::matching_ged::build_dependency_graph::<NewNodeRef>(new_fn);
+        let reverse = compute_reverse_match_scores(&old_graph, &new_graph);
+        let base = GreedyMatchSelector::SCORE_BASE;
+
+        // Helper to get node indices by name.
+        let find_named = |f: &crate::ir::Fn, name: &str| -> usize {
+            f.nodes
+                .iter()
+                .position(|n| n.name.as_deref() == Some(name))
+                .expect("node by name not found")
+        };
+        // Helper to read reverse score by node names, or 0 if missing.
+        // Panics if nodes are not found.
+        // Usage: rev("old_name", "new_name")
+        let rev = |old_name: &str, new_name: &str| -> i32 {
+            let oi = find_named(old_fn, old_name);
+            let ni = find_named(new_fn, new_name);
+            reverse
+                .get(&(OldNodeRef(oi), NewNodeRef(ni)))
+                .copied()
+                .unwrap_or(0)
+        };
+
+        assert_eq!(rev("bar", "bar"), base);
+        assert_eq!(rev("foo", "bar"), 0);
+        assert_eq!(rev("bar", "foo"), 0);
+        assert_eq!(rev("a", "a"), base);
+        assert_eq!(rev("b", "b"), base / 2);
+        assert_eq!(rev("c", "c"), 0);
+        assert_eq!(rev("w", "w"), base);
+        assert_eq!(rev("x", "x"), 3 * base / 4);
+        assert_eq!(rev("y", "y"), base / 4);
+        assert_eq!(rev("z", "z"), 0);
+    }
+
+    #[test]
+    fn forward_match_and_opportunity_costs_behave_as_expected() {
+        // Reuse the same IR structure as the reverse-match test.
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f(w: bits[8] id=1, x: bits[8] id=2, y: bits[8] id=3, z: bits[8] id=4) -> bits[8] {
+                a: bits[8] = add(w, x, id=10)
+                b: bits[8] = add(x, y, id=11)
+                c: bits[8] = add(x, z, id=12)
+                ret foo: bits[8] = or(a, b, c, id=13)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        let pkg_new = parse_ir_from_string(
+            r#"package p2
+            top fn f2(w: bits[8] id=1, x: bits[8] id=2, y: bits[8] id=3, z: bits[8] id=4) -> bits[8] {
+                a: bits[8] = add(w, x, id=110)
+                not_y: bits[8] = not(y, id=111)
+                b: bits[8] = add(x, not_y, id=112)
+                c: bits[8] = add(x, z, id=114)
+                ret foo: bits[8] = or(a, b, c, id=115)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut sel = GreedyMatchSelector::new(old_fn, new_fn);
+        let base = GreedyMatchSelector::SCORE_BASE;
+        let perfect_match_score = GreedyMatchSelector::PERFECT_MATCH_SCORE;
+
+        // Helper to get node indices by name.
+        let find_named = |f: &crate::ir::Fn, name: &str| -> usize {
+            f.nodes
+                .iter()
+                .position(|n| n.name.as_deref() == Some(name))
+                .expect("node by name not found")
+        };
+
+        // Explicitly pre-match parameters by name using the MatchSelector API.
+        for pname in ["w", "x", "y", "z"].iter() {
+            let oi = find_named(old_fn, pname);
+            let ni = find_named(new_fn, pname);
+            sel.add_ready_node(ReadyNode {
+                side: NodeSide::Old,
+                index: oi,
+            });
+            sel.add_ready_node(ReadyNode {
+                side: NodeSide::New,
+                index: ni,
+            });
+            let action = MatchAction::MatchNodes {
+                old_index: OldNodeRef(oi),
+                new_index: NewNodeRef(ni),
+                new_operands: Vec::new(),
+                is_new_return: false,
+            };
+            sel.update_after_match(&action);
+        }
+        for n in ["a", "b", "c"].iter() {
+            sel.add_ready_node(ReadyNode {
+                side: NodeSide::Old,
+                index: find_named(old_fn, n),
+            });
+        }
+        for n in ["a", "c", "not_y"].iter() {
+            sel.add_ready_node(ReadyNode {
+                side: NodeSide::New,
+                index: find_named(new_fn, n),
+            });
+        }
+
+        // Forward match scores on adds should be perfect under param mapping.
+        let match_score = |old_name: &str, new_name: &str| -> (bool, i32) {
+            let oi = find_named(old_fn, old_name);
+            let ni = find_named(new_fn, new_name);
+            sel.match_score(&OldNodeRef(oi), &NewNodeRef(ni))
+        };
+        assert_eq!(match_score("a", "a"), (true, 2 * perfect_match_score));
+        assert_eq!(
+            match_score("b", "b"),
+            (true, perfect_match_score + base / 2)
+        );
+        assert_eq!(match_score("c", "c"), (true, 2 * perfect_match_score));
+        assert_eq!(match_score("foo", "foo"), (true, perfect_match_score));
+
+        // Helper: opportunity cost via names (use None to omit a side).
+        let best_unready = |a: Option<&str>, b: Option<&str>| -> i32 {
+            sel.best_unready_match_score(
+                a.map(|n| OldNodeRef(find_named(old_fn, n))),
+                b.map(|n| NewNodeRef(find_named(new_fn, n))),
+            )
+        };
+        assert_eq!(best_unready(Some("a"), Some("a")), 0);
+        assert_eq!(best_unready(Some("c"), Some("c")), base / 2);
+        assert_eq!(best_unready(Some("a"), Some("c")), 0);
+        assert_eq!(
+            best_unready(Some("b"), Some("a")),
+            perfect_match_score + base / 2
+        );
+
+        // Helpers for name-based selector scores.
+        let match_score = |old_name: &str, new_name: &str| -> (bool, i32) {
+            let oi = OldNodeRef(find_named(old_fn, old_name));
+            let ni = NewNodeRef(find_named(new_fn, new_name));
+            sel.match_score(&oi, &ni)
+        };
+        assert_eq!(match_score("a", "a"), (true, 2 * perfect_match_score));
+        assert_eq!(match_score("b", "c"), (false, base / 2));
+        assert_eq!(match_score("c", "c"), (true, 2 * perfect_match_score));
+    }
+}

--- a/xlsynth-pir/src/lib.rs
+++ b/xlsynth-pir/src/lib.rs
@@ -5,8 +5,10 @@
 //! Functionality that is purely related to the XLS IR, i.e. parsing,
 //! representing, querying/manipulating, etc.
 
+pub mod dce;
 pub mod edit_distance;
 pub mod fuzz_utils;
+pub mod greedy_matching_ged;
 pub mod ir;
 pub mod ir_deduce;
 pub mod ir_eval;
@@ -21,6 +23,7 @@ pub mod ir_value_utils;
 pub mod ir_verify;
 pub mod ir_verify_parity;
 pub mod localized_eco2;
+pub mod matching_ged;
 pub mod node_hashing;
 pub mod prove_equiv_via_toolchain;
 pub mod simple_rebase;

--- a/xlsynth-pir/src/matching_ged.rs
+++ b/xlsynth-pir/src/matching_ged.rs
@@ -1,0 +1,984 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Library for computing heuristic graph edit distance (GED) between two XLS IR
+//! functions using an incremental node matching approach.
+
+use crate::ir::{self, Fn, Node, NodeRef};
+use crate::ir_utils::{operands, remap_payload_with};
+use crate::node_hashing::{FwdHash, compute_node_local_structural_hash};
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub enum IrEdit {
+    /// Add a node to the graph.
+    AddNode { node: Node },
+    /// Delete a node from the graph.
+    DeleteNode { node: NodeRef },
+    /// Substitute an operand of a node with a different target node.
+    SubstituteOperand {
+        node: NodeRef,
+        operand_slot: usize,
+        new_operand: NodeRef,
+    },
+    /// Sets the return value of the function.
+    SetReturn { node: NodeRef },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct IrEditSet {
+    pub edits: Vec<IrEdit>,
+}
+
+/// Represents a single incremental match decision in the matching process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchAction {
+    /// Delete a node present in the old function.
+    DeleteNode { old_index: OldNodeRef },
+    /// Add a node present in the new function.
+    AddNode {
+        new_index: NewNodeRef,
+        is_return: bool,
+    },
+    /// Pair an old node with a new node, with optional operand substitutions.
+    MatchNodes {
+        old_index: OldNodeRef,
+        new_index: NewNodeRef,
+        new_operands: Vec<NewNodeRef>,
+        is_new_return: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct OldNodeRef(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NewNodeRef(pub usize);
+
+impl From<usize> for OldNodeRef {
+    fn from(v: usize) -> Self {
+        OldNodeRef(v)
+    }
+}
+
+impl From<usize> for NewNodeRef {
+    fn from(v: usize) -> Self {
+        NewNodeRef(v)
+    }
+}
+
+impl From<OldNodeRef> for usize {
+    fn from(v: OldNodeRef) -> Self {
+        v.0
+    }
+}
+
+impl From<NewNodeRef> for usize {
+    fn from(v: NewNodeRef) -> Self {
+        v.0
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IrMatchSet {
+    pub matches: Vec<MatchAction>,
+}
+/// Abstraction representing a node in the IR graph distilling essential
+/// dependency and structural information.
+#[derive(Debug, Clone)]
+pub struct DepNode<I> {
+    pub operands: Vec<I>,       // deps (by node index)
+    pub users: Vec<(I, usize)>, // (user index, operand slot)
+    pub structural_hash: FwdHash,
+    pub is_return: bool,
+    pub name: String,
+}
+
+/// Dependency graph for a function: collection of per-node dependency info.
+#[derive(Debug, Clone)]
+pub struct DepGraph<I> {
+    pub nodes: Vec<DepNode<I>>,
+    pub return_value: I,
+}
+
+impl<I> DepGraph<I>
+where
+    I: Into<usize> + Copy,
+{
+    pub fn get_node(&self, index: I) -> &DepNode<I> {
+        let idx: usize = index.into();
+        &self.nodes[idx]
+    }
+}
+
+/// Builds a dependency graph for the given function using a typed index `I`.
+pub fn build_dependency_graph<I>(f: &Fn) -> DepGraph<I>
+where
+    I: From<usize> + Into<usize> + Copy,
+{
+    let n = f.nodes.len();
+    let mut operands_list: Vec<Vec<I>> = vec![Vec::new(); n];
+    for (i, node) in f.nodes.iter().enumerate() {
+        operands_list[i] = operands(&node.payload)
+            .into_iter()
+            .map(|r| I::from(r.index))
+            .collect();
+    }
+    let mut users_list: Vec<Vec<(I, usize)>> = vec![Vec::new(); n];
+    for (idx, ops) in operands_list.iter().enumerate() {
+        for (slot, &d) in ops.iter().enumerate() {
+            let du: usize = d.into();
+            users_list[du].push((I::from(idx), slot));
+        }
+    }
+    let mut nodes: Vec<DepNode<I>> = Vec::with_capacity(n);
+    let mut local_hashes: Vec<FwdHash> = Vec::with_capacity(n);
+    for i in 0..n {
+        local_hashes.push(compute_node_local_structural_hash(f, NodeRef { index: i }));
+    }
+    let ret_index_usize: Option<usize> = f.ret_node_ref.map(|nr| nr.index);
+    for i in 0..n {
+        nodes.push(DepNode {
+            operands: operands_list[i].clone(),
+            users: users_list[i].clone(),
+            structural_hash: local_hashes[i],
+            is_return: ret_index_usize == Some(i),
+            name: crate::ir::node_textual_id(f, NodeRef { index: i }),
+        });
+    }
+    assert!(
+        ret_index_usize.is_some(),
+        "build_dependency_graph: function has no return node"
+    );
+    let return_value: I = I::from(ret_index_usize.unwrap());
+    DepGraph {
+        nodes,
+        return_value,
+    }
+}
+
+/// Identifies which function a ready node belongs to when planning edits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeSide {
+    Old,
+    New,
+}
+
+/// Describes a node that is ready (all dependencies satisfied) in either the
+/// old or new function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadyNode {
+    pub side: NodeSide,
+    pub index: usize,
+}
+
+/// Computes MatchNodes actions that pair parameters (GetParam nodes) in `old`
+/// and `new` functions by parameter name.
+pub fn compute_parameter_matches(old: &Fn, new: &Fn) -> Vec<MatchAction> {
+    let mut old_param_to_idx: HashMap<String, usize> = HashMap::new();
+    for (idx, node) in old.nodes.iter().enumerate() {
+        if let crate::ir::NodePayload::GetParam(pid) = node.payload {
+            if let Some(p) = old.params.iter().find(|p| p.id == pid) {
+                old_param_to_idx.insert(p.name.clone(), idx);
+            }
+        }
+    }
+    let mut new_param_to_idx: HashMap<String, usize> = HashMap::new();
+    for (idx, node) in new.nodes.iter().enumerate() {
+        if let crate::ir::NodePayload::GetParam(pid) = node.payload {
+            if let Some(p) = new.params.iter().find(|p| p.id == pid) {
+                new_param_to_idx.insert(p.name.clone(), idx);
+            }
+        }
+    }
+
+    let mut matches: Vec<MatchAction> = Vec::new();
+    for op in old.params.iter() {
+        if let (Some(&oi), Some(&ni)) = (
+            old_param_to_idx.get(&op.name),
+            new_param_to_idx.get(&op.name),
+        ) {
+            matches.push(MatchAction::MatchNodes {
+                old_index: OldNodeRef(oi),
+                new_index: NewNodeRef(ni),
+                new_operands: Vec::new(),
+                is_new_return: new
+                    .ret_node_ref
+                    .map(|nr| nr.index)
+                    .map_or(false, |ri| ri == ni),
+            });
+        }
+    }
+    matches
+}
+
+/// Abstraction for prioritizing and selecting match actions.
+
+pub trait MatchSelector {
+    /// Adds a node that has become ready to be handled.
+    fn add_ready_node(&mut self, node: ReadyNode);
+
+    /// Selects the next match action to apply, or `None` if none remain.
+    fn select_next_match(&mut self) -> Option<MatchAction>;
+
+    /// Notifies the selector that a match action has been observed/applied so
+    /// it can update any internal state (e.g., statistics, heuristics).
+    fn update_after_match(&mut self, _edit: &MatchAction) {}
+}
+
+/// Naive selector which matches parameter nodes but uses add/remove for all
+/// other nodes.
+pub struct NaiveMatchSelector<'a> {
+    order_counter: usize,
+    heap: BinaryHeap<QueueEntry>,
+    old: &'a Fn,
+    new: &'a Fn,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QueueEntry {
+    cost: u32,
+    order: usize,
+    action: MatchAction,
+}
+
+impl Ord for QueueEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Reverse cost and order for min-heap behavior using BinaryHeap (which is
+        // max-heap).
+        (Reverse(self.cost), Reverse(self.order)).cmp(&(Reverse(other.cost), Reverse(other.order)))
+    }
+}
+
+impl PartialOrd for QueueEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'a> NaiveMatchSelector<'a> {
+    pub fn new(old: &'a Fn, new: &'a Fn) -> Self {
+        let mut sel = Self {
+            order_counter: 0,
+            heap: BinaryHeap::new(),
+            old,
+            new,
+        };
+
+        // Seed parameter matches by name and enqueue them.
+        for m in compute_parameter_matches(old, new).into_iter() {
+            sel.push_action(m);
+        }
+
+        sel
+    }
+
+    fn push_action(&mut self, action: MatchAction) {
+        let entry = QueueEntry {
+            cost: 1,
+            order: self.order_counter,
+            action,
+        };
+        self.order_counter += 1;
+        self.heap.push(entry);
+    }
+}
+
+impl<'a> MatchSelector for NaiveMatchSelector<'a> {
+    fn add_ready_node(&mut self, node: ReadyNode) {
+        match node.side {
+            NodeSide::Old => {
+                if matches!(
+                    self.old.nodes[node.index].payload,
+                    crate::ir::NodePayload::GetParam(_)
+                ) {
+                    return;
+                }
+                self.push_action(MatchAction::DeleteNode {
+                    old_index: OldNodeRef(node.index),
+                });
+            }
+            NodeSide::New => {
+                if matches!(
+                    self.new.nodes[node.index].payload,
+                    crate::ir::NodePayload::GetParam(_)
+                ) {
+                    return;
+                }
+                self.push_action(MatchAction::AddNode {
+                    new_index: NewNodeRef(node.index),
+                    is_return: self
+                        .new
+                        .ret_node_ref
+                        .map(|nr| nr.index)
+                        .map_or(false, |ri| ri == node.index),
+                });
+            }
+        }
+    }
+
+    fn select_next_match(&mut self) -> Option<MatchAction> {
+        let entry = self.heap.pop()?;
+        Some(entry.action)
+    }
+}
+
+/// Computes an edit set required to transform `old` into `new` using the
+/// provided selector.
+pub fn compute_function_edit<S: MatchSelector>(
+    old: &Fn,
+    new: &Fn,
+    selector: &mut S,
+) -> Result<IrEditSet, String> {
+    let matches = compute_function_match(old, new, selector)?;
+    Ok(convert_match_set_to_edit_set(old, new, &matches))
+}
+
+/// Computes the match actions required to transform `old` into `new`, using an
+/// externally provided selector that controls priority and edit choice.
+pub fn compute_function_match<S: MatchSelector>(
+    old: &Fn,
+    new: &Fn,
+    selector: &mut S,
+) -> Result<IrMatchSet, String> {
+    if old.get_type() != new.get_type() {
+        return Err(format!(
+            "Signature mismatch: old {} vs new {}",
+            format_function_type(old),
+            format_function_type(new)
+        ));
+    }
+
+    // Verify parameter names match (order-sensitive) to avoid ambiguous operand
+    // mapping.
+    let old_param_names: Vec<&str> = old.params.iter().map(|p| p.name.as_str()).collect();
+    let new_param_names: Vec<&str> = new.params.iter().map(|p| p.name.as_str()).collect();
+    if old_param_names != new_param_names {
+        return Err(format!(
+            "Parameter names mismatch: old [{:?}] vs new [{:?}]",
+            old_param_names, new_param_names
+        ));
+    }
+
+    // Build dependency graphs for readiness tracking.
+    let old_graph = build_dependency_graph::<OldNodeRef>(old);
+    let new_graph = build_dependency_graph::<NewNodeRef>(new);
+
+    // Remaining unhandled dependency counts per node.
+    let mut old_remain: Vec<usize> = old_graph.nodes.iter().map(|n| n.operands.len()).collect();
+    let mut new_remain: Vec<usize> = new_graph.nodes.iter().map(|n| n.operands.len()).collect();
+
+    // (defined after seeding below)
+
+    // Seed selector with all nodes that have no operands in each graph.
+    for (i, &r) in old_remain.iter().enumerate() {
+        if r == 0 {
+            selector.add_ready_node(ReadyNode {
+                side: NodeSide::Old,
+                index: i,
+            });
+        }
+    }
+    for (i, &r) in new_remain.iter().enumerate() {
+        if r == 0 {
+            selector.add_ready_node(ReadyNode {
+                side: NodeSide::New,
+                index: i,
+            });
+        }
+    }
+
+    // Helper: decrement users' remaining counts and enqueue when they become ready.
+    let mut update_ready = |idx: usize, side: NodeSide, selector: &mut S| match side {
+        NodeSide::Old => {
+            for &(user, _slot) in old_graph.nodes[idx].users.iter() {
+                let u: usize = user.into();
+                if old_remain[u] > 0 {
+                    old_remain[u] -= 1;
+                    if old_remain[u] == 0 {
+                        selector.add_ready_node(ReadyNode { side, index: u });
+                    }
+                }
+            }
+        }
+        NodeSide::New => {
+            for &(user, _slot) in new_graph.nodes[idx].users.iter() {
+                let u: usize = user.into();
+                if new_remain[u] > 0 {
+                    new_remain[u] -= 1;
+                    if new_remain[u] == 0 {
+                        selector.add_ready_node(ReadyNode { side, index: u });
+                    }
+                }
+            }
+        }
+    };
+
+    let mut matches: Vec<MatchAction> = Vec::new();
+    while let Some(edit) = selector.select_next_match() {
+        match edit.clone() {
+            MatchAction::DeleteNode { old_index: index } => {
+                matches.push(edit.clone());
+                update_ready(index.into(), NodeSide::Old, selector);
+                selector.update_after_match(&edit);
+            }
+            MatchAction::AddNode {
+                new_index: index, ..
+            } => {
+                let is_ret = new
+                    .ret_node_ref
+                    .map(|nr| nr.index)
+                    .map_or(false, |ri| ri == usize::from(index));
+                matches.push(MatchAction::AddNode {
+                    new_index: index,
+                    is_return: is_ret,
+                });
+                update_ready(index.into(), NodeSide::New, selector);
+                selector.update_after_match(&edit);
+            }
+            MatchAction::MatchNodes {
+                old_index,
+                new_index,
+                ..
+            } => {
+                // Record match edit with explicit new_operands and return flag.
+                let ni: usize = new_index.into();
+                let new_operands: Vec<NewNodeRef> = operands(&new.nodes[ni].payload)
+                    .into_iter()
+                    .map(|r| NewNodeRef(r.index))
+                    .collect();
+                matches.push(MatchAction::MatchNodes {
+                    old_index,
+                    new_index,
+                    new_operands,
+                    is_new_return: new.ret_node_ref.map(|nr| nr.index)
+                        == Some(usize::from(new_index)),
+                });
+                // Propagate readiness in old/new graphs.
+                update_ready(old_index.into(), NodeSide::Old, selector);
+                update_ready(new_index.into(), NodeSide::New, selector);
+                selector.update_after_match(&edit);
+            }
+        }
+    }
+
+    Ok(IrMatchSet { matches })
+}
+
+/// Applies a sequence of IrEdits to `old` and returns the result.
+pub fn apply_function_edits(old: &Fn, edits: &IrEditSet) -> Result<Fn, String> {
+    let mut patched = old.clone();
+
+    for e in edits.edits.iter() {
+        match e.clone() {
+            IrEdit::DeleteNode { node } => {
+                if node.index >= patched.nodes.len() {
+                    return Err(format!("DeleteNode index {} out of bounds", node.index));
+                }
+                patched.nodes[node.index].payload = crate::ir::NodePayload::Nil;
+            }
+            IrEdit::AddNode { node } => {
+                // Payloads in AddNode must already use old or previously-added patched indices.
+                patched.nodes.push(node);
+            }
+            IrEdit::SubstituteOperand {
+                node,
+                operand_slot,
+                new_operand,
+            } => {
+                let idx = node.index;
+                if idx >= patched.nodes.len() {
+                    return Err(format!(
+                        "SubstituteOperand user node index {} out of bounds",
+                        idx
+                    ));
+                }
+                // Validate slot
+                let op_count = operands(&patched.nodes[idx].payload).len();
+                if operand_slot >= op_count {
+                    return Err(format!(
+                        "SubstituteOperand slot {} out of bounds for node {} ({} operands)",
+                        operand_slot, idx, op_count
+                    ));
+                }
+                // Remap exactly the requested operand slot to new_operand, preserving others.
+                let mut seen: usize = 0;
+                let remapped_payload =
+                    remap_payload_with(&patched.nodes[idx].payload, |nr: NodeRef| {
+                        let out = if seen == operand_slot {
+                            new_operand
+                        } else {
+                            nr
+                        };
+                        seen += 1;
+                        out
+                    });
+                patched.nodes[idx].payload = remapped_payload;
+            }
+            IrEdit::SetReturn { node } => {
+                patched.ret_node_ref = Some(NodeRef { index: node.index });
+            }
+        }
+    }
+
+    Ok(patched)
+}
+
+/// Converts a set of `MatchAction`s applied to a old/new pair into IrEdits on
+/// old which produce a graph isomorphic to new.
+pub fn convert_match_set_to_edit_set(old: &Fn, new: &Fn, m: &IrMatchSet) -> IrEditSet {
+    // Build cross-reference maps between matched nodes for operand redirection.
+    let mut new_to_old: HashMap<usize, usize> = HashMap::new();
+    for action in m.matches.iter() {
+        if let MatchAction::MatchNodes {
+            old_index,
+            new_index,
+            ..
+        } = action
+        {
+            new_to_old.insert((*new_index).into(), (*old_index).into());
+        }
+    }
+
+    let mut edits: Vec<IrEdit> = Vec::new();
+    let original_old_len = old.nodes.len();
+    // Map from original-new indices to the eventual patched indices for added
+    // nodes, assigned sequentially starting at original_old_len in the order
+    // AddNode edits are emitted.
+    let mut added_new_to_patched: HashMap<usize, usize> = HashMap::new();
+    let mut add_count: usize = 0;
+    for action in m.matches.iter() {
+        match action {
+            MatchAction::AddNode {
+                new_index,
+                is_return: _,
+            } => {
+                // Clone new node and remap operands that refer to matched new nodes to their
+                // corresponding old indices. References to other new nodes must refer to
+                // previously added nodes; remap those to their patched indices.
+                let ni: usize = (*new_index).into();
+                let src = &new.nodes[ni];
+                let remapped_payload = remap_payload_with(&src.payload, |nr: NodeRef| {
+                    if let Some(&old_idx) = new_to_old.get(&nr.index) {
+                        NodeRef { index: old_idx }
+                    } else {
+                        if let Some(&patched_idx) = added_new_to_patched.get(&nr.index) {
+                            NodeRef { index: patched_idx }
+                        } else {
+                            panic!(
+                                "AddNode payload references future new node {} which is not yet added",
+                                nr.index
+                            );
+                        }
+                    }
+                });
+                let cloned = crate::ir::Node {
+                    text_id: src.text_id,
+                    name: src.name.clone(),
+                    ty: src.ty.clone(),
+                    payload: remapped_payload,
+                    pos: src.pos.clone(),
+                };
+                // Assign patched index for this added node per protocol
+                let patched_index = original_old_len + add_count;
+                added_new_to_patched.insert(ni, patched_index);
+                add_count += 1;
+                edits.push(IrEdit::AddNode { node: cloned });
+            }
+            MatchAction::DeleteNode { old_index } => {
+                let oi: usize = (*old_index).into();
+                edits.push(IrEdit::DeleteNode {
+                    node: NodeRef { index: oi },
+                });
+            }
+            MatchAction::MatchNodes {
+                old_index,
+                new_index: _,
+                new_operands,
+                is_new_return: _,
+            } => {
+                // Infer operand substitutions using provided new_operands.
+                let oi: usize = (*old_index).into();
+                let old_ops = operands(&old.nodes[oi].payload);
+                if old_ops.len() == new_operands.len() {
+                    for (slot, (o_ref, n_new_ref)) in
+                        old_ops.iter().zip(new_operands.iter()).enumerate()
+                    {
+                        let nidx: usize = (*n_new_ref).into();
+                        if let Some(&mapped_old_target) = new_to_old.get(&nidx) {
+                            if o_ref.index != mapped_old_target {
+                                edits.push(IrEdit::SubstituteOperand {
+                                    node: NodeRef { index: oi },
+                                    operand_slot: slot,
+                                    new_operand: NodeRef {
+                                        index: mapped_old_target,
+                                    },
+                                });
+                            }
+                        } else if let Some(&patched_idx) = added_new_to_patched.get(&nidx) {
+                            if o_ref.index != patched_idx {
+                                edits.push(IrEdit::SubstituteOperand {
+                                    node: NodeRef { index: oi },
+                                    operand_slot: slot,
+                                    new_operand: NodeRef { index: patched_idx },
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    // Ensure the function return matches `new`.
+    if let Some(nr) = new.ret_node_ref {
+        if let Some(&old_idx) = new_to_old.get(&nr.index) {
+            // Only emit SetReturn if the old function does not already return this node.
+            if old.ret_node_ref.map(|r| r.index) != Some(old_idx) {
+                edits.push(IrEdit::SetReturn {
+                    node: NodeRef { index: old_idx },
+                });
+            }
+        } else {
+            // Return refers to a newly added node; map to its patched index assigned above.
+            let patched_idx = *added_new_to_patched
+                .get(&nr.index)
+                .expect("SetReturn refers to a new node that was not added");
+            edits.push(IrEdit::SetReturn {
+                node: NodeRef { index: patched_idx },
+            });
+        }
+    }
+    IrEditSet { edits }
+}
+
+/// Formats a single IrEdit into a human-friendly string using names from `old`.
+pub fn format_ir_edit(old: &Fn, e: &IrEdit) -> String {
+    let name_for_index = |idx: usize| -> String {
+        if idx < old.nodes.len() {
+            ir::node_textual_id(old, NodeRef { index: idx })
+        } else {
+            format!("added.{}", idx)
+        }
+    };
+    match e.clone() {
+        IrEdit::DeleteNode { node } => {
+            format!("DeleteNode: {}", name_for_index(node.index))
+        }
+        IrEdit::AddNode { node } => {
+            // Use the same identifier style as DeleteNode: name if present, else
+            // "op.text_id".
+            let added_name = node
+                .name
+                .clone()
+                .unwrap_or_else(|| format!("{}.{}", node.payload.get_operator(), node.text_id));
+            format!("AddNode: {}", added_name)
+        }
+        IrEdit::SubstituteOperand {
+            node,
+            operand_slot,
+            new_operand,
+        } => {
+            let node_idx = node.index;
+            let payload = &old.nodes[node_idx].payload;
+            let orig_ops = operands(payload);
+            let orig_name = if operand_slot < orig_ops.len() {
+                name_for_index(orig_ops[operand_slot].index)
+            } else {
+                format!("<slot {} oob>", operand_slot)
+            };
+            let rendered = orig_ops
+                .iter()
+                .enumerate()
+                .map(|(i, nr)| {
+                    if i == operand_slot {
+                        format!("**{}**", name_for_index(new_operand.index))
+                    } else {
+                        name_for_index(nr.index)
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join(", ");
+            format!(
+                "SubstituteOperand: {}({}), was {}",
+                ir::node_textual_id(old, NodeRef { index: node_idx }),
+                rendered,
+                orig_name
+            )
+        }
+        IrEdit::SetReturn { node } => {
+            format!("SetReturn: {}", name_for_index(node.index))
+        }
+    }
+}
+
+/// Formats an IrEditSet into a multiline string using names from `old`.
+pub fn format_ir_edits(old: &Fn, edits: &IrEditSet) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for e in edits.edits.iter() {
+        lines.push(format_ir_edit(old, e));
+    }
+    lines.join("\n")
+}
+
+/// Formats a single MatchAction into a human-friendly string using names from
+/// both `old` and `new` functions.
+pub fn format_match_action<F>(m: &MatchAction, node_to_string: F) -> String
+where
+    F: std::ops::Fn(NodeSide, usize) -> String,
+{
+    match m.clone() {
+        MatchAction::DeleteNode { old_index } => {
+            format!("DeleteNode: {}", node_to_string(NodeSide::Old, old_index.0))
+        }
+        MatchAction::AddNode {
+            new_index,
+            is_return,
+        } => {
+            let s = node_to_string(NodeSide::New, new_index.0);
+            if is_return {
+                format!("AddNode (ret): {}", s)
+            } else {
+                format!("AddNode: {}", s)
+            }
+        }
+        MatchAction::MatchNodes {
+            old_index,
+            new_index,
+            new_operands: _,
+            is_new_return,
+        } => {
+            let old_s = node_to_string(NodeSide::Old, old_index.0);
+            let new_s = node_to_string(NodeSide::New, new_index.0);
+            if is_new_return {
+                format!("MatchNodes (ret): {} <-> {}", old_s, new_s)
+            } else {
+                format!("MatchNodes: {} <-> {}", old_s, new_s)
+            }
+        }
+    }
+}
+
+/// Formats a sequence of MatchAction values into a multiline string using
+/// names from the provided `old` and `new` functions.
+pub fn format_match_actions(old: &Fn, new: &Fn, actions: &[MatchAction]) -> String {
+    let lines: Vec<String> = actions
+        .iter()
+        .map(|m| {
+            format_match_action(m, |side, idx| match side {
+                NodeSide::Old => ir::node_textual_id(old, NodeRef { index: idx }),
+                NodeSide::New => ir::node_textual_id(new, NodeRef { index: idx }),
+            })
+        })
+        .collect();
+    lines.join("\n")
+}
+
+fn format_function_type(f: &Fn) -> String {
+    let params = f
+        .params
+        .iter()
+        .map(|p| format!("{}", p.ty))
+        .collect::<Vec<String>>()
+        .join(", ");
+    format!("fn({}) -> {}", params, f.ret_ty)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir_parser::Parser;
+
+    fn parse_ir_from_string(s: &str) -> crate::ir::Package {
+        let mut parser = Parser::new(s);
+        parser.parse_and_validate_package().unwrap()
+    }
+
+    #[test]
+    fn compute_returns_adds_and_deletes_for_all_nodes() {
+        let pkg = parse_ir_from_string(
+            r#"package p
+            top fn f(x: bits[8]) -> bits[8] {
+                ret identity.2: bits[8] = identity(x, id=2)
+            }
+            "#,
+        );
+        let lhs = pkg.get_top().unwrap();
+
+        let pkg2 = parse_ir_from_string(
+            r#"package p2
+            top fn f2(x: bits[8]) -> bits[8] {
+                ret identity.2: bits[8] = identity(x, id=2)
+            }
+            "#,
+        );
+        let rhs = pkg2.get_top().unwrap();
+
+        let mut selector = NaiveMatchSelector::new(lhs, rhs);
+        let edits = compute_function_edit(lhs, rhs, &mut selector).unwrap();
+        assert!(!edits.edits.is_empty());
+        let patched = apply_function_edits(lhs, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, rhs
+        ));
+    }
+
+    #[test]
+    fn compute_errors_on_mismatched_signatures() {
+        let pkg = parse_ir_from_string(
+            r#"package p
+            top fn f(x: bits[8]) -> bits[8] {
+                ret identity.2: bits[8] = identity(x, id=2)
+            }
+            "#,
+        );
+        let lhs = pkg.get_top().unwrap();
+
+        let pkg2 = parse_ir_from_string(
+            r#"package p2
+            top fn f2(x: bits[9]) -> bits[9] {
+                ret identity.2: bits[9] = identity(x, id=2)
+            }
+            "#,
+        );
+        let rhs = pkg2.get_top().unwrap();
+
+        let mut selector = NaiveMatchSelector::new(lhs, rhs);
+        let result = compute_function_edit(lhs, rhs, &mut selector);
+        assert!(result.is_err());
+    }
+
+    #[test]
+
+    fn apply_is_noop_for_now() {
+        let pkg = parse_ir_from_string(
+            r#"package p
+            top fn f(x: bits[8]) -> bits[8] {
+                ret identity.2: bits[8] = identity(x, id=2)
+            }
+            "#,
+        );
+        let f = pkg.get_top().unwrap();
+        let edits = IrEditSet::default();
+        let applied = apply_function_edits(f, &edits).unwrap();
+        assert_eq!(applied.to_string(), f.to_string());
+    }
+
+    #[test]
+    fn apply_edits_literal_change_matches_new() {
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[8] {
+                ret literal.1: bits[8] = literal(value=0, id=1)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        let pkg_new = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[8] {
+                ret literal.101: bits[8] = literal(value=1, id=101)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut selector = crate::greedy_matching_ged::GreedyMatchSelector::new(old_fn, new_fn);
+        let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
+        let patched = apply_function_edits(old_fn, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, new_fn
+        ));
+    }
+
+    #[test]
+    fn apply_edits_add_identity_of_literal() {
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[1] {
+                ret literal.1: bits[1] = literal(value=0, id=1)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        let pkg_new = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[1] {
+                literal.11: bits[1] = literal(value=1, id=11)
+                ret identity.22: bits[1] = identity(literal.11, id=22)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut selector = NaiveMatchSelector::new(old_fn, new_fn);
+        let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
+        let patched = apply_function_edits(old_fn, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, new_fn
+        ));
+    }
+
+    #[test]
+    fn edit_distance_handles_different_return_nodes() {
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[1] {
+                literal.1: bits[1] = literal(value=1, id=1)
+                ret identity.2: bits[1] = identity(literal.1, id=2)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        // Same nodes, but return points to a different node (the literal).
+        let pkg_new = parse_ir_from_string(
+            r#"package p
+            top fn f() -> bits[1] {
+                ret literal.1: bits[1] = literal(value=1, id=1)
+                identity.2: bits[1] = identity(literal.1, id=2)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut selector = NaiveMatchSelector::new(old_fn, new_fn);
+        let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
+        let patched = apply_function_edits(old_fn, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, new_fn
+        ));
+    }
+
+    #[test]
+    fn edit_distance_multiple_parameters_identity_wrap() {
+        let pkg_old = parse_ir_from_string(
+            r#"package p
+            top fn f(a: bits[8] id=1, b: bits[8] id=2) -> bits[8] {
+                ret add.3: bits[8] = add(a, b, id=3)
+            }
+            "#,
+        );
+        let old_fn = pkg_old.get_top().unwrap();
+
+        // Different structure: wrap the add in an identity, keep params identical.
+        let pkg_new = parse_ir_from_string(
+            r#"package p
+            top fn f(a: bits[8] id=1, b: bits[8] id=2) -> bits[8] {
+                add.103: bits[8] = add(a, b, id=103)
+                ret identity.104: bits[8] = identity(add.103, id=104)
+            }
+            "#,
+        );
+        let new_fn = pkg_new.get_top().unwrap();
+
+        let mut selector = NaiveMatchSelector::new(old_fn, new_fn);
+        let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
+        let patched = apply_function_edits(old_fn, &edits).unwrap();
+        assert!(crate::node_hashing::functions_structurally_equivalent(
+            &patched, new_fn
+        ));
+    }
+}

--- a/xlsynth-pir/src/node_hashing.rs
+++ b/xlsynth-pir/src/node_hashing.rs
@@ -3,6 +3,7 @@
 //! Helpers for computing structural hashes of XLS IR nodes.
 
 use crate::ir::{self, Fn, NodePayload, NodeRef, ParamId, Type};
+use crate::ir_utils::{get_topological, operands};
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
 pub struct FwdHash(pub blake3::Hash);
@@ -168,7 +169,7 @@ fn hash_payload_attributes(f: &Fn, payload: &NodePayload, hasher: &mut blake3::H
     }
 }
 
-pub(crate) fn compute_node_structural_hash(
+pub fn compute_node_structural_hash(
     f: &Fn,
     node_ref: NodeRef,
     child_hashes: &[FwdHash],
@@ -184,7 +185,7 @@ pub(crate) fn compute_node_structural_hash(
     FwdHash(hasher.finalize())
 }
 
-pub(crate) fn compute_node_local_structural_hash(f: &Fn, node_ref: NodeRef) -> FwdHash {
+pub fn compute_node_local_structural_hash(f: &Fn, node_ref: NodeRef) -> FwdHash {
     // Hash operator tag + type + payload attributes only; ignore children.
     let node = f.get_node(node_ref);
     let mut hasher = blake3::Hasher::new();
@@ -198,7 +199,7 @@ pub(crate) fn compute_node_local_structural_hash(f: &Fn, node_ref: NodeRef) -> F
 /// structural hash with its users' backward hashes and the operand indices
 /// at which this node appears. The user pairs are sorted by (hash bytes,
 /// operand index) to produce a stable characterization.
-pub(crate) fn compute_node_backward_structural_hash(
+pub fn compute_node_backward_structural_hash(
     f: &Fn,
     node_ref: NodeRef,
     user_pairs: &[(BwdHash, usize)],
@@ -221,4 +222,117 @@ pub(crate) fn compute_node_backward_structural_hash(
         hasher.update(&(u64::try_from(idx).unwrap_or(0)).to_le_bytes());
     }
     BwdHash(hasher.finalize())
+}
+
+/// Returns true if two functions are structurally isomorphic between the
+/// parameters and the return node. That is, the functions have the same
+/// signature and the return value is equivalent in the CSE (common
+/// subexpression elimination) sense.
+pub fn functions_structurally_equivalent(lhs: &Fn, rhs: &Fn) -> bool {
+    if lhs.get_type() != rhs.get_type() {
+        return false;
+    }
+    if lhs.params.len() != rhs.params.len() {
+        return false;
+    }
+    if lhs.ret_node_ref.is_none() || rhs.ret_node_ref.is_none() {
+        return false;
+    }
+
+    fn compute_forward_hashes(f: &Fn) -> Vec<FwdHash> {
+        let n = f.nodes.len();
+        if n == 0 {
+            return vec![];
+        }
+        let order = get_topological(f);
+        let mut out: Vec<Option<FwdHash>> = vec![None; n];
+        for nr in order {
+            let deps = operands(&f.get_node(nr).payload);
+            let child_hashes: Vec<FwdHash> = deps
+                .into_iter()
+                .map(|c| out[c.index].expect("child hash must be computed first"))
+                .collect();
+            let h = compute_node_structural_hash(f, nr, &child_hashes);
+            out[nr.index] = Some(h);
+        }
+        out.into_iter()
+            .map(|o| o.expect("hash must be computed for all nodes"))
+            .collect()
+    }
+
+    let lhs_fwd = compute_forward_hashes(lhs);
+    let rhs_fwd = compute_forward_hashes(rhs);
+    lhs_fwd[lhs.ret_node_ref.unwrap().index] == rhs_fwd[rhs.ret_node_ref.unwrap().index]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir_parser::Parser;
+
+    fn parse_top_fn(ir_pkg_text: &str) -> Fn {
+        let mut p = Parser::new(ir_pkg_text);
+        let pkg = p.parse_and_validate_package().unwrap();
+        pkg.get_top().unwrap().clone()
+    }
+
+    #[test]
+    fn isomorphic_functions_return_true() {
+        let lhs = parse_top_fn(
+            r#"package p
+            top fn f(a: bits[8]) -> bits[8] {
+              ret add.3: bits[8] = add(a, a)
+            }
+            "#,
+        );
+        let rhs = parse_top_fn(
+            r#"package q
+            top fn g(a: bits[8]) -> bits[8] {
+              ret add.3: bits[8] = add(a, a)
+            }
+            "#,
+        );
+        assert!(functions_structurally_equivalent(&lhs, &rhs));
+    }
+
+    #[test]
+    fn extra_parameter_is_notequivalent() {
+        let lhs = parse_top_fn(
+            r#"package p
+            top fn f(a: bits[8]) -> bits[8] {
+              ret identity.2: bits[8] = identity(a)
+            }
+            "#,
+        );
+        let rhs = parse_top_fn(
+            r#"package q
+            top fn g(a: bits[8], b: bits[8]) -> bits[8] {
+              ret identity.3: bits[8] = identity(a)
+            }
+            "#,
+        );
+        assert!(!functions_structurally_equivalent(&lhs, &rhs));
+    }
+
+    #[test]
+    fn different_graphs_but_dead_uses_ignored_are_equivalent() {
+        let lhs = parse_top_fn(
+            r#"package p
+            top fn f(a: bits[8]) -> bits[8] {
+              ret identity.2: bits[8] = identity(a)
+            }
+            "#,
+        );
+        let rhs = parse_top_fn(
+            r#"package q
+            top fn g(a: bits[8]) -> bits[8] {
+              d: bits[8] = literal(value=7, id=2)
+              u: bits[8] = add(a, d, id=3)
+              ret x: bits[8] = identity(a, id=4)
+              q: bits[8] = identity(x, id=5)
+            }
+            "#,
+        );
+        assert!(functions_structurally_equivalent(&lhs, &rhs));
+    }
 }


### PR DESCRIPTION
The algorithm greedily matches node pairs in the old and new IR graphs
based on a priority scheme. Add-node and delete-node edit actions are
enqueued if no good matches exist.

ECO can be run like so:

xlsynth-driver greedy-eco old.opt.ir new.opt.ir \
  --old_ir_top=main --new_ir_top=main \
  --patched_out=patched.opt.ir \
  --edits_debug_out=edits.txt