### PR TITLE
Fix macOS install-name handling for downloaded libxls dylib

### DIFF
--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -60,6 +60,48 @@ impl DsoInfo {
     }
 }
 
+/// Resolves `path` to an absolute location suitable for use as a Mach-O install
+/// name.
+///
+/// We prefer `std::fs::canonicalize` for stability; if that fails (e.g. the
+/// destination is missing or behind a broken symlink), we fall back to joining
+/// the current working directory for relative paths or returning the original
+/// absolute path verbatim.
+fn resolve_absolute_dso_id(path: &Path) -> PathBuf {
+    match std::fs::canonicalize(path) {
+        Ok(p) => p,
+        Err(_) => {
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                std::env::current_dir()
+                    .expect("current directory should be readable")
+                    .join(path)
+            }
+        }
+    }
+}
+
+/// Runs `install_name_tool -id` with the absolute dylib path so downstream
+/// binaries link directly to the on-disk location instead of relying on
+/// `@rpath` resolution at runtime.
+fn set_macos_install_name(dso_path: &Path) {
+    let install_name_path = resolve_absolute_dso_id(dso_path);
+    println!(
+        "cargo:info=Fixing DSO id: to {}",
+        install_name_path.display()
+    );
+    let status = Command::new("install_name_tool")
+        .arg("-id")
+        .arg(&install_name_path)
+        .arg(dso_path)
+        .status()
+        .expect("fixing DSO id should succeed");
+    if !status.success() {
+        panic!("Fixing DSO id failed with status: {:?}", status);
+    }
+}
+
 /// Performs a "high integrity" download of a file from a URL by doing the
 /// following:
 /// - Downloading a checksum file first.
