### PR TITLE
Add better support for blocks in ir.rs.

### DIFF
--- a/xlsynth-driver/src/greedy_eco.rs
+++ b/xlsynth-driver/src/greedy_eco.rs
@@ -33,13 +33,17 @@ pub fn handle_greedy_eco(matches: &ArgMatches) {
         Some(name) => old_pkg
             .get_fn(name)
             .unwrap_or_else(|| panic!("old package missing function '{}'", name)),
-        None => old_pkg.get_top().expect("old package missing top function"),
+        None => old_pkg
+            .get_top_fn()
+            .expect("old package missing top function"),
     };
     let new_fn = match new_top_flag {
         Some(name) => new_pkg
             .get_fn(name)
             .unwrap_or_else(|| panic!("new package missing function '{}'", name)),
-        None => new_pkg.get_top().expect("new package missing top function"),
+        None => new_pkg
+            .get_top_fn()
+            .expect("new package missing top function"),
     };
 
     // Compute edits using the greedy selector.
@@ -65,7 +69,7 @@ pub fn handle_greedy_eco(matches: &ArgMatches) {
     } else {
         // Replace top function.
         let slot = old_pkg
-            .get_top_mut()
+            .get_top_fn_mut()
             .expect("old package missing top function (mut)");
         *slot = patched_fn;
     }

--- a/xlsynth-driver/src/ir2gates.rs
+++ b/xlsynth-driver/src/ir2gates.rs
@@ -212,7 +212,7 @@ fn ir_to_gatefn_with_stats(
         eprintln!("Error encountered parsing XLS IR package: {:?}", err);
         std::process::exit(1);
     });
-    let ir_top = match ir_package.get_top() {
+    let ir_top = match ir_package.get_top_fn() {
         Some(ir_top) => ir_top,
         None => {
             eprintln!("No top module found in the IR package");

--- a/xlsynth-driver/src/ir_equiv.rs
+++ b/xlsynth-driver/src/ir_equiv.rs
@@ -88,7 +88,7 @@ fn parse_and_prepare_fn(
             std::process::exit(1);
         })
     } else {
-        pkg.get_top().cloned().unwrap_or_else(|| {
+        pkg.get_top_fn().cloned().unwrap_or_else(|| {
             eprintln!(
                 "[{}] No top function found in {} IR (origin: {})",
                 subcommand, side, origin

--- a/xlsynth-driver/src/ir_equiv_blocks.rs
+++ b/xlsynth-driver/src/ir_equiv_blocks.rs
@@ -4,7 +4,9 @@ use crate::ir_equiv::{dispatch_ir_equiv, EquivInputs};
 use crate::parallelism::ParallelismStrategy;
 use crate::toolchain_config::ToolchainConfig;
 
-use xlsynth_pir::ir::{self as ir_mod, BlockPortInfo, FileTable, Package, PackageMember};
+use xlsynth_pir::ir::{
+    self as ir_mod, BlockPortInfo, FileTable, MemberType, Package, PackageMember,
+};
 use xlsynth_pir::ir_parser;
 use xlsynth_prover::prover::SolverChoice;
 use xlsynth_prover::types::AssertionSemantics;
@@ -102,7 +104,7 @@ pub fn handle_ir_equiv_blocks(matches: &clap::ArgMatches, config: &Option<Toolch
             }
             return None;
         }
-        if let Some(top_name) = &pkg.top_name {
+        if let Some((top_name, MemberType::Block)) = &pkg.top {
             for m in pkg.members.iter() {
                 if let PackageMember::Block { func, port_info } = m {
                     if &func.name == top_name {
@@ -160,13 +162,13 @@ pub fn handle_ir_equiv_blocks(matches: &clap::ArgMatches, config: &Option<Toolch
         name: "lhs_pkg".to_string(),
         file_table: FileTable::new(),
         members: vec![PackageMember::Function(lhs_fn.clone())],
-        top_name: Some(lhs_fn.name.clone()),
+        top: Some((lhs_fn.name.clone(), MemberType::Block)),
     };
     let rhs_pkg = Package {
         name: "rhs_pkg".to_string(),
         file_table: FileTable::new(),
         members: vec![PackageMember::Function(rhs_fn.clone())],
-        top_name: Some(rhs_fn.name.clone()),
+        top: Some((rhs_fn.name.clone(), MemberType::Block)),
     };
     let lhs_pkg_text = lhs_pkg.to_string();
     let rhs_pkg_text = rhs_pkg.to_string();

--- a/xlsynth-driver/src/ir_ged.rs
+++ b/xlsynth-driver/src/ir_ged.rs
@@ -20,12 +20,12 @@ fn ir_ged(
 
     let lhs_fn = match lhs_ir_top {
         Some(top) => lhs_pkg.get_fn(top).unwrap(),
-        None => lhs_pkg.get_top().unwrap(),
+        None => lhs_pkg.get_top_fn().unwrap(),
     };
 
     let rhs_fn = match rhs_ir_top {
         Some(top) => rhs_pkg.get_fn(top).unwrap(),
-        None => rhs_pkg.get_top().unwrap(),
+        None => rhs_pkg.get_top_fn().unwrap(),
     };
 
     let distance = edit_distance::compute_edit_distance(lhs_fn, rhs_fn);

--- a/xlsynth-driver/src/ir_localized_eco.rs
+++ b/xlsynth-driver/src/ir_localized_eco.rs
@@ -14,7 +14,7 @@ use rand::SeedableRng;
 use xlsynth::IrValue;
 use xlsynth_g8r::check_equivalence;
 use xlsynth_pir::ir::Type;
-use xlsynth_pir::ir::{self as ir_mod, BlockPortInfo, PackageMember};
+use xlsynth_pir::ir::{self as ir_mod, BlockPortInfo, MemberType, PackageMember};
 use xlsynth_pir::ir_parser::{self, emit_fn_as_block};
 use xlsynth_prover::types::AssertionSemantics;
 
@@ -132,7 +132,7 @@ pub fn handle_ir_localized_eco(matches: &ArgMatches, config: &Option<ToolchainCo
                 vec![("name", top)],
             ),
         },
-        None => match old_pkg.get_top() {
+        None => match old_pkg.get_top_fn() {
             Some(f) => f,
             None => {
                 let msg = format!(
@@ -152,7 +152,7 @@ pub fn handle_ir_localized_eco(matches: &ArgMatches, config: &Option<ToolchainCo
                 vec![("name", top)],
             ),
         },
-        None => match new_pkg.get_top() {
+        None => match new_pkg.get_top_fn() {
             Some(f) => f,
             None => {
                 let msg = format!(
@@ -428,7 +428,7 @@ fn select_block_from_package<'a>(
         }
         return None;
     }
-    if let Some(top_name) = &pkg.top_name {
+    if let Some((top_name, MemberType::Block)) = &pkg.top {
         for m in pkg.members.iter() {
             if let PackageMember::Block { func, port_info } = m {
                 if &func.name == top_name {
@@ -491,7 +491,7 @@ fn handle_ir_localized_eco_blocks_in_packages(
         report_cli_error_and_exit(&msg, Some("ir-localized-eco"), vec![]);
     }
     println!("  Emitting patched block text...");
-    let patched_block_text = emit_fn_as_block(&applied, None, Some(old_ports));
+    let patched_block_text = emit_fn_as_block(&applied, None, Some(old_ports), false);
     let patched_ir_path = out_dir.join("patched_old.block.ir");
     std::fs::write(&patched_ir_path, patched_block_text.as_bytes()).unwrap();
     println!("  Patched IR written to: {}", patched_ir_path.display());
@@ -499,8 +499,8 @@ fn handle_ir_localized_eco_blocks_in_packages(
     // Copy old/new for convenience: write ONLY the selected blocks.
     let old_copy_path = out_dir.join("old.ir");
     let new_copy_path = out_dir.join("new.ir");
-    let old_block_text = emit_fn_as_block(old_fn, None, Some(old_ports));
-    let new_block_text = emit_fn_as_block(new_fn, None, Some(new_ports));
+    let old_block_text = emit_fn_as_block(old_fn, None, Some(old_ports), false);
+    let new_block_text = emit_fn_as_block(new_fn, None, Some(new_ports), false);
     std::fs::write(&old_copy_path, old_block_text.as_bytes()).unwrap();
     std::fs::write(&new_copy_path, new_block_text.as_bytes()).unwrap();
     println!("  Old IR copied to: {}", old_copy_path.display());

--- a/xlsynth-driver/src/ir_round_trip.rs
+++ b/xlsynth-driver/src/ir_round_trip.rs
@@ -48,7 +48,7 @@ pub fn handle_ir_round_trip(matches: &ArgMatches) {
                                     n.pos = None;
                                 }
                             }
-                            let block_text = emit_fn_as_block(&f, None, Some(&port_info));
+                            let block_text = emit_fn_as_block(&f, None, Some(&port_info), false);
                             print!("{}", block_text);
                         }
                         Err(_e2) => {
@@ -73,7 +73,7 @@ pub fn handle_ir_round_trip(matches: &ArgMatches) {
                 n.pos = None;
             }
         }
-        let block_text = emit_fn_as_block(&f, None, Some(&port_info));
+        let block_text = emit_fn_as_block(&f, None, Some(&port_info), false);
         print!("{}", block_text);
     }
 }

--- a/xlsynth-driver/src/ir_structural_similarity.rs
+++ b/xlsynth-driver/src/ir_structural_similarity.rs
@@ -169,7 +169,7 @@ pub fn handle_ir_structural_similarity(matches: &ArgMatches, _config: &Option<To
                 return;
             }
         },
-        None => match lhs_pkg.get_top() {
+        None => match lhs_pkg.get_top_fn() {
             Some(f) => f,
             None => {
                 println!("  LHS input: no top set and no --lhs_ir_top provided; aborting");
@@ -188,7 +188,7 @@ pub fn handle_ir_structural_similarity(matches: &ArgMatches, _config: &Option<To
                 return;
             }
         },
-        None => match rhs_pkg.get_top() {
+        None => match rhs_pkg.get_top_fn() {
             Some(f) => f,
             None => {
                 println!("  RHS input: no top set and no --rhs_ir_top provided; aborting");

--- a/xlsynth-driver/tests/ir_round_trip_block_tests.rs
+++ b/xlsynth-driver/tests/ir_round_trip_block_tests.rs
@@ -23,13 +23,6 @@ fn test_ir_round_trip_standalone_block() {
 
 #[test]
 fn test_ir_round_trip_package_with_top_block() {
-    let pkg_ir = r#"package p
-
-block myb(a: bits[1], out: bits[1]) {
-  a: bits[1] = input_port(name=a, id=1)
-  out: () = output_port(a, name=out, id=2)
-}
-"#;
     // Input package that includes a top block equivalent to the expected emission.
     let input_ir = r#"package p
 
@@ -50,7 +43,7 @@ top block myb(a: bits[1], out: bits[1]) {
         .unwrap();
     assert!(out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert_eq!(stdout, pkg_ir);
+    assert_eq!(stdout, input_ir);
 }
 
 #[test]

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gatify.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gatify.rs
@@ -37,7 +37,7 @@ fuzz_target!(|sample: FuzzSample| {
                 return;
             }
         };
-    let parsed_fn = parsed_package.get_top().unwrap();
+    let parsed_fn = parsed_package.get_top_fn().unwrap();
 
     // Convert to gates with folding disabled to make less machinery under test.
     let _gate_fn_no_fold = gatify(

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_eval_interp_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_eval_interp_equiv.rs
@@ -68,7 +68,7 @@ fuzz_target!(|with: FuzzSampleWithArgs| {
     let parsed_pkg = ir_parser::Parser::new(&pkg_text)
         .parse_and_validate_package()
         .expect("parse_and_validate_package should not fail");
-    let parsed_top = match parsed_pkg.get_top() {
+    let parsed_top = match parsed_pkg.get_top_fn() {
         Some(f) => f.clone(),
         None => return,
     };

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
@@ -94,8 +94,8 @@ fuzz_target!(|sample: FuzzSample| {
         .parse_and_validate_package()
         .unwrap();
 
-    let orig_fn = orig_pkg.get_top().unwrap();
-    let opt_fn = opt_pkg.get_top().unwrap();
+    let orig_fn = orig_pkg.get_top_fn().unwrap();
+    let opt_fn = opt_pkg.get_top_fn().unwrap();
 
     // Check equivalence using the external tool first, specifying the top function
     let orig_ir = pkg.to_string();

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_outline_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_outline_equiv.rs
@@ -170,7 +170,7 @@ fuzz_target!(|sample: FuzzSample| {
         Err(_e) => panic!("Rust IR parser failed on C++-emitted package text (clone)"),
     };
 
-    let orig_fn = orig_pkg.get_top().expect("missing top function").clone();
+    let orig_fn = orig_pkg.get_top_fn().expect("missing top function").clone();
     let n = orig_fn.nodes.len();
     if n < 2 {
         // Early-return: not enough nodes to outline a nontrivial region
@@ -202,7 +202,7 @@ fuzz_target!(|sample: FuzzSample| {
 
     // Perform outlining on a mutable clone of the package using the original
     // function
-    let work_fn = work_pkg.get_top().unwrap().clone();
+    let work_fn = work_pkg.get_top_fn().unwrap().clone();
     // Choose parameter and return ordering modes from hash bits for reproducibility
     let param_mode = if (h & 1) == 0 {
         ParamOrderMode::Default
@@ -256,7 +256,7 @@ fuzz_target!(|sample: FuzzSample| {
         } = r
         {
             // Provide context in logs on failure
-            if let Some(f) = orig_pkg.get_top() {
+            if let Some(f) = orig_pkg.get_top_fn() {
                 log::info!("Original IR fn:\n{}", f);
             }
             if let Some(PackageMember::Function(f)) = work_pkg
@@ -289,7 +289,7 @@ fuzz_target!(|sample: FuzzSample| {
             ..
         } = r
         {
-            if let Some(f) = orig_pkg.get_top() {
+            if let Some(f) = orig_pkg.get_top_fn() {
                 log::info!("Original IR fn:\n{}", f);
             }
             if let Some(PackageMember::Function(f)) = work_pkg

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_rebase_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_rebase_equiv.rs
@@ -54,8 +54,8 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
     let desired_pkg = ir_parser::Parser::new(&pkg_desired.to_string())
         .parse_and_validate_package()
         .unwrap();
-    let orig = orig_pkg.get_top().unwrap();
-    let desired = desired_pkg.get_top().unwrap().clone();
+    let orig = orig_pkg.get_top_fn().unwrap();
+    let desired = desired_pkg.get_top_fn().unwrap().clone();
 
     // 4) Precondition: signatures must match; guaranteed by FuzzSampleSameTypedPair
     assert_eq!(
@@ -78,7 +78,7 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
         name: "rebased_pkg".to_string(),
         file_table: ir::FileTable::new(),
         members: vec![ir::PackageMember::Function(rebased.clone())],
-        top_name: Some("rebased".to_string()),
+        top: Some(("rebased".to_string(), ir::MemberType::Function)),
     };
     if let Err(e) = validate_fn(&rebased, &pkg) {
         panic!("rebased IR failed composite validation: {}", e);

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_roundtrip.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_roundtrip.rs
@@ -37,7 +37,7 @@ fuzz_target!(|sample: FuzzSample| {
 
     // 3) Verify and obtain the top function
     let parsed_top = parsed_pkg
-        .get_top()
+        .get_top_fn()
         .expect("generator should set a top function");
 
     // 4) Emit the function text via Display and parse the function alone, too
@@ -52,7 +52,7 @@ fuzz_target!(|sample: FuzzSample| {
         .parse_and_validate_package()
         .expect("Package pretty-printer emitted IR that failed to reparse/validate");
     let reparsed_pkg_top = reparsed_pkg
-        .get_top()
+        .get_top_fn()
         .expect("package pretty-printer should preserve top function");
 
     // 6) Structural equivalence checks between original parsed top and both

--- a/xlsynth-g8r/src/check_equivalence.rs
+++ b/xlsynth-g8r/src/check_equivalence.rs
@@ -247,7 +247,7 @@ mod tests {
 ";
         let mut parser = ir_parser::Parser::new(simple_xor_ir);
         let ir_package = parser.parse_and_validate_package().unwrap();
-        let ir_top = ir_package.get_top().unwrap();
+        let ir_top = ir_package.get_top_fn().unwrap();
 
         // Now we make a simple one bit gate fn.
         let mut gate_builder = GateBuilder::new("my_xor".to_string(), GateBuilderOptions::opt());

--- a/xlsynth-g8r/src/gate2ir.rs
+++ b/xlsynth-g8r/src/gate2ir.rs
@@ -292,7 +292,7 @@ top fn do_and(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
 ";
         let mut parser = ir_parser::Parser::new(input_ir_text);
         let ir_package = parser.parse_and_validate_package().unwrap();
-        let ir_top = ir_package.get_top().unwrap();
+        let ir_top = ir_package.get_top_fn().unwrap();
         let gatify_output = gatify(
             &ir_top,
             GatifyOptions {
@@ -318,7 +318,7 @@ top fn do_not(a: bits[1] id=1) -> bits[1] {
 ";
         let mut parser = ir_parser::Parser::new(input_ir_text);
         let ir_package = parser.parse_and_validate_package().unwrap();
-        let ir_top = ir_package.get_top().unwrap();
+        let ir_top = ir_package.get_top_fn().unwrap();
         let gatify_output = gatify(
             &ir_top,
             GatifyOptions {
@@ -346,7 +346,7 @@ top fn do_nand(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
 ";
         let mut parser = ir_parser::Parser::new(input_ir_text);
         let ir_package = parser.parse_and_validate_package().unwrap();
-        let ir_top = ir_package.get_top().unwrap();
+        let ir_top = ir_package.get_top_fn().unwrap();
         let gatify_output = gatify(
             &ir_top,
             GatifyOptions {

--- a/xlsynth-g8r/src/ir2gate.rs
+++ b/xlsynth-g8r/src/ir2gate.rs
@@ -2148,7 +2148,7 @@ fn f(a: bits[8], b: bits[8]) -> bits[8] {
 ";
         let mut parser = ir_parser::Parser::new(ir_text);
         let ir_package = parser.parse_and_validate_package().unwrap();
-        let ir_fn = ir_package.get_top().unwrap();
+        let ir_fn = ir_package.get_top_fn().unwrap();
 
         let gatify_output = gatify(
             &ir_fn,

--- a/xlsynth-g8r/src/mcmc_logic.rs
+++ b/xlsynth-g8r/src/mcmc_logic.rs
@@ -891,7 +891,7 @@ pub fn load_start<P: AsRef<Path>>(p_generic: P) -> Result<GateFn> {
                     anyhow::anyhow!("Failed to parse IR package '{}': {:?}", p_str, e)
                 })?;
 
-                let top_entity = package.get_top().ok_or_else(|| {
+                let top_entity = package.get_top_fn().ok_or_else(|| {
                     anyhow::anyhow!("No top entity found in IR package '{}'", p_str)
                 })?;
                 println!("Found top function: {}", top_entity.name);

--- a/xlsynth-g8r/src/process_ir_path.rs
+++ b/xlsynth-g8r/src/process_ir_path.rs
@@ -75,7 +75,7 @@ pub fn process_ir_path(ir_path: &std::path::Path, options: &Options) -> Ir2Gates
         std::process::exit(1);
     });
 
-    let ir_top = match ir_package.get_top() {
+    let ir_top = match ir_package.get_top_fn() {
         Some(ir_top) => ir_top,
         None => {
             eprintln!("No top module found in the IR package");

--- a/xlsynth-g8r/tests/gatify_tests.rs
+++ b/xlsynth-g8r/tests/gatify_tests.rs
@@ -31,7 +31,7 @@ fn do_test_ir_conversion_with_top(
     let ir_package = parser.parse_and_validate_package().unwrap();
     let ir_fn = match top_name {
         Some(name) => ir_package.get_fn(name).unwrap(),
-        None => ir_package.get_top().unwrap(),
+        None => ir_package.get_top_fn().unwrap(),
     };
     let gatify_output = gatify(
         &ir_fn,
@@ -66,7 +66,7 @@ fn do_test_ir_conversion_no_equiv(ir_package_text: &str, opt: Opt) {
     let _ = env_logger::builder().is_test(true).try_init();
     let mut parser = ir_parser::Parser::new(&ir_package_text);
     let ir_package = parser.parse_and_validate_package().unwrap();
-    let ir_fn = ir_package.get_top().unwrap();
+    let ir_fn = ir_package.get_top_fn().unwrap();
     let _ = gatify(
         &ir_fn,
         GatifyOptions {

--- a/xlsynth-g8r/tests/test_adder_equivalence.rs
+++ b/xlsynth-g8r/tests/test_adder_equivalence.rs
@@ -21,7 +21,7 @@ top fn add_{n}_bits(a: bits[{n}] id=1, b: bits[{n}] id=2) -> bits[{n}] {{
     let mut parser = ir_parser::Parser::new(&original_ir);
     let orig_package = parser.parse_and_validate_package().unwrap();
     let orig_package_ir_text = orig_package.to_string();
-    let orig_ir_fn = orig_package.get_top().unwrap();
+    let orig_ir_fn = orig_package.get_top_fn().unwrap();
     let gatify_output = ir2gate::gatify(
         &orig_ir_fn,
         ir2gate::GatifyOptions {

--- a/xlsynth-pir/fuzz/Cargo.toml
+++ b/xlsynth-pir/fuzz/Cargo.toml
@@ -14,6 +14,8 @@ libfuzzer-sys = { version = "0.4" }
 log = "0.4"
 env_logger = "0.11"
 blake3 = "1"
+# Pretty diffs for assertions in fuzz targets
+pretty_assertions = "1.4.1"
 # Local crates
 xlsynth-pir = { path = ".." }
 xlsynth = { path = "../../xlsynth" }

--- a/xlsynth-pir/fuzz/fuzz_targets/fuzz_block_roundtrip.rs
+++ b/xlsynth-pir/fuzz/fuzz_targets/fuzz_block_roundtrip.rs
@@ -44,8 +44,8 @@ fn run_codegen_block_ir_to_string(
 
 fuzz_target!(|sample: FuzzSample| {
     // Toolchain path must be provided via environment for this fuzz target.
-    let tool_path = std::env::var("XLS_TOOLCHAIN_PATH")
-        .expect("XLS_TOOLCHAIN_PATH must be set for fuzz_block_roundtrip");
+    let tool_path =
+        std::env::var("XLSYNTH_TOOLS").expect("XLSYNTH_TOOLS must be set for fuzz_block_roundtrip");
 
     // 1) Build IR package with a single function from the sample.
     let mut pkg = xlsynth::IrPackage::new("fuzz_pkg").expect("IrPackage::new should succeed");

--- a/xlsynth-pir/fuzz/fuzz_targets/fuzz_greedy_matching_ged.rs
+++ b/xlsynth-pir/fuzz/fuzz_targets/fuzz_greedy_matching_ged.rs
@@ -169,7 +169,7 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
         Ok(p) => p,
         Err(_) => return,
     };
-    let old_fn = match parsed1.get_top() {
+    let old_fn = match parsed1.get_top_fn() {
         Some(f) => f,
         None => return,
     };
@@ -179,7 +179,7 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
         Ok(p) => p,
         Err(_) => return,
     };
-    let new_fn = match parsed2.get_top() {
+    let new_fn = match parsed2.get_top_fn() {
         Some(f) => f,
         None => return,
     };

--- a/xlsynth-pir/fuzz/fuzz_targets/fuzz_naive_matching_ged.rs
+++ b/xlsynth-pir/fuzz/fuzz_targets/fuzz_naive_matching_ged.rs
@@ -35,7 +35,7 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
         Ok(p) => p,
         Err(_) => return,
     };
-    let old_fn = match parsed1.get_top() {
+    let old_fn = match parsed1.get_top_fn() {
         Some(f) => f,
         None => return,
     };
@@ -45,7 +45,7 @@ fuzz_target!(|pair: FuzzSampleSameTypedPair| {
         Ok(p) => p,
         Err(_) => return,
     };
-    let new_fn = match parsed2.get_top() {
+    let new_fn = match parsed2.get_top_fn() {
         Some(f) => f,
         None => return,
     };

--- a/xlsynth-pir/src/edit_distance.rs
+++ b/xlsynth-pir/src/edit_distance.rs
@@ -136,7 +136,7 @@ mod tests {
             }
             "#,
         );
-        let inverter = inverter_pkg.get_top().unwrap();
+        let inverter = inverter_pkg.get_top_fn().unwrap();
         let identity_pkg = parse_ir_from_string(
             r#"package identity_pkg
             top fn identity(x: bits[1]) -> bits[1] {
@@ -144,7 +144,7 @@ mod tests {
             }
             "#,
         );
-        let identity = identity_pkg.get_top().unwrap();
+        let identity = identity_pkg.get_top_fn().unwrap();
         let edit_distance = compute_edit_distance(&inverter, &identity);
         // The only difference is the operator in the node ("not" vs "identity").
         assert_eq!(edit_distance, 1);
@@ -159,7 +159,7 @@ mod tests {
             }
             "#,
         );
-        let and_fn = and_pkg.get_top().unwrap();
+        let and_fn = and_pkg.get_top_fn().unwrap();
         let and_converse_pkg = parse_ir_from_string(
             r#"package and_converse_pkg
             top fn and_converse(x: bits[1], y: bits[1]) -> bits[1] {
@@ -167,7 +167,7 @@ mod tests {
             }
             "#,
         );
-        let and_converse_fn = and_converse_pkg.get_top().unwrap();
+        let and_converse_fn = and_converse_pkg.get_top_fn().unwrap();
         let edit_distance = compute_edit_distance(&and_fn, &and_converse_fn);
         // For the "and" node the operands differ in order,
         // causing a substitution cost of 1.
@@ -183,7 +183,7 @@ mod tests {
             }
             "#,
         );
-        let not_fn = not_pkg.get_top().unwrap();
+        let not_fn = not_pkg.get_top_fn().unwrap();
         let neg_pkg = parse_ir_from_string(
             r#"package neg_pkg
             top fn neg(x: bits[1]) -> bits[1] {
@@ -191,7 +191,7 @@ mod tests {
             }
             "#,
         );
-        let neg_fn = neg_pkg.get_top().unwrap();
+        let neg_fn = neg_pkg.get_top_fn().unwrap();
         let edit_distance = compute_edit_distance(&not_fn, &neg_fn);
         // The only difference is the operator in the node ("not" vs "neg").
         assert_eq!(edit_distance, 1);
@@ -207,7 +207,7 @@ mod tests {
             }
             "#,
         );
-        let not_not_fn = not_not_pkg.get_top().unwrap();
+        let not_not_fn = not_not_pkg.get_top_fn().unwrap();
         let neg_neg_pkg = parse_ir_from_string(
             r#"package neg_neg_pkg
             top fn neg_neg(x: bits[1]) -> bits[1] {
@@ -216,7 +216,7 @@ mod tests {
             }
             "#,
         );
-        let neg_neg_fn = neg_neg_pkg.get_top().unwrap();
+        let neg_neg_fn = neg_neg_pkg.get_top_fn().unwrap();
         let edit_distance = compute_edit_distance(&not_not_fn, &neg_neg_fn);
         assert_eq!(edit_distance, 2);
     }
@@ -230,7 +230,7 @@ mod tests {
             }
             "#,
         );
-        let two_tuple_fn = two_tuple_pkg.get_top().unwrap();
+        let two_tuple_fn = two_tuple_pkg.get_top_fn().unwrap();
         let singleton_pkg = parse_ir_from_string(
             r#"package singleton_pkg
             top fn singleton(x: bits[1]) -> (bits[1]) {
@@ -238,7 +238,7 @@ mod tests {
             }
             "#,
         );
-        let singleton_fn = singleton_pkg.get_top().unwrap();
+        let singleton_fn = singleton_pkg.get_top_fn().unwrap();
         let edit_distance = compute_edit_distance(&two_tuple_fn, &singleton_fn);
         // The only difference is the operator in the node ("tuple" vs "identity").
         assert_eq!(edit_distance, 1);

--- a/xlsynth-pir/src/greedy_matching_ged.rs
+++ b/xlsynth-pir/src/greedy_matching_ged.rs
@@ -546,7 +546,7 @@ mod tests {
             }
             "#,
         );
-        let lhs = pkg.get_top().unwrap();
+        let lhs = pkg.get_top_fn().unwrap();
 
         let pkg2 = parse_ir_from_string(
             r#"package p2
@@ -555,7 +555,7 @@ mod tests {
             }
             "#,
         );
-        let rhs = pkg2.get_top().unwrap();
+        let rhs = pkg2.get_top_fn().unwrap();
 
         // Use GreedyMatchSelector-based matcher
         let mut selector = GreedyMatchSelector::new(lhs, rhs);
@@ -576,7 +576,7 @@ mod tests {
             }
             "#,
         );
-        let lhs = pkg.get_top().unwrap();
+        let lhs = pkg.get_top_fn().unwrap();
 
         let pkg2 = parse_ir_from_string(
             r#"package p2
@@ -585,7 +585,7 @@ mod tests {
             }
             "#,
         );
-        let rhs = pkg2.get_top().unwrap();
+        let rhs = pkg2.get_top_fn().unwrap();
 
         let mut selector = GreedyMatchSelector::new(lhs, rhs);
         let result = compute_function_edit(lhs, rhs, &mut selector);
@@ -601,7 +601,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         let pkg_new = parse_ir_from_string(
             r#"package p
@@ -610,7 +610,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
         let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
@@ -629,7 +629,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         let pkg_new = parse_ir_from_string(
             r#"package p
@@ -639,7 +639,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
         let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
@@ -659,7 +659,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         // Same nodes, but return points to a different node (the literal).
         let pkg_new = parse_ir_from_string(
@@ -670,7 +670,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
         let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
@@ -689,7 +689,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         // Different structure: wrap the add in an identity, keep params identical.
         let pkg_new = parse_ir_from_string(
@@ -700,7 +700,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
         let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
@@ -719,7 +719,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         let pkg_new = parse_ir_from_string(
             r#"package p
@@ -728,7 +728,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
         let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
@@ -766,7 +766,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         let pkg_new = parse_ir_from_string(
             r#"package p
@@ -775,7 +775,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut selector = GreedyMatchSelector::new(old_fn, new_fn);
         let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
@@ -816,7 +816,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         // New: or(or(A'(w,x), C'(y,z)), B'(x,y)) — A stays in inner slot0; B,C swap
         // levels.
@@ -831,7 +831,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         // Build dependency graphs and compute reverse matches.
         let old_graph = crate::matching_ged::build_dependency_graph::<OldNodeRef>(old_fn);
@@ -883,7 +883,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         let pkg_new = parse_ir_from_string(
             r#"package p2
@@ -896,7 +896,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut sel = GreedyMatchSelector::new(old_fn, new_fn);
         let base = GreedyMatchSelector::SCORE_BASE;

--- a/xlsynth-pir/src/ir_fuzz.rs
+++ b/xlsynth-pir/src/ir_fuzz.rs
@@ -1754,7 +1754,7 @@ mod tests {
                 let mut p = ir_parser::Parser::new(&txt);
                 if let Ok(mut pir_pkg) = p.parse_and_validate_package() {
                     let _ = crate::ir_validate::validate_package(&pir_pkg);
-                    if let Some(top_fn) = pir_pkg.get_top_mut() {
+                    if let Some(top_fn) = pir_pkg.get_top_fn_mut() {
                         let dce_f = remove_dead_nodes(&*top_fn);
                         let mut live_param_set = HashSet::<NodeRef>::new();
                         for (index, node) in dce_f.nodes.iter().enumerate() {

--- a/xlsynth-pir/src/ir_rebase_ids.rs
+++ b/xlsynth-pir/src/ir_rebase_ids.rs
@@ -64,7 +64,7 @@ mod tests {
             name: "test_pkg".to_string(),
             file_table: ir::FileTable::new(),
             members: vec![ir::PackageMember::Function(f.clone())],
-            top_name: Some(f.name.clone()),
+            top: Some((f.name.clone(), ir::MemberType::Function)),
         }
     }
 

--- a/xlsynth-pir/src/ir_utils.rs
+++ b/xlsynth-pir/src/ir_utils.rs
@@ -655,7 +655,7 @@ mod tests {
             name: "test".to_string(),
             file_table: FileTable::new(),
             members: vec![PackageMember::Function(f.clone())],
-            top_name: None,
+            top: None,
         };
         let max_id = f
             .nodes
@@ -681,7 +681,7 @@ mod tests {
             name: "test".to_string(),
             file_table: FileTable::new(),
             members: vec![PackageMember::Function(f)],
-            top_name: None,
+            top: None,
         };
         assert_eq!(next_text_id(&pkg), 1);
     }

--- a/xlsynth-pir/src/localized_eco2.rs
+++ b/xlsynth-pir/src/localized_eco2.rs
@@ -49,7 +49,7 @@ mod tests {
         let pkg_text = format!("package test\n\n{}\n", ir_body);
         let mut p = Parser::new(&pkg_text);
         let pkg = p.parse_and_validate_package().unwrap();
-        pkg.get_top().unwrap().clone()
+        pkg.get_top_fn().unwrap().clone()
     }
 
     #[test]

--- a/xlsynth-pir/src/matching_ged.rs
+++ b/xlsynth-pir/src/matching_ged.rs
@@ -803,7 +803,7 @@ mod tests {
             }
             "#,
         );
-        let lhs = pkg.get_top().unwrap();
+        let lhs = pkg.get_top_fn().unwrap();
 
         let pkg2 = parse_ir_from_string(
             r#"package p2
@@ -812,7 +812,7 @@ mod tests {
             }
             "#,
         );
-        let rhs = pkg2.get_top().unwrap();
+        let rhs = pkg2.get_top_fn().unwrap();
 
         let mut selector = NaiveMatchSelector::new(lhs, rhs);
         let edits = compute_function_edit(lhs, rhs, &mut selector).unwrap();
@@ -832,7 +832,7 @@ mod tests {
             }
             "#,
         );
-        let lhs = pkg.get_top().unwrap();
+        let lhs = pkg.get_top_fn().unwrap();
 
         let pkg2 = parse_ir_from_string(
             r#"package p2
@@ -841,7 +841,7 @@ mod tests {
             }
             "#,
         );
-        let rhs = pkg2.get_top().unwrap();
+        let rhs = pkg2.get_top_fn().unwrap();
 
         let mut selector = NaiveMatchSelector::new(lhs, rhs);
         let result = compute_function_edit(lhs, rhs, &mut selector);
@@ -858,7 +858,7 @@ mod tests {
             }
             "#,
         );
-        let f = pkg.get_top().unwrap();
+        let f = pkg.get_top_fn().unwrap();
         let edits = IrEditSet::default();
         let applied = apply_function_edits(f, &edits).unwrap();
         assert_eq!(applied.to_string(), f.to_string());
@@ -873,7 +873,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         let pkg_new = parse_ir_from_string(
             r#"package p
@@ -882,7 +882,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut selector = crate::greedy_matching_ged::GreedyMatchSelector::new(old_fn, new_fn);
         let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
@@ -901,7 +901,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         let pkg_new = parse_ir_from_string(
             r#"package p
@@ -911,7 +911,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut selector = NaiveMatchSelector::new(old_fn, new_fn);
         let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
@@ -931,7 +931,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         // Same nodes, but return points to a different node (the literal).
         let pkg_new = parse_ir_from_string(
@@ -942,7 +942,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut selector = NaiveMatchSelector::new(old_fn, new_fn);
         let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();
@@ -961,7 +961,7 @@ mod tests {
             }
             "#,
         );
-        let old_fn = pkg_old.get_top().unwrap();
+        let old_fn = pkg_old.get_top_fn().unwrap();
 
         // Different structure: wrap the add in an identity, keep params identical.
         let pkg_new = parse_ir_from_string(
@@ -972,7 +972,7 @@ mod tests {
             }
             "#,
         );
-        let new_fn = pkg_new.get_top().unwrap();
+        let new_fn = pkg_new.get_top_fn().unwrap();
 
         let mut selector = NaiveMatchSelector::new(old_fn, new_fn);
         let edits = compute_function_edit(old_fn, new_fn, &mut selector).unwrap();

--- a/xlsynth-pir/src/node_hashing.rs
+++ b/xlsynth-pir/src/node_hashing.rs
@@ -273,7 +273,7 @@ mod tests {
     fn parse_top_fn(ir_pkg_text: &str) -> Fn {
         let mut p = Parser::new(ir_pkg_text);
         let pkg = p.parse_and_validate_package().unwrap();
-        pkg.get_top().unwrap().clone()
+        pkg.get_top_fn().unwrap().clone()
     }
 
     #[test]

--- a/xlsynth-prover/src/prover.rs
+++ b/xlsynth-prover/src/prover.rs
@@ -215,13 +215,13 @@ impl<S: SolverConfig> Prover for S {
             Some(name) => lhs_pkg
                 .get_fn(name)
                 .expect("Top function not found in LHS package"),
-            None => lhs_pkg.get_top().expect("No functions in LHS package"),
+            None => lhs_pkg.get_top_fn().expect("No functions in LHS package"),
         };
         let rhs_top = match top {
             Some(name) => rhs_pkg
                 .get_fn(name)
                 .expect("Top function not found in RHS package"),
-            None => rhs_pkg.get_top().expect("No functions in RHS package"),
+            None => rhs_pkg.get_top_fn().expect("No functions in RHS package"),
         };
 
         let lhs = ProverFn {


### PR DESCRIPTION
This isn't perfect but it is a step toward better block support in PIR. PackageMember is used as the polymorphic Fn/Block type. It'd be better to use a trait (FunctionLike?).