@@ -437,19 +479,7 @@ fn download_dso_if_dne(url_base: &str, out_dir: &str) -> DsoInfo {
     .expect("download of DSO should succeed");
 
     if cfg!(target_os = "macos") {
-        let dso_filename = dso_info.get_dso_filename();
-        println!("cargo:info=Fixing DSO id: to {dso_filename}");
-        // Fix the DSO id so it can be found via the rpath.
-        let status = Command::new("install_name_tool")
-            .arg("-id")
-            .arg(format!("@rpath/{}", &dso_filename))
-            .arg(&dso_path)
-            .status()
-            .expect("fixing DSO id should succeed");
-
-        if !status.success() {
-            panic!("Fixing DSO id failed with status: {:?}", status);
-        }
+        set_macos_install_name(&dso_path);
     }
 
     dso_info
@@ -647,16 +677,7 @@ fn main() {
 
         // Fix the DSO id so it can be found via the rpath (macOS only).
         if cfg!(target_os = "macos") {
-            let dso_filename = dso_info.get_dso_filename();
-            let status = Command::new("install_name_tool")
-                .arg("-id")
-                .arg(format!("@rpath/{}", &dso_filename))
-                .arg(&dso_dest)
-                .status()
-                .expect("fixing DSO id should succeed");
-            if !status.success() {
-                panic!("Fixing DSO id failed with status: {:?}", status);
-            }
+            set_macos_install_name(&dso_dest);
         }
 
         println!(

--- a/xlsynth-sys/tests/install_name_test.rs
+++ b/xlsynth-sys/tests/install_name_test.rs
@@ -5,11 +5,9 @@
 //! logic.
 
 use std::ffi::OsStr;
+use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use std::process::Command;
-
-#[cfg(target_family = "unix")]
-use std::os::unix::fs::MetadataExt;
 
 /// Resolve the concrete `.dylib` path on macOS by inspecting `XLS_DSO_PATH`.
 ///

--- a/xlsynth-sys/tests/install_name_test.rs
+++ b/xlsynth-sys/tests/install_name_test.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression test ensuring the macOS XLS dynamic library advertises an
+//! absolute install-name, guarding against regressions in the build script
+//! logic.
+
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[cfg(target_family = "unix")]
+use std::os::unix::fs::MetadataExt;
+
+/// Resolve the concrete `.dylib` path on macOS by inspecting `XLS_DSO_PATH`.
+///
+/// When a directory is provided, we gather every `libxls-*.dylib` candidate,
+/// sort them lexicographically, and select the last entry. The filenames embed
+/// version numbers, so this yields the most recent artifact in a stable way.
+fn resolve_macos_dso_path() -> PathBuf {
+    let configured_path = PathBuf::from(xlsynth_sys::XLS_DSO_PATH);
+    if configured_path.is_file() {
+        return configured_path;
+    }
+
+    if configured_path.is_dir() {
+        let mut candidates: Vec<PathBuf> = std::fs::read_dir(&configured_path)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "Failed to read XLS_DSO_PATH directory {}: {}",
+                    configured_path.display(),
+                    err
+                )
+            })
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.is_file())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(OsStr::to_str)
+                    .map(|name| name.starts_with("libxls-") && name.ends_with(".dylib"))
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        assert!(
+            !candidates.is_empty(),
+            "No libxls-*.dylib candidates found in XLS_DSO_PATH directory: {}",
+            configured_path.display()
+        );
+
+        candidates.sort();
+        return candidates
+            .last()
+            .expect("candidates vector cannot be empty after is_empty check")
+            .to_path_buf();
+    }
+
+    panic!(
+        "XLS_DSO_PATH must be a directory or file; got: {}",
+        configured_path.display()
+    );
+}
+
+#[test]
+fn install_name_is_absolute() {
+    if !cfg!(target_os = "macos") {
+        eprintln!("Skipping macOS install-name regression test on non-macOS target.");
+        return;
+    }
+
+    let dso_path = resolve_macos_dso_path();
+
+    let output = Command::new("otool")
+        .arg("-D")
+        .arg(&dso_path)
+        .output()
+        .unwrap_or_else(|err| {
+            panic!(
+                "Failed to launch otool -D for {}: {}",
+                dso_path.display(),
+                err
+            )
+        });
+
+    assert!(
+        output.status.success(),
+        "otool -D {} exited with {:?}: {}",
+        dso_path.display(),
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout_text = String::from_utf8_lossy(&output.stdout).into_owned();
+    let install_name_line = stdout_text
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.ends_with(':'))
+        .unwrap_or_else(|| {
+            panic!(
+                "otool -D output missing install-name line.\nDSO path: {}\notool stdout:\n{}",
+                dso_path.display(),
+                stdout_text
+            )
+        })
+        .to_string();
+
+    assert!(
+        install_name_line.starts_with('/'),
+        "Install-name must start with '/'.\nDSO path: {}\nInstall-name: {}\notool stdout:\n{}",
+        dso_path.display(),
+        install_name_line,
+        stdout_text
+    );
+    assert!(
+        !install_name_line.starts_with('@'),
+        "Install-name must not use @-prefixed rpath references.\nDSO path: {}\nInstall-name: {}\notool stdout:\n{}",
+        dso_path.display(),
+        install_name_line,
+        stdout_text
+    );
+
+    let install_path = PathBuf::from(&install_name_line);
+    let canonical_dso = std::fs::canonicalize(&dso_path);
+    let canonical_install = std::fs::canonicalize(&install_path);
+
+    match (canonical_dso, canonical_install) {
+        (Ok(expected), Ok(actual)) => {
+            assert_eq!(
+                actual,
+                expected,
+                "Install-name resolved to {} but canonical DSO path is {}.\nDSO path: {}\notool stdout:\n{}",
+                actual.display(),
+                expected.display(),
+                dso_path.display(),
+                stdout_text
+            );
+        }
+        _ => {
+            let install_metadata = std::fs::metadata(&install_path).unwrap_or_else(|err| {
+                panic!(
+                    "Install-name {} could not be opened: {}",
+                    install_path.display(),
+                    err
+                )
+            });
+            let dso_metadata = std::fs::metadata(&dso_path).unwrap_or_else(|err| {
+                panic!(
+                    "Resolved DSO {} could not be opened: {}",
+                    dso_path.display(),
+                    err
+                )
+            });
+
+            #[cfg(target_family = "unix")]
+            {
+                assert_eq!(
+                    install_metadata.dev(),
+                    dso_metadata.dev(),
+                    "Install-name {} resolved to device {} but DSO resides on device {}.",
+                    install_path.display(),
+                    install_metadata.dev(),
+                    dso_metadata.dev()
+                );
+                assert_eq!(
+                    install_metadata.ino(),
+                    dso_metadata.ino(),
+                    "Install-name {} resolved to inode {} but DSO inode is {}.",
+                    install_path.display(),
+                    install_metadata.ino(),
+                    dso_metadata.ino()
+                );
+            }
+
+            #[cfg(not(target_family = "unix"))]
+            {
+                assert_eq!(
+                    install_metadata.len(),
+                    dso_metadata.len(),
+                    "Install-name {} resolved to file length {} but DSO length is {}.",
+                    install_path.display(),
+                    install_metadata.len(),
+                    dso_metadata.len()
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Problem: macOS builds rewrote the libxls install_name to @rpath/..., but binaries that use this crate lose the corresponding rpath from the build script and then fail to load the libxls dylib at runtime.

Fix: update xlsynth-sys/build.rs to resolve the dylib’s absolute path and use it when running install_name_tool, both for downloaded artifacts and for workspace symlinks.

Example of the old failure:
```
  Referenced from: <05DAE6F4-DA63-3B24-ACA5-D0527188A8FF> /my/binary/path
  Reason: no LC_RPATH's found
```

# Testing
I tested my binary; this fixes it.