### PR TITLE
Make always_equivalent rewrite-instance-scoped rather the rewrite-kind-scoped.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ xlsynth-g8r/fuzz/artifacts/
 xlsynth-pir/fuzz/Cargo.lock
 xlsynth-pir/fuzz/corpus/
 xlsynth-pir/fuzz/artifacts/
+xlsynth-mcmc-pir/fuzz/corpus/
+xlsynth-mcmc-pir/fuzz/artifacts/
 __pycache__
 .pytest_cache
 .ruff_cache

--- a/scripts/run_all_fuzz_tests.py
+++ b/scripts/run_all_fuzz_tests.py
@@ -208,7 +208,9 @@ def main() -> int:
         futures = [executor.submit(run_cmd_captured, cmd) for _, _, cmd in run_jobs]
         for (fuzz_dir, target, cmd), future in zip(run_jobs, futures):
             print(f"\n--- Running {target} in {fuzz_dir} ---", file=sys.stderr)
-            print("  => " + " ".join(shlex.quote(part) for part in cmd), file=sys.stderr)
+            print(
+                "  => " + " ".join(shlex.quote(part) for part in cmd), file=sys.stderr
+            )
             returncode, output = future.result()
             if output:
                 print(output, end="")

--- a/scripts/run_all_fuzz_tests.py
+++ b/scripts/run_all_fuzz_tests.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import argparse
+import concurrent.futures
 import shlex
 import subprocess
 import sys
@@ -28,13 +29,11 @@ DEFAULT_FEATURES: list[str] = [
 ]
 DEFAULT_FUZZ_RUN_ARGS: str = ""
 DEFAULT_FUZZ_BIN_ARGS: str = "-max_total_time=5"
+DEFAULT_THREADS: int = 4
 
 # Targets which are known to fail.
 SKIP_TARGETS: list[str] = [
     "fuzz_bulk_replace",
-    "fuzz_gate_transform_arbitrary",
-    "fuzz_ir_opt_equiv",
-    "fuzz_ir_outline_equiv",
 ]
 
 
@@ -57,6 +56,17 @@ def run_cmd(cmd: list[str]) -> None:
     """
     print("  => " + " ".join(shlex.quote(part) for part in cmd), file=sys.stderr)
     subprocess.check_call(cmd)
+
+
+def run_cmd_captured(cmd: list[str]) -> tuple[int, str]:
+    """Execute `cmd` and capture combined stdout/stderr for deterministic replay."""
+    completed = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return completed.returncode, completed.stdout
 
 
 def get_crate_features(crate_path: Path) -> list[str]:
@@ -92,7 +102,16 @@ def main() -> int:
         default="none",
         help='Sanitizer to enable via RUSTFLAGS, e.g. "address", "thread", or "none".',
     )
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=DEFAULT_THREADS,
+        help=f"Maximum number of fuzz targets to run in parallel. Defaults to {DEFAULT_THREADS}.",
+    )
     args = parser.parse_args()
+    num_workers = args.threads
+    if num_workers <= 0:
+        parser.error("--threads must be positive")
     sanitizer_args = ["--sanitizer", args.sanitizer]
 
     # scripts/ is one level below the repo root.
@@ -149,8 +168,8 @@ def main() -> int:
                 *fuzz_run_args_list,
             ]
         )
+    run_jobs: list[tuple[Path, str, list[str]]] = []
     for fuzz_dir, targets in fuzz_targets:
-        print(f"\n=== Running fuzz targets in {fuzz_dir} ===", file=sys.stderr)
         features = get_crate_features(fuzz_dir)
         supported_features = [f for f in features if f in args.features]
         features_args = (
@@ -161,22 +180,40 @@ def main() -> int:
                 print(f"Skipping {target} in {fuzz_dir}.", file=sys.stderr)
                 continue
 
-            print(f"\n--- Running {target} in {fuzz_dir} ---", file=sys.stderr)
-            run_cmd(
-                [
-                    "cargo",
-                    "fuzz",
-                    "run",
-                    "--fuzz-dir",
-                    fuzz_dir.as_posix(),
-                    *sanitizer_args,
-                    *features_args,
-                    *fuzz_run_args_list,
+            run_jobs.append(
+                (
+                    fuzz_dir,
                     target,
-                    "--",
-                    *fuzz_bin_args_list,
-                ]
+                    [
+                        "cargo",
+                        "fuzz",
+                        "run",
+                        "--fuzz-dir",
+                        fuzz_dir.as_posix(),
+                        *sanitizer_args,
+                        *features_args,
+                        *fuzz_run_args_list,
+                        target,
+                        "--",
+                        *fuzz_bin_args_list,
+                    ],
+                )
             )
+
+    print(
+        f"\n=== Running {len(run_jobs)} fuzz targets with {num_workers} worker threads ===",
+        file=sys.stderr,
+    )
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+        futures = [executor.submit(run_cmd_captured, cmd) for _, _, cmd in run_jobs]
+        for (fuzz_dir, target, cmd), future in zip(run_jobs, futures):
+            print(f"\n--- Running {target} in {fuzz_dir} ---", file=sys.stderr)
+            print("  => " + " ".join(shlex.quote(part) for part in cmd), file=sys.stderr)
+            returncode, output = future.result()
+            if output:
+                print(output, end="")
+            if returncode != 0:
+                return returncode
     return 0
 
 

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_bulk_replace.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_bulk_replace.rs
@@ -4,8 +4,11 @@
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 use rand::prelude::IteratorRandom;
+use rand::rngs::StdRng;
 use rand::Rng;
+use rand::SeedableRng;
 use std::collections::HashMap;
+use std::sync::Once;
 
 use xlsynth_g8r::aig::bulk_replace::{bulk_replace, SubstitutionMap};
 use xlsynth_g8r::aig::dce::dce;
@@ -13,6 +16,8 @@ use xlsynth_g8r::aig::{AigBitVector, AigOperand, AigRef, GateFn, GateBuilder, Ga
 use xlsynth_g8r::aig_sim::gate_sim::{eval, Collect};
 
 use xlsynth_pir::fuzz_utils;
+
+static LOGGER_INIT: Once = Once::new();
 
 #[derive(Debug, Clone, Arbitrary)]
 enum FuzzGateOp {
@@ -278,7 +283,7 @@ fn build_gate_graph(sample: &FuzzGateGraph) -> Option<(GateFn, GateBuilderOption
     }
     // Defensive: Avoid building overly large graphs
     if nodes.len() > 256 {
-        println!("[fuzz] nodes.len() exceeded cap: {}", nodes.len());
+        log::debug!("[fuzz] nodes.len() exceeded cap: {}", nodes.len());
         return None;
     }
     // Add outputs
@@ -291,7 +296,7 @@ fn build_gate_graph(sample: &FuzzGateGraph) -> Option<(GateFn, GateBuilderOption
         return None;
     }
     let graph = builder.build();
-    println!(
+    log::debug!(
         "[fuzz] About to return graph: nodes.len() = {}, outputs = {}",
         graph.gates.len(),
         graph.outputs.len()
@@ -305,12 +310,117 @@ struct FuzzSubstitutions {
     subs: Vec<(u16, u16, bool)>, // (from_idx, to_idx, negated)
 }
 
+fn make_rng(graph: &FuzzGateGraph, substitutions: &FuzzSubstitutions) -> StdRng {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[graph.num_inputs]);
+    hasher.update(&[graph.input_width]);
+    hasher.update(&[graph.num_ops]);
+    hasher.update(&[graph.num_outputs]);
+    hasher.update(&[graph.chain_depth]);
+    hasher.update(&[u8::from(graph.use_opt)]);
+    hasher.update(
+        &graph
+            .fanout_node
+            .map_or(u16::MAX, |fanout_node| fanout_node)
+            .to_le_bytes(),
+    );
+
+    hasher.update(&(graph.ops.len() as u64).to_le_bytes());
+    for op in &graph.ops {
+        match *op {
+            FuzzGateOp::And {
+                lhs,
+                rhs,
+                lhs_neg,
+                rhs_neg,
+            } => {
+                hasher.update(&[0]);
+                hasher.update(&lhs.to_le_bytes());
+                hasher.update(&rhs.to_le_bytes());
+                hasher.update(&[u8::from(lhs_neg), u8::from(rhs_neg)]);
+            }
+            FuzzGateOp::Or {
+                lhs,
+                rhs,
+                lhs_neg,
+                rhs_neg,
+            } => {
+                hasher.update(&[1]);
+                hasher.update(&lhs.to_le_bytes());
+                hasher.update(&rhs.to_le_bytes());
+                hasher.update(&[u8::from(lhs_neg), u8::from(rhs_neg)]);
+            }
+            FuzzGateOp::Xor {
+                lhs,
+                rhs,
+                lhs_neg,
+                rhs_neg,
+            } => {
+                hasher.update(&[2]);
+                hasher.update(&lhs.to_le_bytes());
+                hasher.update(&rhs.to_le_bytes());
+                hasher.update(&[u8::from(lhs_neg), u8::from(rhs_neg)]);
+            }
+            FuzzGateOp::Xnor {
+                lhs,
+                rhs,
+                lhs_neg,
+                rhs_neg,
+            } => {
+                hasher.update(&[3]);
+                hasher.update(&lhs.to_le_bytes());
+                hasher.update(&rhs.to_le_bytes());
+                hasher.update(&[u8::from(lhs_neg), u8::from(rhs_neg)]);
+            }
+            FuzzGateOp::Mux2 {
+                sel,
+                on_true,
+                on_false,
+                sel_neg,
+                t_neg,
+                f_neg,
+            } => {
+                hasher.update(&[4]);
+                hasher.update(&sel.to_le_bytes());
+                hasher.update(&on_true.to_le_bytes());
+                hasher.update(&on_false.to_le_bytes());
+                hasher.update(&[u8::from(sel_neg), u8::from(t_neg), u8::from(f_neg)]);
+            }
+        }
+    }
+
+    hasher.update(&(graph.constants.len() as u64).to_le_bytes());
+    for value in &graph.constants {
+        hasher.update(&[u8::from(*value)]);
+    }
+
+    hasher.update(&(graph.redundant_pairs.len() as u64).to_le_bytes());
+    for pair in &graph.redundant_pairs {
+        hasher.update(&pair.a.to_le_bytes());
+        hasher.update(&pair.b.to_le_bytes());
+    }
+
+    hasher.update(&(substitutions.subs.len() as u64).to_le_bytes());
+    for (from_idx, to_idx, negated) in &substitutions.subs {
+        hasher.update(&from_idx.to_le_bytes());
+        hasher.update(&to_idx.to_le_bytes());
+        hasher.update(&[u8::from(*negated)]);
+    }
+
+    StdRng::from_seed(*hasher.finalize().as_bytes())
+}
+
 fuzz_target!(|data: (FuzzGateGraph, FuzzSubstitutions)| {
     // Ensure XLSYNTH_TOOLS is set up front for equivalence checking
     if std::env::var("XLSYNTH_TOOLS").is_err() {
         panic!("XLSYNTH_TOOLS environment variable must be set for equivalence checking in this fuzz target");
     }
-    let _ = env_logger::builder().is_test(true).try_init();
+    LOGGER_INIT.call_once(|| {
+        let _ = env_logger::Builder::from_env(env_logger::Env::default())
+            .is_test(true)
+            .try_init();
+    });
+    let mut rng = make_rng(&data.0, &data.1);
     // Clamp the number of operations to avoid excessive graph size and OOM
     const MAX_OPS: u8 = 64;
     const MAX_OUTPUTS: u8 = 16;
@@ -325,8 +435,8 @@ fuzz_target!(|data: (FuzzGateGraph, FuzzSubstitutions)| {
         Some(pair) => pair,
         None => return, // skip degenerate graph
     };
-    println!("[fuzz] FuzzGateGraph: {:?}", data.0);
-    println!(
+    log::debug!("[fuzz] FuzzGateGraph: {:?}", data.0);
+    log::debug!(
         "[fuzz] gate_fn.gates.len() = {}, gate_fn.outputs.len() = {}",
         gate_fn.gates.len(),
         gate_fn.outputs.len()
@@ -350,14 +460,14 @@ fuzz_target!(|data: (FuzzGateGraph, FuzzSubstitutions)| {
 
     // With some probability, generate a long chain substitution map (A->B, B->C,
     // ..., Y->Z)
-    if rand::random::<u8>() % 8 == 0 && node_count > 3 {
+    if rng.r#gen::<u8>() % 8 == 0 && node_count > 3 {
         let max_chain = node_count.min(16);
-        let chain_len = (3..=max_chain).choose(&mut rand::thread_rng()).unwrap_or(3);
+        let chain_len = (3..=max_chain).choose(&mut rng).unwrap_or(3);
         if node_count <= chain_len + 1 {
             // Not enough nodes for a valid chain, fall back to normal
             // substitution logic
         } else {
-            let start = rand::thread_rng().gen_range(1..(node_count - chain_len));
+            let start = rng.gen_range(1..(node_count - chain_len));
             for i in 0..chain_len {
                 let from_idx = start + i;
                 let to_idx = start + i + 1;
@@ -500,9 +610,12 @@ fuzz_target!(|data: (FuzzGateGraph, FuzzSubstitutions)| {
         );
     }
 
-    // 2. Idempotence: running bulk_replace again should yield the same result
-    //    (structurally)
-    let new_fn2 = bulk_replace(&new_fn, &substitutions, opts);
+    // 2. No-op rebuild: the original substitution map is expressed in terms of
+    //    `gate_fn` node IDs, but `bulk_replace` runs DCE and renumbers nodes in
+    //    `new_fn`. Reapplying that stale map would be invalid, so rebuild
+    //    `new_fn` with an empty map instead and check output shape stability.
+    let no_op_substitutions = SubstitutionMap::new();
+    let new_fn2 = bulk_replace(&new_fn, &no_op_substitutions, opts);
     assert_eq!(
         new_fn.outputs.len(),
         new_fn2.outputs.len(),
@@ -531,7 +644,6 @@ fuzz_target!(|data: (FuzzGateGraph, FuzzSubstitutions)| {
         );
     }
     // Optionally, check simulation outputs for a random input vector
-    let mut rng = rand::thread_rng();
     let mut input_vecs = Vec::new();
     for input in &gate_fn.inputs {
         let width = input.get_bit_count();

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_arbitrary.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_arbitrary.rs
@@ -2,10 +2,13 @@
 
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
-use rand::thread_rng;
 
+#[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
 use xlsynth_g8r::prove_gate_fn_equiv_common::EquivResult;
+#[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
 use xlsynth_g8r::prove_gate_fn_equiv_varisat::{
     Ctx as VarisatCtx, prove_gate_fn_equiv as prove_sat,
 };
@@ -15,12 +18,28 @@ use xlsynth_g8r::transforms::{self, transform_trait::TransformDirection};
 use xlsynth_g8r_fuzz::{FuzzGraph, build_graph};
 
 const NUM_STEPS: usize = 32;
+const MAX_TRANSFORM_DRAWS: usize = NUM_STEPS * 32;
+
+fn make_rng(graph: &FuzzGraph) -> StdRng {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[graph.num_inputs]);
+    hasher.update(&[graph.input_width]);
+    hasher.update(&[graph.num_ops]);
+    hasher.update(&[graph.num_outputs]);
+    hasher.update(&[u8::from(graph.use_opt)]);
+    hasher.update(&(graph.ops.len() as u64).to_le_bytes());
+    for op in &graph.ops {
+        hasher.update(&op.lhs.to_le_bytes());
+        hasher.update(&op.rhs.to_le_bytes());
+        hasher.update(&[u8::from(op.lhs_neg), u8::from(op.rhs_neg)]);
+    }
+    StdRng::from_seed(*hasher.finalize().as_bytes())
+}
 
 fuzz_target!(|graph: FuzzGraph| {
-    // Ensure INFO logging is enabled for visibility inside fuzz runs.
-    let _ = env_logger::builder()
+    // Respect `RUST_LOG` so callers can choose quiet or verbose fuzz runs.
+    let _ = env_logger::Builder::from_env(env_logger::Env::default())
         .is_test(true)
-        .filter_level(log::LevelFilter::Info)
         .try_init();
 
     // Build an initial GateFn from the fuzzed graph description.
@@ -29,6 +48,7 @@ fuzz_target!(|graph: FuzzGraph| {
         return;
     };
 
+    #[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
     let orig_g = cur_g.clone();
 
     // Prepare the transform set & RNG.
@@ -37,10 +57,14 @@ fuzz_target!(|graph: FuzzGraph| {
         log::info!("No transforms available – skipping input");
         return;
     }
-    let mut rng = thread_rng();
+    let mut rng = make_rng(&graph);
 
     let mut attempts = 0usize;
-    while attempts < NUM_STEPS {
+    for _draw in 0..MAX_TRANSFORM_DRAWS {
+        if attempts >= NUM_STEPS {
+            break;
+        }
+
         // Pick a random transform.
         let t = transforms.iter_mut().choose(&mut rng).unwrap();
         let cand_locs = t.find_candidates(&cur_g, TransformDirection::Forward);

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_outline_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_outline_equiv.rs
@@ -4,6 +4,8 @@
 use libfuzzer_sys::fuzz_target;
 
 use std::collections::{HashMap, HashSet, VecDeque};
+#[cfg(feature = "with-z3-binary-test")]
+use std::sync::OnceLock;
 
 #[cfg(any(feature = "with-bitwuzla-system", feature = "with-bitwuzla-built"))]
 use xlsynth_prover::solver::bitwuzla::{Bitwuzla, BitwuzlaOptions};
@@ -131,6 +133,18 @@ fn permute_vec_deterministic<T: Clone>(v: &mut Vec<T>, seed: u64) {
     }
 }
 
+#[cfg(feature = "with-z3-binary-test")]
+fn z3_binary_available() -> bool {
+    static Z3_BINARY_AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *Z3_BINARY_AVAILABLE.get_or_init(|| {
+        std::process::Command::new("z3")
+            .arg("-version")
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    })
+}
+
 fuzz_target!(|sample: FuzzSample| {
     let _ = env_logger::builder().is_test(true).try_init();
 
@@ -236,8 +250,11 @@ fuzz_target!(|sample: FuzzSample| {
     log::info!("work_pkg_text:\n{}", work_pkg.to_string());
 
     // Prove equivalence: original function == outlined outer function
-    let lhs = EqProverFn::new(&orig_fn, None);
-    let rhs = EqProverFn::new(&res.outer, None);
+    // The outlined outer invokes `outlined_inner`, so the prover needs package
+    // context on the RHS to resolve the callee. Pass package context on the LHS
+    // too for symmetry and future-proofing if generated samples gain invokes.
+    let lhs = EqProverFn::new(&orig_fn, Some(&orig_pkg));
+    let rhs = EqProverFn::new(&res.outer, Some(&work_pkg));
 
     #[cfg(feature = "has-bitwuzla")]
     {
@@ -308,24 +325,28 @@ fuzz_target!(|sample: FuzzSample| {
 
     #[cfg(feature = "with-z3-binary-test")]
     {
-        let r = prove_ir_fn_equiv::<EasySmtSolver>(
-            &EasySmtConfig::z3(),
-            &lhs,
-            &rhs,
-            AssertionSemantics::Same,
-            None,
-            false,
-        );
-        if let EquivResult::Disproved {
-            lhs_inputs,
-            rhs_inputs,
-            ..
-        } = r
-        {
-            panic!(
-                "Outline equivalence failed (Z3 binary): lhs_inputs={:?} rhs_inputs={:?}",
-                lhs_inputs, rhs_inputs
+        // A missing local `z3` binary is an environment issue, not a sample
+        // failure; skip only this backend in that case.
+        if z3_binary_available() {
+            let r = prove_ir_fn_equiv::<EasySmtSolver>(
+                &EasySmtConfig::z3(),
+                &lhs,
+                &rhs,
+                AssertionSemantics::Same,
+                None,
+                false,
             );
+            if let EquivResult::Disproved {
+                lhs_inputs,
+                rhs_inputs,
+                ..
+            } = r
+            {
+                panic!(
+                    "Outline equivalence failed (Z3 binary): lhs_inputs={:?} rhs_inputs={:?}",
+                    lhs_inputs, rhs_inputs
+                );
+            }
         }
     }
 });

--- a/xlsynth-g8r/src/transforms/balance_and_tree.rs
+++ b/xlsynth-g8r/src/transforms/balance_and_tree.rs
@@ -8,7 +8,7 @@ use crate::transforms::transform_trait::{
 };
 use crate::use_count::get_id_to_use_count;
 use anyhow::{Result, anyhow};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 const TAG_LEFT: &str = "balanced_chain_left";
 const TAG_RIGHT: &str = "balanced_chain_right";
@@ -88,7 +88,6 @@ fn collect_chain(
                         return None; // branching
                     }
                     ops_rev.push(a);
-                    nodes.push(cur);
                     cur = b.node;
                     continue;
                 } else {
@@ -103,11 +102,26 @@ fn collect_chain(
     if orient == Some(Orientation::Left) {
         ops.reverse();
     }
-    if nodes.len() >= 2 {
+    if nodes.len() >= 2 && !chain_ops_depend_on_chain_nodes(g, &nodes, &ops) {
         Some((orient.unwrap(), nodes, ops))
     } else {
         None
     }
+}
+
+fn chain_ops_depend_on_chain_nodes(g: &GateFn, nodes: &[AigRef], ops: &[AigOperand]) -> bool {
+    let chain_nodes: HashSet<AigRef> = nodes.iter().copied().collect();
+    for op in ops {
+        if chain_nodes.contains(&op.node) {
+            return true;
+        }
+        for chain_node in nodes {
+            if topo::reaches_target(&g.gates, op.node, *chain_node) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn build_balanced(g: &mut GateFn, nodes: &[AigRef], ops: &[AigOperand]) -> Result<()> {
@@ -286,7 +300,11 @@ fn collect_chain_linear(
     if orient == Orientation::Left {
         ops.reverse();
     }
-    Some((nodes, ops))
+    if chain_ops_depend_on_chain_nodes(g, &nodes, &ops) {
+        None
+    } else {
+        Some((nodes, ops))
+    }
 }
 
 #[derive(Debug)]
@@ -539,6 +557,54 @@ mod tests {
             .apply(&mut g, &c2[0], TransformDirection::Forward)
             .unwrap();
         assert_eq!(g.to_string(), original);
+    }
+
+    #[test]
+    fn test_collect_chain_right_orientation_does_not_duplicate_nodes() {
+        let mut gb = GateBuilder::new("f".to_string(), GateBuilderOptions::no_opt());
+        let i0 = gb.add_input("i0".to_string(), 1).get_lsb(0).clone();
+        let i1 = gb.add_input("i1".to_string(), 1).get_lsb(0).clone();
+        let i2 = gb.add_input("i2".to_string(), 1).get_lsb(0).clone();
+        let i3 = gb.add_input("i3".to_string(), 1).get_lsb(0).clone();
+        let n2 = gb.add_and_binary(i2, i3);
+        let n1 = gb.add_and_binary(i1, n2);
+        let root = gb.add_and_binary(i0, n1);
+        gb.add_output("o".to_string(), root.into());
+        let g = gb.build();
+        let use_counts = get_id_to_use_count(&g);
+
+        let (orient, nodes, ops) =
+            collect_chain(&g, root.node, &use_counts).expect("expected right chain");
+
+        assert_eq!(orient, Orientation::Right);
+        assert_eq!(nodes, vec![root.node, n1.node, n2.node]);
+        assert_eq!(ops, vec![i0, i1, i2, i3]);
+        assert_eq!(nodes.len() + 1, ops.len());
+    }
+
+    #[test]
+    fn test_collect_chain_rejects_leaf_operand_that_is_a_chain_node() {
+        let mut gb = GateBuilder::new("f".to_string(), GateBuilderOptions::no_opt());
+        let i0 = gb.add_input("i0".to_string(), 1).get_lsb(0).clone();
+        let i1 = gb.add_input("i1".to_string(), 1).get_lsb(0).clone();
+        let i2 = gb.add_input("i2".to_string(), 1).get_lsb(0).clone();
+        let n0 = gb.add_and_binary(i0, i1);
+        let n1 = gb.add_and_binary(n0, i2);
+        let dead_root = gb.add_and_binary(
+            n1,
+            AigOperand {
+                node: n0.node,
+                negated: true,
+            },
+        );
+        // Keep `n1` live, but not `dead_root`, so the dead-root sibling edge to
+        // `n0` does not contribute to use-counts and this would otherwise look
+        // like a valid left chain.
+        gb.add_output("o".to_string(), n1.into());
+        let g = gb.build();
+        let use_counts = get_id_to_use_count(&g);
+
+        assert!(collect_chain(&g, dead_root.node, &use_counts).is_none());
     }
 
     #[test]

--- a/xlsynth-g8r/src/transforms/factor_shared_and.rs
+++ b/xlsynth-g8r/src/transforms/factor_shared_and.rs
@@ -79,8 +79,12 @@ pub fn factor_shared_and_primitive(g: &mut GateFn, outer: AigRef) -> Result<(), 
         _ => return Err("factor_shared_and_primitive: no single shared operand"),
     };
 
-    if node_reaches_target(&g.gates, unique_l.node, outer)
-        || node_reaches_target(&g.gates, unique_r.node, outer)
+    if shared.node == outer
+        || unique_l.node == left.node
+        || unique_r.node == left.node
+        || node_reaches_target(&g.gates, shared.node, outer)
+        || node_reaches_target(&g.gates, unique_l.node, left.node)
+        || node_reaches_target(&g.gates, unique_r.node, left.node)
     {
         return Err("factor_shared_and_primitive: would create cycle");
     }
@@ -355,9 +359,21 @@ fn can_factor_without_cycle(g: &GateFn, outer: AigRef) -> bool {
         ll_b
     };
 
-    // After factoring we will create a new edge shared -> outer
-    // This is safe unless shared already (transitively) reaches outer.
-    if node_reaches_target(&g.gates, shared.node, outer) {
+    let (_unique_l, unique_r) = if ll_a == shared {
+        (ll_b, if rl_a == shared { rl_b } else { rl_a })
+    } else {
+        (ll_a, if rl_a == shared { rl_b } else { rl_a })
+    };
+
+    // After factoring, `outer` will gain an edge to `shared`, and `left.node`
+    // will gain an edge to `unique_r`. Reject if either edge would point back
+    // into the producer cone, including the degenerate direct self-loop case
+    // on `left.node`.
+    if shared.node == outer
+        || unique_r.node == left.node
+        || node_reaches_target(&g.gates, shared.node, outer)
+        || node_reaches_target(&g.gates, unique_r.node, left.node)
+    {
         return false;
     }
 
@@ -588,5 +604,28 @@ mod tests {
         let mut f = FactorSharedAndTransform::new();
         let c = f.find_candidates(&g, TransformDirection::Forward);
         assert!(c.is_empty());
+    }
+
+    #[test]
+    fn factor_shared_and_rejects_dead_outer_when_unique_rhs_is_left_child() {
+        let mut gb = GateBuilder::new("f".to_string(), GateBuilderOptions::no_opt());
+        let a = gb.add_input("a".to_string(), 1).get_lsb(0).clone();
+        let b = gb.add_input("b".to_string(), 1).get_lsb(0).clone();
+        let left = gb.add_and_binary(a.clone(), b);
+        let right = gb.add_and_binary(a, left);
+        let dead_outer = gb.add_and_binary(left, right);
+        gb.add_output("o".to_string(), right.into());
+        let mut g = gb.build();
+
+        let mut t = FactorSharedAndTransform::new();
+        assert!(
+            t.find_candidates(&g, TransformDirection::Forward)
+                .is_empty(),
+            "dead outer with a back-edge to left child should not be a candidate"
+        );
+        assert_eq!(
+            factor_shared_and_primitive(&mut g, dead_outer.node),
+            Err("factor_shared_and_primitive: would create cycle")
+        );
     }
 }

--- a/xlsynth-g8r/src/transforms/rewire_operand.rs
+++ b/xlsynth-g8r/src/transforms/rewire_operand.rs
@@ -7,7 +7,10 @@ use crate::transforms::transform_trait::{
     union_node_provenance_into_node,
 };
 use anyhow::{Result, anyhow};
-use rand::Rng;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+const REWIRE_OPERAND_RNG_SEED: u64 = 0x8e802a26f3f4294d;
 
 /// Primitive: rewires one operand of an `And2` gate to `new_op`.
 /// Returns the previous operand value.
@@ -37,11 +40,15 @@ pub fn rewire_operand_primitive(
 }
 
 #[derive(Debug)]
-pub struct RewireOperandTransform;
+pub struct RewireOperandTransform {
+    rng: StdRng,
+}
 
 impl RewireOperandTransform {
     pub fn new() -> Self {
-        RewireOperandTransform
+        RewireOperandTransform {
+            rng: StdRng::seed_from_u64(REWIRE_OPERAND_RNG_SEED),
+        }
     }
 }
 
@@ -55,16 +62,15 @@ impl Transform for RewireOperandTransform {
         g: &GateFn,
         _direction: TransformDirection,
     ) -> Vec<TransformLocation> {
-        let mut rng = rand::thread_rng();
         let mut cands = Vec::new();
         for (idx, node) in g.gates.iter().enumerate() {
             if let AigNode::And2 { a, b, .. } = node {
                 let parent = AigRef { id: idx };
                 let new_op_lhs = AigOperand {
                     node: AigRef {
-                        id: rng.gen_range(0..g.gates.len()),
+                        id: self.rng.gen_range(0..g.gates.len()),
                     },
-                    negated: rng.r#gen(),
+                    negated: self.rng.r#gen(),
                 };
                 cands.push(TransformLocation::OperandReplacement {
                     parent,
@@ -74,9 +80,9 @@ impl Transform for RewireOperandTransform {
                 });
                 let new_op_rhs = AigOperand {
                     node: AigRef {
-                        id: rng.gen_range(0..g.gates.len()),
+                        id: self.rng.gen_range(0..g.gates.len()),
                     },
-                    negated: rng.r#gen(),
+                    negated: self.rng.r#gen(),
                 };
                 cands.push(TransformLocation::OperandReplacement {
                     parent,

--- a/xlsynth-mcmc-pir/fuzz/Cargo.toml
+++ b/xlsynth-mcmc-pir/fuzz/Cargo.toml
@@ -1,0 +1,36 @@
+[workspace]
+
+[package]
+name = "xlsynth-mcmc-pir-fuzz"
+edition = "2024"
+publish = false
+
+[package.metadata]
+fuzz = true
+cargo-fuzz = true
+
+[dependencies]
+blake3 = "1"
+env_logger = "0.11"
+libfuzzer-sys = "0.4"
+log = "0.4"
+rand = "0.8"
+xlsynth = { path = "../../xlsynth" }
+xlsynth-mcmc-pir = { path = ".." }
+xlsynth-pir = { path = "../../xlsynth-pir" }
+xlsynth-prover = { path = "../../xlsynth-prover" }
+
+[[bin]]
+name = "fuzz_pir_transform_arbitrary"
+path = "fuzz_targets/fuzz_pir_transform_arbitrary.rs"
+test = false
+doc = false
+
+[features]
+default = []
+has-bitwuzla = ["xlsynth-prover/has-bitwuzla"]
+has-boolector = ["xlsynth-prover/has-boolector"]
+with-bitwuzla-system = ["has-bitwuzla", "xlsynth-prover/with-bitwuzla-system"]
+with-bitwuzla-built = ["has-bitwuzla", "xlsynth-prover/with-bitwuzla-built"]
+with-boolector-system = ["has-boolector", "xlsynth-prover/with-boolector-system"]
+with-boolector-built = ["has-boolector", "xlsynth-prover/with-boolector-built"]

--- a/xlsynth-mcmc-pir/fuzz/FUZZ.md
+++ b/xlsynth-mcmc-pir/fuzz/FUZZ.md
@@ -1,0 +1,35 @@
+# Arbitrary PIR Transform Fuzz Target
+
+This fuzz target generates a random single-function PIR package from
+`xlsynth_pir::ir_fuzz::FuzzSample`, then repeatedly picks random PIR transforms,
+applies candidate rewrites, validates the resulting package, and formally proves
+equivalence for any candidate marked `always_equivalent`.
+
+Target name: `fuzz_pir_transform_arbitrary`
+
+Run:
+
+```bash
+cargo fuzz run fuzz_pir_transform_arbitrary
+```
+
+Essential property under test:
+
+- Candidate-level `always_equivalent` claims made by PIR transforms are sound,
+  and applying random rewrite sequences preserves structural validity.
+
+Early returns justification:
+
+- Samples rejected by `generate_ir_fn` are skipped because IR construction failed
+  before transform application could be exercised. These are generator-shape
+  failures, not transform soundness failures.
+- Packages that fail PIR parse/validation before any transform is applied are
+  skipped because they do not provide a valid starting point for the rewrite
+  harness.
+
+Main failure modes surfaced:
+
+- A candidate marked `always_equivalent` produces a disproved or solver-error
+  result.
+- A transform candidate applies successfully but yields an invalid PIR package.
+- Transform discovery/application crashes on structurally valid PIR input.

--- a/xlsynth-mcmc-pir/fuzz/fuzz_targets/fuzz_pir_transform_arbitrary.rs
+++ b/xlsynth-mcmc-pir/fuzz/fuzz_targets/fuzz_pir_transform_arbitrary.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+
+use std::sync::Once;
+
+use libfuzzer_sys::fuzz_target;
+use rand::rngs::StdRng;
+use rand::seq::IteratorRandom;
+use rand::SeedableRng;
+use xlsynth::IrPackage;
+use xlsynth_mcmc_pir::transforms::get_all_pir_transforms;
+use xlsynth_pir::ir;
+use xlsynth_pir::ir_fuzz::{generate_ir_fn, FuzzSample};
+use xlsynth_pir::ir_parser::Parser;
+use xlsynth_pir::ir_utils::compact_and_toposort_in_place;
+use xlsynth_pir::ir_validate;
+use xlsynth_prover::prover::types::{
+    AssertionSemantics, EquivParallelism, EquivResult, ProverFn,
+};
+use xlsynth_prover::prover::{prover_for_choice, Prover, SolverChoice};
+
+const NUM_STEPS: usize = 32;
+const MAX_TRANSFORM_DRAWS: usize = NUM_STEPS * 32;
+
+static INIT_LOGGER: Once = Once::new();
+
+fuzz_target!(|sample: FuzzSample| {
+    INIT_LOGGER.call_once(|| {
+        let _ = env_logger::Builder::from_env(env_logger::Env::default())
+            .is_test(true)
+            .try_init();
+    });
+
+    let mut xls_pkg =
+        IrPackage::new("fuzz_pir_transform_arbitrary").expect("IrPackage::new should succeed");
+    if let Err(e) = generate_ir_fn(sample.ops.clone(), &mut xls_pkg, None) {
+        // Early-return rationale: unsupported generator outputs are outside
+        // this target's transform-soundness scope; see FUZZ.md.
+        log::debug!("generate_ir_fn failed, skipping sample: {e}");
+        return;
+    }
+
+    let initial_ir_text = xls_pkg.to_string();
+    let mut cur_pkg = match Parser::new(&initial_ir_text).parse_and_validate_package() {
+        Ok(pkg) => pkg,
+        Err(e) => {
+            // Early-return rationale: this sample does not give us a valid
+            // starting PIR package, so transform application is not being
+            // exercised. See FUZZ.md.
+            log::debug!("initial parse/validate failed, skipping sample: {e}");
+            return;
+        }
+    };
+    if cur_pkg.get_top_fn().is_none() {
+        // Early-return rationale: generated package has no function to mutate;
+        // this is a degenerate harness input rather than a transform bug.
+        return;
+    }
+
+    let mut transforms = get_all_pir_transforms();
+    if transforms.is_empty() {
+        panic!("get_all_pir_transforms unexpectedly returned an empty transform set");
+    }
+    let mut rng = make_rng(&initial_ir_text);
+    let prover = make_in_process_prover();
+
+    let mut successful_steps = 0usize;
+    for _ in 0..MAX_TRANSFORM_DRAWS {
+        if successful_steps >= NUM_STEPS {
+            break;
+        }
+
+        let transform = transforms
+            .iter_mut()
+            .choose(&mut rng)
+            .expect("transform set should be non-empty");
+        let cur_fn = cur_pkg
+            .get_top_fn()
+            .expect("current package should retain a top function");
+        let candidates = transform.find_candidates(cur_fn);
+        let Some(candidate) = candidates.into_iter().choose(&mut rng) else {
+            log::debug!("transform {:?}: no candidates", transform.kind());
+            continue;
+        };
+
+        let mut next_pkg = cur_pkg.clone();
+        let next_fn = next_pkg
+            .get_top_fn_mut()
+            .expect("cloned package should retain a top function");
+        if let Err(e) = transform.apply(next_fn, &candidate.location) {
+            log::debug!(
+                "transform {:?} apply failed at {:?}, skipping candidate: {e}",
+                transform.kind(),
+                candidate.location,
+            );
+            continue;
+        }
+        if let Err(e) = compact_and_toposort_in_place(next_fn) {
+            log::debug!(
+                "transform {:?} produced non-toposortable PIR at {:?}, skipping candidate: {e}",
+                transform.kind(),
+                candidate.location,
+            );
+            continue;
+        }
+        if let Err(e) = ir_validate::validate_package(&next_pkg) {
+            panic!(
+                "transform {:?} produced invalid PIR at {:?}: {e:?}\n\nbefore:\n{}\n\nafter:\n{}",
+                transform.kind(),
+                candidate.location,
+                cur_pkg,
+                next_pkg,
+            );
+        }
+
+        if candidate.always_equivalent {
+            prove_candidate_equivalent(
+                prover.as_ref(),
+                &cur_pkg,
+                &next_pkg,
+                transform.kind(),
+                &candidate.location,
+            );
+        }
+
+        cur_pkg = next_pkg;
+        successful_steps += 1;
+    }
+});
+
+fn make_rng(initial_ir_text: &str) -> StdRng {
+    StdRng::from_seed(*blake3::hash(initial_ir_text.as_bytes()).as_bytes())
+}
+
+fn prove_candidate_equivalent(
+    prover: &dyn Prover,
+    cur_pkg: &ir::Package,
+    next_pkg: &ir::Package,
+    kind: xlsynth_mcmc_pir::transforms::PirTransformKind,
+    location: &xlsynth_mcmc_pir::transforms::TransformLocation,
+) {
+    prove_candidate_equivalent_with_result(
+        cur_pkg,
+        next_pkg,
+        kind,
+        location,
+        prover.prove_ir_equiv(
+            &ProverFn::new(expect_top_fn(cur_pkg), Some(cur_pkg)),
+            &ProverFn::new(expect_top_fn(next_pkg), Some(next_pkg)),
+            EquivParallelism::SingleThreaded,
+            AssertionSemantics::Same,
+            None,
+            false,
+        ),
+    )
+}
+
+fn make_in_process_prover() -> Box<dyn Prover> {
+    if cfg!(not(any(feature = "has-bitwuzla", feature = "has-boolector"))) {
+        panic!(
+            "fuzz_pir_transform_arbitrary refuses SolverChoice::Auto when it \
+             would fall back to Toolchain; enable with-bitwuzla-system, \
+             with-bitwuzla-built, with-boolector-system, or with-boolector-built"
+        );
+    }
+    prover_for_choice(SolverChoice::Auto, None)
+}
+
+fn expect_top_fn(pkg: &ir::Package) -> &ir::Fn {
+    pkg.get_top_fn().expect("package should have a top fn")
+}
+
+fn prove_candidate_equivalent_with_result(
+    cur_pkg: &ir::Package,
+    next_pkg: &ir::Package,
+    kind: xlsynth_mcmc_pir::transforms::PirTransformKind,
+    location: &xlsynth_mcmc_pir::transforms::TransformLocation,
+    equiv_result: EquivResult,
+) {
+    match equiv_result {
+        EquivResult::Proved => {}
+        EquivResult::Disproved {
+            lhs_inputs,
+            rhs_inputs,
+            lhs_output,
+            rhs_output,
+        } => {
+            panic!(
+                "transform {:?} at {:?} was marked always_equivalent but was disproved\n\
+                 lhs_inputs={lhs_inputs:?}\n\
+                 rhs_inputs={rhs_inputs:?}\n\
+                 lhs_output={lhs_output:?}\n\
+                 rhs_output={rhs_output:?}\n\n\
+                 before:\n{}\n\n\
+                 after:\n{}",
+                kind, location, cur_pkg, next_pkg,
+            );
+        }
+        EquivResult::ToolchainDisproved(msg) | EquivResult::Error(msg) => {
+            panic!(
+                "formal equivalence failed for transform {:?} at {:?}: {msg}\n\nbefore:\n{}\n\n\
+                 after:\n{}",
+                kind, location, cur_pkg, next_pkg,
+            );
+        }
+    }
+}

--- a/xlsynth-mcmc-pir/src/lib.rs
+++ b/xlsynth-mcmc-pir/src/lib.rs
@@ -1038,6 +1038,30 @@ pub fn mcmc_iteration(
 
     match chosen_transform.apply(&mut candidate_fn, &chosen_candidate.location) {
         Ok(()) => {
+            // Transform implementations may emit acyclic def-after-use graphs.
+            // Canonicalize centrally here so the oracle and cost paths see the
+            // same normalized IR without each transform paying a local
+            // topo-sort/compaction cost.
+            if let Err(e) = compact_and_toposort_in_place(&mut candidate_fn) {
+                log::debug!(
+                    "[pir-mcmc] compact/toposort failed for '{}' after {:?} at {:?}: {}; \
+                     rejecting candidate",
+                    candidate_fn.name,
+                    current_transform_kind,
+                    chosen_candidate.location,
+                    e
+                );
+                return McmcIterationOutput {
+                    output_state: current_fn,
+                    output_cost: current_cost,
+                    best_updated: false,
+                    outcome: IterationOutcomeDetails::CandidateFailure,
+                    oracle_time_micros: 0,
+                    transform_always_equivalent: chosen_candidate.always_equivalent,
+                    transform: Some(current_transform_kind),
+                };
+            }
+
             log::trace!("PIR transform applied successfully; determining cost...");
             let (is_equiv, oracle_time_micros) = if chosen_candidate.always_equivalent {
                 // Always-equivalent transforms can skip equivalence checks.
@@ -1407,6 +1431,14 @@ fn pir_equiv_oracle<R: Rng>(
     }
 }
 
+fn get_pir_transforms_for_run(enable_formal_oracle: bool) -> Vec<Box<dyn PirTransform>> {
+    let mut all_transforms = get_all_pir_transforms();
+    if !enable_formal_oracle {
+        all_transforms.retain(|t| t.can_emit_always_equivalent_candidates());
+    }
+    all_transforms
+}
+
 impl SegmentRunner<IrFn, Cost, PirTransformKind> for PirSegmentRunner {
     type Error = anyhow::Error;
 
@@ -1432,7 +1464,7 @@ impl SegmentRunner<IrFn, Cost, PirTransformKind> for PirSegmentRunner {
             };
 
         let mut iteration_rng = Pcg64Mcg::seed_from_u64(params.seed);
-        let all_transforms = get_all_pir_transforms();
+        let all_transforms = get_pir_transforms_for_run(self.enable_formal_oracle);
         let weights = build_transform_weights(&all_transforms);
 
         let mut context = PirMcmcContext {
@@ -1800,6 +1832,8 @@ pub fn run_pir_mcmc_with_shared_best(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
     use count_toggles::WeightedSwitchingOptions;
     use xlsynth_pir::ir::{ExtNaryAddArchitecture, NodePayload};
@@ -1920,6 +1954,30 @@ mod tests {
             "expected optimized PIR to reconstruct brent_kung ext_nary_add:\n{}",
             optimized
         );
+    }
+
+    #[test]
+    fn get_pir_transforms_for_run_prunes_unsafe_only_classes_without_formal_oracle() {
+        let no_oracle_kinds: HashSet<PirTransformKind> =
+            get_pir_transforms_for_run(/* enable_formal_oracle= */ false)
+                .into_iter()
+                .map(|t| t.kind())
+                .collect();
+        let oracle_kinds: HashSet<PirTransformKind> =
+            get_pir_transforms_for_run(/* enable_formal_oracle= */ true)
+                .into_iter()
+                .map(|t| t.kind())
+                .collect();
+
+        assert!(!no_oracle_kinds.contains(&PirTransformKind::ShiftHoist));
+        assert!(!no_oracle_kinds.contains(&PirTransformKind::MaskOperandHighBit));
+        assert!(!no_oracle_kinds.contains(&PirTransformKind::RewireOperandToSameType));
+        assert!(no_oracle_kinds.contains(&PirTransformKind::AbsorbAddOperandIntoExtNaryAdd));
+        assert!(no_oracle_kinds.contains(&PirTransformKind::AddToExtNaryAdd));
+
+        assert!(oracle_kinds.contains(&PirTransformKind::ShiftHoist));
+        assert!(oracle_kinds.contains(&PirTransformKind::MaskOperandHighBit));
+        assert!(oracle_kinds.contains(&PirTransformKind::RewireOperandToSameType));
     }
 
     #[test]

--- a/xlsynth-mcmc-pir/src/lib.rs
+++ b/xlsynth-mcmc-pir/src/lib.rs
@@ -1001,15 +1001,18 @@ pub fn mcmc_iteration(
     let chosen_transform = &mut context.all_transforms[chosen_transform_idx];
     let current_transform_kind = chosen_transform.kind();
 
-    let candidate_locations = chosen_transform.find_candidates(&current_fn);
+    let mut candidates = chosen_transform.find_candidates(&current_fn);
+    if !context.enable_formal_oracle {
+        candidates.retain(|c| c.always_equivalent);
+    }
 
     log::trace!(
         "Found {} PIR candidates for {:?}",
-        candidate_locations.len(),
+        candidates.len(),
         current_transform_kind,
     );
 
-    if candidate_locations.is_empty() {
+    if candidates.is_empty() {
         return McmcIterationOutput {
             output_state: current_fn,
             output_cost: current_cost,
@@ -1021,22 +1024,22 @@ pub fn mcmc_iteration(
         };
     }
 
-    let chosen_location = candidate_locations.choose(context.rng).unwrap();
+    let chosen_candidate = candidates.choose(context.rng).unwrap();
 
-    log::trace!("Chosen PIR location: {:?}", chosen_location);
+    log::trace!("Chosen PIR candidate: {:?}", chosen_candidate);
 
     let mut candidate_fn = current_fn.clone();
 
     log::trace!(
         "Applying PIR transform {:?} at {:?}",
         current_transform_kind,
-        chosen_location
+        chosen_candidate.location
     );
 
-    match chosen_transform.apply(&mut candidate_fn, chosen_location) {
+    match chosen_transform.apply(&mut candidate_fn, &chosen_candidate.location) {
         Ok(()) => {
             log::trace!("PIR transform applied successfully; determining cost...");
-            let (is_equiv, oracle_time_micros) = if chosen_transform.always_equivalent() {
+            let (is_equiv, oracle_time_micros) = if chosen_candidate.always_equivalent {
                 // Always-equivalent transforms can skip equivalence checks.
                 (true, 0u128)
             } else {
@@ -1066,7 +1069,7 @@ pub fn mcmc_iteration(
                     best_updated: false,
                     outcome: IterationOutcomeDetails::OracleFailure,
                     oracle_time_micros,
-                    transform_always_equivalent: chosen_transform.always_equivalent(),
+                    transform_always_equivalent: chosen_candidate.always_equivalent,
                     transform: Some(current_transform_kind),
                 }
             } else {
@@ -1124,7 +1127,7 @@ pub fn mcmc_iteration(
                             best_updated: false,
                             outcome: IterationOutcomeDetails::SimFailure,
                             oracle_time_micros: sim_micros,
-                            transform_always_equivalent: chosen_transform.always_equivalent(),
+                            transform_always_equivalent: chosen_candidate.always_equivalent,
                             transform: Some(current_transform_kind),
                         };
                     }
@@ -1195,7 +1198,7 @@ pub fn mcmc_iteration(
                             kind: current_transform_kind,
                         },
                         oracle_time_micros,
-                        transform_always_equivalent: chosen_transform.always_equivalent(),
+                        transform_always_equivalent: chosen_candidate.always_equivalent,
                         transform: Some(current_transform_kind),
                     }
                 } else {
@@ -1205,7 +1208,7 @@ pub fn mcmc_iteration(
                         best_updated: false,
                         outcome: IterationOutcomeDetails::MetropolisReject,
                         oracle_time_micros,
-                        transform_always_equivalent: chosen_transform.always_equivalent(),
+                        transform_always_equivalent: chosen_candidate.always_equivalent,
                         transform: Some(current_transform_kind),
                     }
                 }
@@ -1223,7 +1226,7 @@ pub fn mcmc_iteration(
                 best_updated: false,
                 outcome: IterationOutcomeDetails::ApplyFailure,
                 oracle_time_micros: 0,
-                transform_always_equivalent: true,
+                transform_always_equivalent: chosen_candidate.always_equivalent,
                 transform: Some(current_transform_kind),
             }
         }
@@ -1429,13 +1432,7 @@ impl SegmentRunner<IrFn, Cost, PirTransformKind> for PirSegmentRunner {
             };
 
         let mut iteration_rng = Pcg64Mcg::seed_from_u64(params.seed);
-        let mut all_transforms = get_all_pir_transforms();
-        if !self.enable_formal_oracle {
-            // Safety-by-default: non-always-equivalent transforms are only enabled when a
-            // formal equivalence oracle is enabled. This prevents accidentally accepting
-            // incorrect rewrites due to sampling-only equivalence.
-            all_transforms.retain(|t| t.always_equivalent());
-        }
+        let all_transforms = get_all_pir_transforms();
         let weights = build_transform_weights(&all_transforms);
 
         let mut context = PirMcmcContext {

--- a/xlsynth-mcmc-pir/src/transforms/add_fission.rs
+++ b/xlsynth-mcmc-pir/src/transforms/add_fission.rs
@@ -165,8 +165,9 @@ impl PirTransform for AddFissionTransform {
         PirTransformKind::AddFission
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             if let NodePayload::Binop(Binop::Add, _, _) = f.get_node(nr).payload {
                 // `bits[0]` is permitted in the IR, but this transform materializes a
@@ -176,7 +177,10 @@ impl PirTransform for AddFissionTransform {
                     continue;
                 }
                 if Self::match_fission_add(f, nr).is_some() || Self::add_has_add_user(f, nr) {
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
             }
         }

--- a/xlsynth-mcmc-pir/src/transforms/add_sign_ext_u1_to_sub_zero_ext_u1.rs
+++ b/xlsynth-mcmc-pir/src/transforms/add_sign_ext_u1_to_sub_zero_ext_u1.rs
@@ -121,8 +121,9 @@ impl PirTransform for AddSignExtU1ToSubZeroExtU1Transform {
         PirTransformKind::AddSignExtU1ToSubZeroExtU1
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 // Expand: add(x, sign_ext(b,w)) (either operand).
@@ -142,7 +143,10 @@ impl PirTransform for AddSignExtU1ToSubZeroExtU1Transform {
                         }
                     }
                     if ok {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
 
@@ -156,7 +160,10 @@ impl PirTransform for AddSignExtU1ToSubZeroExtU1Transform {
                         continue;
                     }
                     if Self::zero_ext_u1_parts(f, *zext).is_some() {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -239,9 +246,5 @@ impl PirTransform for AddSignExtU1ToSubZeroExtU1Transform {
                 Err("AddSignExtU1ToSubZeroExtU1Transform: expected add(..) or sub(..)".to_string())
             }
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/and_mask_sign_ext_to_sel.rs
+++ b/xlsynth-mcmc-pir/src/transforms/and_mask_sign_ext_to_sel.rs
@@ -74,8 +74,9 @@ impl PirTransform for AndMaskSignExtToSelTransform {
         PirTransformKind::AndMaskSignExtToSel
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 // Expand: and(x, sign_ext(b,w)) (nary)
@@ -92,7 +93,10 @@ impl PirTransform for AndMaskSignExtToSelTransform {
                         }
                     }
                     if found.is_some() {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 // Fold: sel(b, cases=[0_w, x])
@@ -117,7 +121,10 @@ impl PirTransform for AndMaskSignExtToSelTransform {
                     if Self::bits_width(f, cases[1]) != Some(w) {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 _ => {}
             }
@@ -222,9 +229,5 @@ impl PirTransform for AndMaskSignExtToSelTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/and_reduce_demorgan.rs
+++ b/xlsynth-mcmc-pir/src/transforms/and_reduce_demorgan.rs
@@ -44,12 +44,16 @@ impl PirTransform for AndReduceDeMorganTransform {
         PirTransformKind::AndReduceDeMorgan
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Unop(Unop::AndReduce, _) => {
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 NodePayload::Unop(Unop::Not, arg) => {
                     let NodePayload::Unop(Unop::OrReduce, inner) = f.get_node(*arg).payload else {
@@ -58,7 +62,10 @@ impl PirTransform for AndReduceDeMorganTransform {
                     let NodePayload::Unop(Unop::Not, _) = f.get_node(inner).payload else {
                         continue;
                     };
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 _ => {}
             }
@@ -117,9 +124,5 @@ impl PirTransform for AndReduceDeMorganTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/bit_slice_add_sub_distribute.rs
+++ b/xlsynth-mcmc-pir/src/transforms/bit_slice_add_sub_distribute.rs
@@ -2,7 +2,7 @@
 
 use xlsynth_pir::ir::{Binop, Fn as IrFn, Node, NodePayload, NodeRef, Type};
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 /// Distributes low-bit truncation over add/sub (and folds back).
 ///
@@ -71,8 +71,9 @@ impl PirTransform for BitSliceAddSubDistributeTransform {
         PirTransformKind::BitSliceAddSubDistribute
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -93,7 +94,10 @@ impl PirTransform for BitSliceAddSubDistributeTransform {
                         continue;
                     };
                     if wl == wr && k <= wl {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 NodePayload::Binop(op @ Binop::Add, lhs, rhs)
@@ -132,7 +136,10 @@ impl PirTransform for BitSliceAddSubDistributeTransform {
                         continue;
                     };
                     if wx_src == wy_src && k <= wx_src {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -245,11 +252,11 @@ mod tests {
         let mut f = parser.parse_fn().unwrap();
         let mut t = BitSliceAddSubDistributeTransform;
         let cand = t.find_candidates(&f).pop().expect("candidate");
-        let target = match cand.clone() {
+        let target = match cand.location.clone() {
             TransformLocation::Node(nr) => nr,
             _ => unreachable!(),
         };
-        t.apply(&mut f, &cand).expect("apply");
+        t.apply(&mut f, &cand.location).expect("apply");
         match &f.get_node(target).payload {
             NodePayload::Binop(Binop::Add, _, _) => {}
             other => panic!("unexpected payload: {:?}", other),
@@ -267,11 +274,11 @@ mod tests {
         let mut f = parser.parse_fn().unwrap();
         let mut t = BitSliceAddSubDistributeTransform;
         let cand = t.find_candidates(&f).pop().expect("candidate");
-        let target = match cand.clone() {
+        let target = match cand.location.clone() {
             TransformLocation::Node(nr) => nr,
             _ => unreachable!(),
         };
-        t.apply(&mut f, &cand).expect("apply");
+        t.apply(&mut f, &cand.location).expect("apply");
         match &f.get_node(target).payload {
             NodePayload::BitSlice { start, width, .. } => {
                 assert_eq!(*start, 0);

--- a/xlsynth-mcmc-pir/src/transforms/bit_slice_bit_slice_fold.rs
+++ b/xlsynth-mcmc-pir/src/transforms/bit_slice_bit_slice_fold.rs
@@ -50,16 +50,23 @@ impl PirTransform for BitSliceBitSliceFoldTransform {
         PirTransformKind::BitSliceBitSliceFold
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::BitSlice { arg, .. } => {
                     if matches!(f.get_node(*arg).payload, NodePayload::BitSlice { .. }) {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     } else {
                         // allow expansion too
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -133,9 +140,5 @@ impl PirTransform for BitSliceBitSliceFoldTransform {
             width: w2,
         };
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/bit_slice_concat_distribute.rs
+++ b/xlsynth-mcmc-pir/src/transforms/bit_slice_concat_distribute.rs
@@ -67,15 +67,19 @@ impl PirTransform for BitSliceConcatDistributeTransform {
         PirTransformKind::BitSliceConcatDistribute
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             if let NodePayload::BitSlice { arg, .. } = &f.get_node(nr).payload {
                 if matches!(
                     f.get_node(*arg).payload,
                     NodePayload::Nary(NaryOp::Concat, _)
                 ) {
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
             }
         }
@@ -152,9 +156,5 @@ impl PirTransform for BitSliceConcatDistributeTransform {
         let cat = Self::mk_concat_node(f, width, bs_a, bs_b);
         f.get_node_mut(target_ref).payload = NodePayload::Unop(Unop::Identity, cat);
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/bit_slice_sel_distribute.rs
+++ b/xlsynth-mcmc-pir/src/transforms/bit_slice_sel_distribute.rs
@@ -96,8 +96,9 @@ impl PirTransform for BitSliceSelDistributeTransform {
         PirTransformKind::BitSliceSelDistribute
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -113,7 +114,10 @@ impl PirTransform for BitSliceSelDistributeTransform {
                         if wa.is_some() && wa == wb && wout == Some(*width) {
                             // Also require slice to be in-bounds to avoid constructing invalid IR.
                             if start.saturating_add(*width) <= wa.unwrap() {
-                                out.push(TransformLocation::Node(nr));
+                                out.push(TransformCandidate {
+                                    location: TransformLocation::Node(nr),
+                                    always_equivalent,
+                                });
                             }
                         }
                     }
@@ -148,7 +152,10 @@ impl PirTransform for BitSliceSelDistributeTransform {
                     let wout = Self::bits_width(f, nr);
                     if wa.is_some() && wa == wb && wout == Some(a_width) {
                         if a_start.saturating_add(a_width) <= wa.unwrap() {
-                            out.push(TransformLocation::Node(nr));
+                            out.push(TransformCandidate {
+                                location: TransformLocation::Node(nr),
+                                always_equivalent,
+                            });
                         }
                     }
                 }
@@ -272,9 +279,5 @@ impl PirTransform for BitSliceSelDistributeTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/carry_split_add.rs
+++ b/xlsynth-mcmc-pir/src/transforms/carry_split_add.rs
@@ -79,14 +79,18 @@ impl PirTransform for CarrySplitAddTransform {
         PirTransformKind::CarrySplitAdd
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Binop(Binop::Add, _, _) => {
                     if let Some(w) = Self::bits_width(f, nr) {
                         if w >= 2 {
-                            out.push(TransformLocation::Node(nr));
+                            out.push(TransformCandidate {
+                                location: TransformLocation::Node(nr),
+                                always_equivalent,
+                            });
                         }
                     }
                 }
@@ -101,9 +105,15 @@ impl PirTransform for CarrySplitAddTransform {
                         f.get_node(ops[0]).payload,
                         NodePayload::Binop(Binop::Add, _, _)
                     ) {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     } else {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -318,9 +328,5 @@ impl PirTransform for CarrySplitAddTransform {
 
             _ => Err("CarrySplitAddTransform: expected add(..) or concat(..)".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/clamp_chain_collapse.rs
+++ b/xlsynth-mcmc-pir/src/transforms/clamp_chain_collapse.rs
@@ -2,7 +2,7 @@
 
 use xlsynth_pir::ir::{Binop, Fn as IrFn, NaryOp, Node, NodePayload, NodeRef, Type, Unop};
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 /// A non-always-equivalent transform that attempts to collapse a deep
 /// clamp-like selector tree into a single comparison-based clamp.
@@ -112,8 +112,9 @@ impl PirTransform for ClampChainCollapseTransform {
         PirTransformKind::ClampChainCollapse
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = false;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::Sel {
                 selector,
@@ -153,7 +154,10 @@ impl PirTransform for ClampChainCollapseTransform {
             if !Self::selector_cone_contains_cmp(f, *selector, x, bound, 64) {
                 continue;
             }
-            out.push(TransformLocation::Node(nr));
+            out.push(TransformCandidate {
+                location: TransformLocation::Node(nr),
+                always_equivalent,
+            });
         }
         out
     }
@@ -214,9 +218,5 @@ impl PirTransform for ClampChainCollapseTransform {
             default: None,
         };
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        false
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/clamp_chain_collapse.rs
+++ b/xlsynth-mcmc-pir/src/transforms/clamp_chain_collapse.rs
@@ -112,6 +112,10 @@ impl PirTransform for ClampChainCollapseTransform {
         PirTransformKind::ClampChainCollapse
     }
 
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        false
+    }
+
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
         let always_equivalent = false;
         let mut out = Vec::<TransformCandidate>::new();

--- a/xlsynth-mcmc-pir/src/transforms/clone_multi_user_node.rs
+++ b/xlsynth-mcmc-pir/src/transforms/clone_multi_user_node.rs
@@ -15,7 +15,8 @@ impl PirTransform for CloneMultiUserNodeTransform {
         PirTransformKind::CloneMultiUserNode
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
         let users_map = compute_users(f);
         users_map
             .iter()
@@ -27,7 +28,10 @@ impl PirTransform for CloneMultiUserNodeTransform {
                 match &node.payload {
                     NodePayload::GetParam(_) => None,
                     NodePayload::Nil => None,
-                    _ if users.len() > 1 => Some(TransformLocation::Node(*nr)),
+                    _ if users.len() > 1 => Some(TransformCandidate {
+                        location: TransformLocation::Node(*nr),
+                        always_equivalent,
+                    }),
                     _ => None,
                 }
             })
@@ -99,9 +103,5 @@ impl PirTransform for CloneMultiUserNodeTransform {
         }
 
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/cmp_sel_canon.rs
+++ b/xlsynth-mcmc-pir/src/transforms/cmp_sel_canon.rs
@@ -92,8 +92,9 @@ impl PirTransform for CmpSelCanonTransform {
         PirTransformKind::CmpSelCanon
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::Sel {
                 selector,
@@ -128,7 +129,10 @@ impl PirTransform for CmpSelCanonTransform {
             if Self::sel_is_min(op, a, b, cases[0], cases[1]).is_none() {
                 continue;
             }
-            out.push(TransformLocation::Node(nr));
+            out.push(TransformCandidate {
+                location: TransformLocation::Node(nr),
+                always_equivalent,
+            });
         }
         out
     }
@@ -182,10 +186,6 @@ impl PirTransform for CmpSelCanonTransform {
             default: None,
         };
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }
 

--- a/xlsynth-mcmc-pir/src/transforms/cmp_swap.rs
+++ b/xlsynth-mcmc-pir/src/transforms/cmp_swap.rs
@@ -57,8 +57,9 @@ impl PirTransform for CmpSwapTransform {
         PirTransformKind::CmpSwap
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::Binop(op, lhs, rhs) = f.get_node(nr).payload else {
                 continue;
@@ -75,7 +76,10 @@ impl PirTransform for CmpSwapTransform {
             if Self::is_bits_type(f, rhs) != Some(w) {
                 continue;
             }
-            out.push(TransformLocation::Node(nr));
+            out.push(TransformCandidate {
+                location: TransformLocation::Node(nr),
+                always_equivalent,
+            });
         }
         out
     }
@@ -111,10 +115,6 @@ impl PirTransform for CmpSwapTransform {
             Self::swapped_op(op).ok_or_else(|| "CmpSwapTransform: unsupported op".to_string())?;
         f.get_node_mut(target_ref).payload = NodePayload::Binop(new_op, rhs, lhs);
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }
 

--- a/xlsynth-mcmc-pir/src/transforms/concat_sel_hoist.rs
+++ b/xlsynth-mcmc-pir/src/transforms/concat_sel_hoist.rs
@@ -2,7 +2,7 @@
 
 use xlsynth_pir::ir::{Fn as IrFn, NaryOp, Node, NodePayload, NodeRef, Type};
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 /// Hoists a single 2-case sel operand through concat and folds the narrow
 /// reverse form back.
@@ -62,8 +62,9 @@ impl PirTransform for ConcatSelHoistTransform {
         PirTransformKind::ConcatSelHoist
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Nary(NaryOp::Concat, ops) => {
@@ -92,7 +93,10 @@ impl PirTransform for ConcatSelHoistTransform {
                     {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 NodePayload::Sel {
                     selector,
@@ -121,7 +125,10 @@ impl PirTransform for ConcatSelHoistTransform {
                     let diff_positions: Vec<usize> =
                         (0..ops0.len()).filter(|i| ops0[*i] != ops1[*i]).collect();
                     if diff_positions.len() == 1 {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -241,11 +248,11 @@ mod tests {
         let mut f = parser.parse_fn().unwrap();
         let mut t = ConcatSelHoistTransform;
         let cand = t.find_candidates(&f).pop().expect("candidate");
-        let target = match cand.clone() {
+        let target = match cand.location.clone() {
             TransformLocation::Node(nr) => nr,
             _ => unreachable!(),
         };
-        t.apply(&mut f, &cand).expect("apply");
+        t.apply(&mut f, &cand.location).expect("apply");
         assert!(matches!(
             f.get_node(target).payload,
             NodePayload::Sel { .. }
@@ -263,11 +270,11 @@ mod tests {
         let mut f = parser.parse_fn().unwrap();
         let mut t = ConcatSelHoistTransform;
         let cand = t.find_candidates(&f).pop().expect("candidate");
-        let target = match cand.clone() {
+        let target = match cand.location.clone() {
             TransformLocation::Node(nr) => nr,
             _ => unreachable!(),
         };
-        t.apply(&mut f, &cand).expect("apply");
+        t.apply(&mut f, &cand.location).expect("apply");
         assert!(matches!(
             f.get_node(target).payload,
             NodePayload::Nary(NaryOp::Concat, _)

--- a/xlsynth-mcmc-pir/src/transforms/const_shll_concat_zero_fold.rs
+++ b/xlsynth-mcmc-pir/src/transforms/const_shll_concat_zero_fold.rs
@@ -63,8 +63,9 @@ impl PirTransform for ConstShllConcatZeroFoldTransform {
         PirTransformKind::ConstShllConcatZeroFold
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 // concat(bit_slice(x, 0, w-k), 0_k) -> shll(x, k)
@@ -96,7 +97,10 @@ impl PirTransform for ConstShllConcatZeroFoldTransform {
                     if Self::bits_width(f, arg) != Some(w) {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
 
                 // shll(x, k) -> concat(bit_slice(x, 0, w-k), 0_k) for constant k
@@ -117,7 +121,10 @@ impl PirTransform for ConstShllConcatZeroFoldTransform {
                     if k_usize == 0 || k_usize >= w {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 _ => {}
             }
@@ -256,9 +263,5 @@ impl PirTransform for ConstShllConcatZeroFoldTransform {
                 "ConstShllConcatZeroFoldTransform: expected concat(...) or shll(...)".to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/csa_fuse_into_consumer.rs
+++ b/xlsynth-mcmc-pir/src/transforms/csa_fuse_into_consumer.rs
@@ -189,8 +189,9 @@ impl PirTransform for CsaFuseIntoConsumerTransform {
         PirTransformKind::CsaFuseIntoConsumer
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             if !matches!(f.get_node(nr).payload, NodePayload::Binop(Binop::Add, _, _)) {
                 continue;
@@ -226,7 +227,10 @@ impl PirTransform for CsaFuseIntoConsumerTransform {
                 }
             }
             if matches {
-                out.push(TransformLocation::Node(nr));
+                out.push(TransformCandidate {
+                    location: TransformLocation::Node(nr),
+                    always_equivalent,
+                });
             }
         }
         out

--- a/xlsynth-mcmc-pir/src/transforms/csa_rebalance_triplet.rs
+++ b/xlsynth-mcmc-pir/src/transforms/csa_rebalance_triplet.rs
@@ -194,8 +194,9 @@ impl PirTransform for CsaRebalanceTripletTransform {
         PirTransformKind::CsaRebalanceTriplet
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             if matches!(f.get_node(nr).payload, NodePayload::Binop(Binop::Add, _, _)) {
                 // `bits[0]` is permitted in the IR, but this transform materializes a
@@ -205,7 +206,10 @@ impl PirTransform for CsaRebalanceTripletTransform {
                     continue;
                 }
                 if Self::match_add_chain(f, nr).is_some() || Self::match_csa_add(f, nr).is_some() {
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
             }
         }

--- a/xlsynth-mcmc-pir/src/transforms/dual_sel_hoist.rs
+++ b/xlsynth-mcmc-pir/src/transforms/dual_sel_hoist.rs
@@ -2,7 +2,7 @@
 
 use xlsynth_pir::ir::{Binop, Fn as IrFn, Node, NodePayload, NodeRef, Type};
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 /// Hoists/folds a binary op through two 2-case sels sharing the same selector.
 ///
@@ -64,8 +64,9 @@ impl PirTransform for DualSelHoistTransform {
         PirTransformKind::DualSelHoist
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -109,7 +110,10 @@ impl PirTransform for DualSelHoistTransform {
                     {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 NodePayload::Sel {
                     selector,
@@ -142,7 +146,10 @@ impl PirTransform for DualSelHoistTransform {
                     {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 _ => {}
             }
@@ -241,11 +248,11 @@ mod tests {
         let mut f = parser.parse_fn().unwrap();
         let mut t = DualSelHoistTransform;
         let cand = t.find_candidates(&f).pop().expect("candidate");
-        let target = match cand.clone() {
+        let target = match cand.location.clone() {
             TransformLocation::Node(nr) => nr,
             _ => unreachable!(),
         };
-        t.apply(&mut f, &cand).expect("apply");
+        t.apply(&mut f, &cand.location).expect("apply");
         assert!(matches!(
             f.get_node(target).payload,
             NodePayload::Sel { .. }
@@ -263,11 +270,11 @@ mod tests {
         let mut f = parser.parse_fn().unwrap();
         let mut t = DualSelHoistTransform;
         let cand = t.find_candidates(&f).pop().expect("candidate");
-        let target = match cand.clone() {
+        let target = match cand.location.clone() {
             TransformLocation::Node(nr) => nr,
             _ => unreachable!(),
         };
-        t.apply(&mut f, &cand).expect("apply");
+        t.apply(&mut f, &cand.location).expect("apply");
         assert!(matches!(
             f.get_node(target).payload,
             NodePayload::Binop(Binop::Add, _, _)

--- a/xlsynth-mcmc-pir/src/transforms/eq_ne_add_literal_shift.rs
+++ b/xlsynth-mcmc-pir/src/transforms/eq_ne_add_literal_shift.rs
@@ -171,8 +171,9 @@ impl PirTransform for EqNeAddLiteralShiftTransform {
         PirTransformKind::EqNeAddLiteralShift
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match node.payload {
@@ -182,7 +183,10 @@ impl PirTransform for EqNeAddLiteralShiftTransform {
                     if Self::add_with_literal_parts(f, lhs).is_some()
                         || Self::add_with_literal_parts(f, rhs).is_some()
                     {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                         continue;
                     }
                     // Fold direction:
@@ -190,7 +194,10 @@ impl PirTransform for EqNeAddLiteralShiftTransform {
                     if Self::sub_with_literal_parts(f, lhs).is_some()
                         || Self::sub_with_literal_parts(f, rhs).is_some()
                     {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -220,9 +227,5 @@ impl PirTransform for EqNeAddLiteralShiftTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/eq_sel_distribute.rs
+++ b/xlsynth-mcmc-pir/src/transforms/eq_sel_distribute.rs
@@ -102,8 +102,9 @@ impl PirTransform for EqSelDistributeTransform {
         PirTransformKind::EqSelDistribute
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -118,7 +119,10 @@ impl PirTransform for EqSelDistributeTransform {
                             && Self::type_of(f, a) == Self::type_of(f, *rhs)
                             && Self::type_of(f, b) == Self::type_of(f, *rhs)
                         {
-                            out.push(TransformLocation::Node(nr));
+                            out.push(TransformCandidate {
+                                location: TransformLocation::Node(nr),
+                                always_equivalent,
+                            });
                             continue;
                         }
                     }
@@ -127,7 +131,10 @@ impl PirTransform for EqSelDistributeTransform {
                             && Self::type_of(f, a) == Self::type_of(f, *lhs)
                             && Self::type_of(f, b) == Self::type_of(f, *lhs)
                         {
-                            out.push(TransformLocation::Node(nr));
+                            out.push(TransformCandidate {
+                                location: TransformLocation::Node(nr),
+                                always_equivalent,
+                            });
                         }
                     }
                 }
@@ -146,7 +153,10 @@ impl PirTransform for EqSelDistributeTransform {
                     if Self::choose_fold_candidate(f, Binop::Eq, cases[0], cases[1]).is_some()
                         || Self::choose_fold_candidate(f, Binop::Ne, cases[0], cases[1]).is_some()
                     {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -295,9 +305,5 @@ impl PirTransform for EqSelDistributeTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/eq_zero_or_reduce.rs
+++ b/xlsynth-mcmc-pir/src/transforms/eq_zero_or_reduce.rs
@@ -68,8 +68,9 @@ impl PirTransform for EqZeroOrReduceTransform {
         PirTransformKind::EqZeroOrReduce
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Binop(Binop::Eq, lhs, rhs) => {
@@ -82,7 +83,10 @@ impl PirTransform for EqZeroOrReduceTransform {
                     if Self::is_zero_literal_node(f, *lhs, w)
                         || Self::is_zero_literal_node(f, *rhs, w)
                     {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 NodePayload::Unop(Unop::Not, arg) => {
@@ -90,7 +94,10 @@ impl PirTransform for EqZeroOrReduceTransform {
                         f.get_node(*arg).payload,
                         NodePayload::Unop(Unop::OrReduce, _)
                     ) {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -153,9 +160,5 @@ impl PirTransform for EqZeroOrReduceTransform {
             }
             _ => Err("EqZeroOrReduceTransform: expected eq(x,0) or not(or_reduce(x))".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/ext_nary_add_rewrites.rs
+++ b/xlsynth-mcmc-pir/src/transforms/ext_nary_add_rewrites.rs
@@ -279,10 +279,62 @@ fn term_payload_matches_nested_ext_nary_add(
     }
 }
 
+/// Returns whether absorbing a resize op into a term keeps the same value for
+/// all inputs without needing an oracle.
+fn absorb_extend_candidate_is_always_equivalent(
+    f: &IrFn,
+    outer_term: &ExtNaryAddTerm,
+    inner_signed: bool,
+    inner_arg: NodeRef,
+    out_w: usize,
+) -> bool {
+    let Some(inner_resize_w) = bits_width(&f.get_node(outer_term.operand).ty) else {
+        return false;
+    };
+    if inner_resize_w >= out_w {
+        return true;
+    }
+
+    let Some(inner_arg_w) = bits_width(&f.get_node(inner_arg).ty) else {
+        return false;
+    };
+    inner_arg_w == 0
+        || (inner_arg_w <= inner_resize_w
+            && (outer_term.signed == inner_signed
+                || (!inner_signed && inner_resize_w > inner_arg_w)))
+}
+
+fn absorb_neg_candidate_is_always_equivalent(
+    f: &IrFn,
+    term: &ExtNaryAddTerm,
+    out_w: usize,
+) -> bool {
+    bits_width(&f.get_node(term.operand).ty)
+        .is_some_and(|operand_w| operand_w == 0 || operand_w >= out_w)
+}
+
+fn absorb_binop_candidate_is_always_equivalent(
+    f: &IrFn,
+    term: &ExtNaryAddTerm,
+    out_w: usize,
+) -> bool {
+    bits_width(&f.get_node(term.operand).ty)
+        .is_some_and(|operand_w| operand_w == 0 || operand_w >= out_w)
+}
+
+fn combine_nary_add_candidate_is_always_equivalent(
+    f: &IrFn,
+    term: &ExtNaryAddTerm,
+    out_w: usize,
+) -> bool {
+    ext_nary_add_result_width(f, term.operand).is_some_and(|inner_w| inner_w >= out_w)
+}
+
 fn change_ext_nary_add_candidates(
     f: &IrFn,
     target_arch: ExtNaryAddArchitecture,
-) -> Vec<TransformLocation> {
+    always_equivalent: bool,
+) -> Vec<TransformCandidate> {
     f.node_refs()
         .into_iter()
         .filter(|nr| {
@@ -294,7 +346,10 @@ fn change_ext_nary_add_candidates(
                 } if current_arch != target_arch
             )
         })
-        .map(TransformLocation::Node)
+        .map(|nr| TransformCandidate {
+            location: TransformLocation::Node(nr),
+            always_equivalent,
+        })
         .collect()
 }
 
@@ -332,7 +387,8 @@ impl PirTransform for AddToExtNaryAddTransform {
         PirTransformKind::AddToExtNaryAdd
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
         f.node_refs()
             .into_iter()
             .filter(|nr| {
@@ -344,7 +400,10 @@ impl PirTransform for AddToExtNaryAddTransform {
                 };
                 is_bits_w(f, lhs, w) && is_bits_w(f, rhs, w)
             })
-            .map(TransformLocation::Node)
+            .map(|nr| TransformCandidate {
+                location: TransformLocation::Node(nr),
+                always_equivalent,
+            })
             .collect()
     }
 
@@ -394,7 +453,8 @@ impl PirTransform for SubToExtNaryAddTransform {
         PirTransformKind::SubToExtNaryAdd
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
         f.node_refs()
             .into_iter()
             .filter(|nr| {
@@ -406,7 +466,10 @@ impl PirTransform for SubToExtNaryAddTransform {
                 };
                 is_bits_w(f, lhs, w) && is_bits_w(f, rhs, w)
             })
-            .map(TransformLocation::Node)
+            .map(|nr| TransformCandidate {
+                location: TransformLocation::Node(nr),
+                always_equivalent,
+            })
             .collect()
     }
 
@@ -456,8 +519,9 @@ impl PirTransform for ChangeExtNaryAddToRippleCarryTransform {
         PirTransformKind::ChangeExtNaryAddToRippleCarry
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        change_ext_nary_add_candidates(f, ExtNaryAddArchitecture::RippleCarry)
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        change_ext_nary_add_candidates(f, ExtNaryAddArchitecture::RippleCarry, always_equivalent)
     }
 
     fn apply(&self, f: &mut IrFn, loc: &TransformLocation) -> Result<(), String> {
@@ -475,8 +539,9 @@ impl PirTransform for ChangeExtNaryAddToBrentKungTransform {
         PirTransformKind::ChangeExtNaryAddToBrentKung
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        change_ext_nary_add_candidates(f, ExtNaryAddArchitecture::BrentKung)
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        change_ext_nary_add_candidates(f, ExtNaryAddArchitecture::BrentKung, always_equivalent)
     }
 
     fn apply(&self, f: &mut IrFn, loc: &TransformLocation) -> Result<(), String> {
@@ -494,8 +559,9 @@ impl PirTransform for ChangeExtNaryAddToKoggeStoneTransform {
         PirTransformKind::ChangeExtNaryAddToKoggeStone
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        change_ext_nary_add_candidates(f, ExtNaryAddArchitecture::KoggeStone)
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        change_ext_nary_add_candidates(f, ExtNaryAddArchitecture::KoggeStone, always_equivalent)
     }
 
     fn apply(&self, f: &mut IrFn, loc: &TransformLocation) -> Result<(), String> {
@@ -513,11 +579,15 @@ impl PirTransform for BinaryExtNaryAddToAddTransform {
         PirTransformKind::BinaryExtNaryAddToAdd
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
         f.node_refs()
             .into_iter()
             .filter(|nr| binary_ext_nary_add_operands_matching_result(f, *nr).is_some())
-            .map(TransformLocation::Node)
+            .map(|nr| TransformCandidate {
+                location: TransformLocation::Node(nr),
+                always_equivalent,
+            })
             .collect()
     }
 
@@ -546,15 +616,27 @@ impl PirTransform for AbsorbExtendIntoExtNaryAddTermTransform {
         PirTransformKind::AbsorbExtendIntoExtNaryAddTerm
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::ExtNaryAdd { terms, .. } = &f.get_node(nr).payload else {
                 continue;
             };
+            let Some(out_w) = ext_nary_add_result_width(f, nr) else {
+                continue;
+            };
             for (term_index, term) in terms.iter().enumerate() {
-                if term_payload_matches_resize(f, term).is_some() {
-                    out.push(make_term_location(nr, term_index, term.operand));
+                if let Some((inner_signed, inner_arg)) = term_payload_matches_resize(f, term) {
+                    out.push(TransformCandidate {
+                        location: make_term_location(nr, term_index, term.operand),
+                        always_equivalent: absorb_extend_candidate_is_always_equivalent(
+                            f,
+                            term,
+                            inner_signed,
+                            inner_arg,
+                            out_w,
+                        ),
+                    });
                 }
             }
         }
@@ -577,10 +659,6 @@ impl PirTransform for AbsorbExtendIntoExtNaryAddTermTransform {
         f.get_node_mut(nr).payload = NodePayload::ExtNaryAdd { terms, arch };
         Ok(())
     }
-
-    fn always_equivalent(&self) -> bool {
-        false
-    }
 }
 
 impl PirTransform for AbsorbNegIntoExtNaryAddTermTransform {
@@ -588,15 +666,23 @@ impl PirTransform for AbsorbNegIntoExtNaryAddTermTransform {
         PirTransformKind::AbsorbNegIntoExtNaryAddTerm
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::ExtNaryAdd { terms, .. } = &f.get_node(nr).payload else {
                 continue;
             };
+            let Some(out_w) = ext_nary_add_result_width(f, nr) else {
+                continue;
+            };
             for (term_index, term) in terms.iter().enumerate() {
                 if term_payload_matches_neg(f, term).is_some() {
-                    out.push(make_term_location(nr, term_index, term.operand));
+                    out.push(TransformCandidate {
+                        location: make_term_location(nr, term_index, term.operand),
+                        always_equivalent: absorb_neg_candidate_is_always_equivalent(
+                            f, term, out_w,
+                        ),
+                    });
                 }
             }
         }
@@ -618,10 +704,6 @@ impl PirTransform for AbsorbNegIntoExtNaryAddTermTransform {
         f.get_node_mut(nr).payload = NodePayload::ExtNaryAdd { terms, arch };
         Ok(())
     }
-
-    fn always_equivalent(&self) -> bool {
-        false
-    }
 }
 
 impl PirTransform for AbsorbAddOperandIntoExtNaryAddTransform {
@@ -629,15 +711,23 @@ impl PirTransform for AbsorbAddOperandIntoExtNaryAddTransform {
         PirTransformKind::AbsorbAddOperandIntoExtNaryAdd
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::ExtNaryAdd { terms, .. } = &f.get_node(nr).payload else {
                 continue;
             };
+            let Some(out_w) = ext_nary_add_result_width(f, nr) else {
+                continue;
+            };
             for (term_index, term) in terms.iter().enumerate() {
                 if term_payload_matches_add(f, term).is_some() {
-                    out.push(make_term_location(nr, term_index, term.operand));
+                    out.push(TransformCandidate {
+                        location: make_term_location(nr, term_index, term.operand),
+                        always_equivalent: absorb_binop_candidate_is_always_equivalent(
+                            f, term, out_w,
+                        ),
+                    });
                 }
             }
         }
@@ -674,10 +764,6 @@ impl PirTransform for AbsorbAddOperandIntoExtNaryAddTransform {
         f.get_node_mut(nr).payload = NodePayload::ExtNaryAdd { terms, arch };
         Ok(())
     }
-
-    fn always_equivalent(&self) -> bool {
-        false
-    }
 }
 
 impl PirTransform for AbsorbSubOperandIntoExtNaryAddTransform {
@@ -685,15 +771,23 @@ impl PirTransform for AbsorbSubOperandIntoExtNaryAddTransform {
         PirTransformKind::AbsorbSubOperandIntoExtNaryAdd
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::ExtNaryAdd { terms, .. } = &f.get_node(nr).payload else {
                 continue;
             };
+            let Some(out_w) = ext_nary_add_result_width(f, nr) else {
+                continue;
+            };
             for (term_index, term) in terms.iter().enumerate() {
                 if term_payload_matches_sub(f, term).is_some() {
-                    out.push(make_term_location(nr, term_index, term.operand));
+                    out.push(TransformCandidate {
+                        location: make_term_location(nr, term_index, term.operand),
+                        always_equivalent: absorb_binop_candidate_is_always_equivalent(
+                            f, term, out_w,
+                        ),
+                    });
                 }
             }
         }
@@ -730,10 +824,6 @@ impl PirTransform for AbsorbSubOperandIntoExtNaryAddTransform {
         f.get_node_mut(nr).payload = NodePayload::ExtNaryAdd { terms, arch };
         Ok(())
     }
-
-    fn always_equivalent(&self) -> bool {
-        false
-    }
 }
 
 impl PirTransform for ExtractNegateFromExtNaryAddTermTransform {
@@ -741,15 +831,23 @@ impl PirTransform for ExtractNegateFromExtNaryAddTermTransform {
         PirTransformKind::ExtractNegateFromExtNaryAddTerm
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::ExtNaryAdd { terms, .. } = &f.get_node(nr).payload else {
                 continue;
             };
+            let Some(out_w) = ext_nary_add_result_width(f, nr) else {
+                continue;
+            };
             for (term_index, term) in terms.iter().enumerate() {
                 if term.negated {
-                    out.push(make_term_location(nr, term_index, term.operand));
+                    out.push(TransformCandidate {
+                        location: make_term_location(nr, term_index, term.operand),
+                        always_equivalent: absorb_neg_candidate_is_always_equivalent(
+                            f, term, out_w,
+                        ),
+                    });
                 }
             }
         }
@@ -776,10 +874,6 @@ impl PirTransform for ExtractNegateFromExtNaryAddTermTransform {
         f.get_node_mut(nr).payload = NodePayload::ExtNaryAdd { terms, arch };
         Ok(())
     }
-
-    fn always_equivalent(&self) -> bool {
-        false
-    }
 }
 
 impl PirTransform for ExtractAddFromNaryAddTermsTransform {
@@ -787,18 +881,18 @@ impl PirTransform for ExtractAddFromNaryAddTermsTransform {
         PirTransformKind::ExtractAddFromNaryAddTerms
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::ExtNaryAdd { terms, .. } = &f.get_node(nr).payload else {
                 continue;
             };
             for left_index in 0..terms.len().saturating_sub(1) {
-                out.push(make_term_location(
-                    nr,
-                    left_index,
-                    terms[left_index].operand,
-                ));
+                out.push(TransformCandidate {
+                    location: make_term_location(nr, left_index, terms[left_index].operand),
+                    always_equivalent,
+                });
             }
         }
         out
@@ -827,10 +921,6 @@ impl PirTransform for ExtractAddFromNaryAddTermsTransform {
         f.get_node_mut(nr).payload = NodePayload::ExtNaryAdd { terms, arch };
         Ok(())
     }
-
-    fn always_equivalent(&self) -> bool {
-        true
-    }
 }
 
 impl PirTransform for CombineNaryAddsTransform {
@@ -838,15 +928,23 @@ impl PirTransform for CombineNaryAddsTransform {
         PirTransformKind::CombineNaryAdds
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::ExtNaryAdd { terms, .. } = &f.get_node(nr).payload else {
                 continue;
             };
+            let Some(out_w) = ext_nary_add_result_width(f, nr) else {
+                continue;
+            };
             for (term_index, term) in terms.iter().enumerate() {
                 if term_payload_matches_nested_ext_nary_add(f, term).is_some() {
-                    out.push(make_term_location(nr, term_index, term.operand));
+                    out.push(TransformCandidate {
+                        location: make_term_location(nr, term_index, term.operand),
+                        always_equivalent: combine_nary_add_candidate_is_always_equivalent(
+                            f, term, out_w,
+                        ),
+                    });
                 }
             }
         }
@@ -877,10 +975,6 @@ impl PirTransform for CombineNaryAddsTransform {
         };
         Ok(())
     }
-
-    fn always_equivalent(&self) -> bool {
-        false
-    }
 }
 
 #[cfg(test)]
@@ -900,15 +994,15 @@ mod tests {
     }
 
     fn find_term_candidate(
-        candidates: &[TransformLocation],
+        candidates: &[TransformCandidate],
         node: NodeRef,
         term_index: usize,
-    ) -> TransformLocation {
+    ) -> TransformCandidate {
         candidates
             .iter()
-            .find(|loc| {
+            .find(|candidate| {
                 matches!(
-                    loc,
+                    &candidate.location,
                     TransformLocation::RewireOperand {
                         node: loc_node,
                         operand_slot,
@@ -978,7 +1072,11 @@ mod tests {
 
         let candidates = t.find_candidates(&f);
         assert_eq!(candidates.len(), 1);
-        assert!(matches!(candidates[0], TransformLocation::Node(nr) if nr == sub_ref));
+        assert!(matches!(
+            candidates[0].location,
+            TransformLocation::Node(nr) if nr == sub_ref
+        ));
+        assert!(candidates[0].always_equivalent);
         t.apply(&mut f, &TransformLocation::Node(sub_ref))
             .expect("apply");
 
@@ -993,7 +1091,6 @@ mod tests {
             }
             other => panic!("expected ext_nary_add after rewrite, got {other:?}"),
         }
-        assert!(t.always_equivalent());
     }
 
     #[test]
@@ -1010,7 +1107,10 @@ mod tests {
         let mut t = ChangeExtNaryAddToRippleCarryTransform;
         let candidates = t.find_candidates(&f);
         assert_eq!(candidates.len(), 1);
-        assert!(matches!(candidates[0], TransformLocation::Node(nr) if nr == nary_ref));
+        assert!(matches!(
+            candidates[0].location,
+            TransformLocation::Node(nr) if nr == nary_ref
+        ));
         t.apply(&mut f, &TransformLocation::Node(nary_ref))
             .expect("apply");
 
@@ -1036,7 +1136,10 @@ mod tests {
         let mut t = ChangeExtNaryAddToBrentKungTransform;
         let candidates = t.find_candidates(&f);
         assert_eq!(candidates.len(), 1);
-        assert!(matches!(candidates[0], TransformLocation::Node(nr) if nr == nary_ref));
+        assert!(matches!(
+            candidates[0].location,
+            TransformLocation::Node(nr) if nr == nary_ref
+        ));
         t.apply(&mut f, &TransformLocation::Node(nary_ref))
             .expect("apply");
 
@@ -1062,7 +1165,10 @@ mod tests {
         let mut t = ChangeExtNaryAddToKoggeStoneTransform;
         let candidates = t.find_candidates(&f);
         assert_eq!(candidates.len(), 1);
-        assert!(matches!(candidates[0], TransformLocation::Node(nr) if nr == nary_ref));
+        assert!(matches!(
+            candidates[0].location,
+            TransformLocation::Node(nr) if nr == nary_ref
+        ));
         t.apply(&mut f, &TransformLocation::Node(nary_ref))
             .expect("apply");
 
@@ -1141,8 +1247,9 @@ mod tests {
         });
         let mut t = AbsorbExtendIntoExtNaryAddTermTransform;
         let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+        assert!(candidate.always_equivalent);
 
-        t.apply(&mut f, &candidate).expect("apply");
+        t.apply(&mut f, &candidate.location).expect("apply");
 
         match &f.get_node(nary_ref).payload {
             NodePayload::ExtNaryAdd { terms, .. } => {
@@ -1152,7 +1259,6 @@ mod tests {
             }
             other => panic!("expected ext_nary_add after rewrite, got {other:?}"),
         }
-        assert!(!t.always_equivalent());
     }
 
     #[test]
@@ -1170,8 +1276,9 @@ mod tests {
         });
         let mut t = AbsorbExtendIntoExtNaryAddTermTransform;
         let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+        assert!(candidate.always_equivalent);
 
-        t.apply(&mut f, &candidate).expect("apply");
+        t.apply(&mut f, &candidate.location).expect("apply");
 
         match &f.get_node(nary_ref).payload {
             NodePayload::ExtNaryAdd { terms, .. } => {
@@ -1181,7 +1288,24 @@ mod tests {
             }
             other => panic!("expected ext_nary_add after rewrite, got {other:?}"),
         }
-        assert!(!t.always_equivalent());
+    }
+
+    #[test]
+    fn absorb_extend_into_ext_nary_add_term_marks_signed_mismatch_growth_unsafe() {
+        let ir_text = r#"fn t(a: bits[4] id=1, b: bits[8] id=2) -> bits[8] {
+  sign_ext.3: bits[6] = sign_ext(a, new_bit_count=6, id=3)
+  ret ext_nary_add.4: bits[8] = ext_nary_add(sign_ext.3, b, signed=[false, false], negated=[false, false], arch=brent_kung, id=4)
+}"#;
+        let mut parser = ir_parser::Parser::new(ir_text);
+        let f = parser.parse_fn().unwrap();
+        let nary_ref = find_node_ref(&f, |payload| {
+            matches!(payload, NodePayload::ExtNaryAdd { .. })
+        });
+        let mut t = AbsorbExtendIntoExtNaryAddTermTransform;
+
+        let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+
+        assert!(!candidate.always_equivalent);
     }
 
     #[test]
@@ -1198,8 +1322,9 @@ mod tests {
         });
         let mut t = AbsorbNegIntoExtNaryAddTermTransform;
         let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+        assert!(candidate.always_equivalent);
 
-        t.apply(&mut f, &candidate).expect("apply");
+        t.apply(&mut f, &candidate.location).expect("apply");
 
         match &f.get_node(nary_ref).payload {
             NodePayload::ExtNaryAdd { terms, .. } => {
@@ -1208,7 +1333,24 @@ mod tests {
             }
             other => panic!("expected ext_nary_add after rewrite, got {other:?}"),
         }
-        assert!(!t.always_equivalent());
+    }
+
+    #[test]
+    fn absorb_neg_into_ext_nary_add_term_marks_narrow_neg_unsafe() {
+        let ir_text = r#"fn t(a: bits[4] id=1, b: bits[8] id=2) -> bits[8] {
+  neg.3: bits[4] = neg(a, id=3)
+  ret ext_nary_add.4: bits[8] = ext_nary_add(neg.3, b, signed=[true, false], negated=[false, false], arch=brent_kung, id=4)
+}"#;
+        let mut parser = ir_parser::Parser::new(ir_text);
+        let f = parser.parse_fn().unwrap();
+        let nary_ref = find_node_ref(&f, |payload| {
+            matches!(payload, NodePayload::ExtNaryAdd { .. })
+        });
+        let mut t = AbsorbNegIntoExtNaryAddTermTransform;
+
+        let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+
+        assert!(!candidate.always_equivalent);
     }
 
     #[test]
@@ -1226,8 +1368,9 @@ mod tests {
         });
         let mut t = AbsorbAddOperandIntoExtNaryAddTransform;
         let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+        assert!(candidate.always_equivalent);
 
-        t.apply(&mut f, &candidate).expect("apply");
+        t.apply(&mut f, &candidate.location).expect("apply");
 
         match &f.get_node(nary_ref).payload {
             NodePayload::ExtNaryAdd { terms, .. } => {
@@ -1239,7 +1382,24 @@ mod tests {
             }
             other => panic!("expected ext_nary_add after rewrite, got {other:?}"),
         }
-        assert!(!t.always_equivalent());
+    }
+
+    #[test]
+    fn absorb_add_operand_into_ext_nary_add_marks_narrow_add_unsafe() {
+        let ir_text = r#"fn t(a: bits[4] id=1, b: bits[4] id=2, c: bits[8] id=3) -> bits[8] {
+  add.4: bits[4] = add(a, b, id=4)
+  ret ext_nary_add.5: bits[8] = ext_nary_add(add.4, c, signed=[false, false], negated=[false, false], arch=brent_kung, id=5)
+}"#;
+        let mut parser = ir_parser::Parser::new(ir_text);
+        let f = parser.parse_fn().unwrap();
+        let nary_ref = find_node_ref(&f, |payload| {
+            matches!(payload, NodePayload::ExtNaryAdd { .. })
+        });
+        let mut t = AbsorbAddOperandIntoExtNaryAddTransform;
+
+        let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+
+        assert!(!candidate.always_equivalent);
     }
 
     #[test]
@@ -1259,8 +1419,9 @@ mod tests {
         let candidates = t.find_candidates(&f);
         assert_eq!(candidates.len(), 1);
         let candidate = find_term_candidate(&candidates, nary_ref, 0);
+        assert!(candidate.always_equivalent);
 
-        t.apply(&mut f, &candidate).expect("apply");
+        t.apply(&mut f, &candidate.location).expect("apply");
 
         match &f.get_node(nary_ref).payload {
             NodePayload::ExtNaryAdd { terms, .. } => {
@@ -1273,7 +1434,6 @@ mod tests {
             }
             other => panic!("expected ext_nary_add after rewrite, got {other:?}"),
         }
-        assert!(!t.always_equivalent());
     }
 
     #[test]
@@ -1291,8 +1451,9 @@ mod tests {
         });
         let mut t = AbsorbSubOperandIntoExtNaryAddTransform;
         let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+        assert!(candidate.always_equivalent);
 
-        t.apply(&mut f, &candidate).expect("apply");
+        t.apply(&mut f, &candidate.location).expect("apply");
 
         match &f.get_node(nary_ref).payload {
             NodePayload::ExtNaryAdd { terms, .. } => {
@@ -1304,6 +1465,24 @@ mod tests {
             }
             other => panic!("expected ext_nary_add after rewrite, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn absorb_sub_operand_into_ext_nary_add_marks_narrow_sub_unsafe() {
+        let ir_text = r#"fn t(a: bits[4] id=1, b: bits[4] id=2, c: bits[8] id=3) -> bits[8] {
+  sub.4: bits[4] = sub(a, b, id=4)
+  ret ext_nary_add.5: bits[8] = ext_nary_add(sub.4, c, signed=[false, false], negated=[false, false], arch=brent_kung, id=5)
+}"#;
+        let mut parser = ir_parser::Parser::new(ir_text);
+        let f = parser.parse_fn().unwrap();
+        let nary_ref = find_node_ref(&f, |payload| {
+            matches!(payload, NodePayload::ExtNaryAdd { .. })
+        });
+        let mut t = AbsorbSubOperandIntoExtNaryAddTransform;
+
+        let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+
+        assert!(!candidate.always_equivalent);
     }
 
     #[test]
@@ -1319,8 +1498,9 @@ mod tests {
         });
         let mut t = ExtractNegateFromExtNaryAddTermTransform;
         let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+        assert!(candidate.always_equivalent);
 
-        t.apply(&mut f, &candidate).expect("apply");
+        t.apply(&mut f, &candidate.location).expect("apply");
 
         match &f.get_node(nary_ref).payload {
             NodePayload::ExtNaryAdd { terms, .. } => {
@@ -1332,7 +1512,23 @@ mod tests {
             }
             other => panic!("expected ext_nary_add after rewrite, got {other:?}"),
         }
-        assert!(!t.always_equivalent());
+    }
+
+    #[test]
+    fn extract_negate_from_ext_nary_add_term_marks_narrow_term_unsafe() {
+        let ir_text = r#"fn t(a: bits[4] id=1, b: bits[8] id=2) -> bits[8] {
+  ret ext_nary_add.3: bits[8] = ext_nary_add(a, b, signed=[true, false], negated=[true, false], arch=brent_kung, id=3)
+}"#;
+        let mut parser = ir_parser::Parser::new(ir_text);
+        let f = parser.parse_fn().unwrap();
+        let nary_ref = find_node_ref(&f, |payload| {
+            matches!(payload, NodePayload::ExtNaryAdd { .. })
+        });
+        let mut t = ExtractNegateFromExtNaryAddTermTransform;
+
+        let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+
+        assert!(!candidate.always_equivalent);
     }
 
     #[test]
@@ -1349,8 +1545,9 @@ mod tests {
         });
         let mut t = ExtractAddFromNaryAddTermsTransform;
         let candidate = find_term_candidate(&t.find_candidates(&f), nary_ref, 0);
+        assert!(candidate.always_equivalent);
 
-        t.apply(&mut f, &candidate).expect("apply");
+        t.apply(&mut f, &candidate.location).expect("apply");
 
         match &f.get_node(nary_ref).payload {
             NodePayload::ExtNaryAdd { terms, arch } => {
@@ -1389,7 +1586,6 @@ mod tests {
             let got_rewritten = expect_success_value(eval_fn(&f, sample));
             assert_eq!(got_original, got_rewritten);
         }
-        assert!(t.always_equivalent());
     }
 
     #[test]
@@ -1414,8 +1610,9 @@ mod tests {
         });
         let mut t = CombineNaryAddsTransform;
         let candidate = find_term_candidate(&t.find_candidates(&f), outer_ref, 0);
+        assert!(candidate.always_equivalent);
 
-        t.apply(&mut f, &candidate).expect("apply");
+        t.apply(&mut f, &candidate.location).expect("apply");
 
         match &f.get_node(outer_ref).payload {
             NodePayload::ExtNaryAdd { terms, arch } => {
@@ -1430,6 +1627,29 @@ mod tests {
             }
             other => panic!("expected ext_nary_add after rewrite, got {other:?}"),
         }
-        assert!(!t.always_equivalent());
+    }
+
+    #[test]
+    fn combine_nary_adds_marks_narrow_inner_nary_add_unsafe() {
+        let ir_text = r#"fn t(a: bits[4] id=1, b: bits[4] id=2, c: bits[8] id=3) -> bits[8] {
+  ext_nary_add.4: bits[4] = ext_nary_add(a, b, signed=[false, false], negated=[false, false], arch=ripple_carry, id=4)
+  ret ext_nary_add.5: bits[8] = ext_nary_add(ext_nary_add.4, c, signed=[false, false], negated=[false, false], arch=brent_kung, id=5)
+}"#;
+        let mut parser = ir_parser::Parser::new(ir_text);
+        let f = parser.parse_fn().unwrap();
+        let outer_ref = find_node_ref(&f, |payload| {
+            matches!(
+                payload,
+                NodePayload::ExtNaryAdd {
+                    arch: Some(ExtNaryAddArchitecture::BrentKung),
+                    ..
+                }
+            )
+        });
+        let mut t = CombineNaryAddsTransform;
+
+        let candidate = find_term_candidate(&t.find_candidates(&f), outer_ref, 0);
+
+        assert!(!candidate.always_equivalent);
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/mask_operand_bit.rs
+++ b/xlsynth-mcmc-pir/src/transforms/mask_operand_bit.rs
@@ -4,7 +4,7 @@ use xlsynth::{IrBits, IrValue};
 use xlsynth_pir::ir::{Fn as IrFn, NaryOp, Node, NodePayload, NodeRef, Type};
 use xlsynth_pir::ir_utils::remap_payload_with;
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 #[derive(Debug)]
 enum MaskBitPosition {
@@ -154,8 +154,12 @@ fn apply_mask_transform(
     Ok(())
 }
 
-fn find_candidates_for_mask_transform(f: &IrFn, max_candidates: usize) -> Vec<TransformLocation> {
-    let mut out: Vec<TransformLocation> = Vec::new();
+fn find_candidates_for_mask_transform(
+    f: &IrFn,
+    max_candidates: usize,
+    always_equivalent: bool,
+) -> Vec<TransformCandidate> {
+    let mut out = Vec::<TransformCandidate>::new();
     for i in 0..f.nodes.len() {
         if out.len() >= max_candidates {
             break;
@@ -167,10 +171,13 @@ fn find_candidates_for_mask_transform(f: &IrFn, max_candidates: usize) -> Vec<Tr
                 break;
             }
             if matches!(bits_width(f, dep), Some(w) if w >= 2) {
-                out.push(TransformLocation::RewireOperand {
-                    node: node_ref,
-                    operand_slot: slot,
-                    new_operand: dep, // placeholder; ignored by this transform
+                out.push(TransformCandidate {
+                    location: TransformLocation::RewireOperand {
+                        node: node_ref,
+                        operand_slot: slot,
+                        new_operand: dep, // placeholder; ignored by this transform
+                    },
+                    always_equivalent,
                 });
             }
         }
@@ -188,16 +195,13 @@ impl PirTransform for MaskOperandHighBitTransform {
         PirTransformKind::MaskOperandHighBit
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        find_candidates_for_mask_transform(f, 2000)
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = false;
+        find_candidates_for_mask_transform(f, 2000, always_equivalent)
     }
 
     fn apply(&self, f: &mut IrFn, loc: &TransformLocation) -> Result<(), String> {
         apply_mask_transform(f, loc, MaskBitPosition::High, "MaskOperandHighBitTransform")
-    }
-
-    fn always_equivalent(&self) -> bool {
-        false
     }
 }
 
@@ -211,15 +215,12 @@ impl PirTransform for MaskOperandLowBitTransform {
         PirTransformKind::MaskOperandLowBit
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        find_candidates_for_mask_transform(f, 2000)
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = false;
+        find_candidates_for_mask_transform(f, 2000, always_equivalent)
     }
 
     fn apply(&self, f: &mut IrFn, loc: &TransformLocation) -> Result<(), String> {
         apply_mask_transform(f, loc, MaskBitPosition::Low, "MaskOperandLowBitTransform")
-    }
-
-    fn always_equivalent(&self) -> bool {
-        false
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/mask_operand_bit.rs
+++ b/xlsynth-mcmc-pir/src/transforms/mask_operand_bit.rs
@@ -195,6 +195,10 @@ impl PirTransform for MaskOperandHighBitTransform {
         PirTransformKind::MaskOperandHighBit
     }
 
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        false
+    }
+
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
         let always_equivalent = false;
         find_candidates_for_mask_transform(f, 2000, always_equivalent)
@@ -213,6 +217,10 @@ pub struct MaskOperandLowBitTransform;
 impl PirTransform for MaskOperandLowBitTransform {
     fn kind(&self) -> PirTransformKind {
         PirTransformKind::MaskOperandLowBit
+    }
+
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        false
     }
 
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {

--- a/xlsynth-mcmc-pir/src/transforms/mod.rs
+++ b/xlsynth-mcmc-pir/src/transforms/mod.rs
@@ -462,6 +462,14 @@ pub enum TransformLocation {
     },
 }
 
+/// A candidate transform application site plus whether that specific
+/// application is known to preserve semantics.
+#[derive(Debug, Clone)]
+pub struct TransformCandidate {
+    pub location: TransformLocation,
+    pub always_equivalent: bool,
+}
+
 /// Defines a reversible transformation that can be applied to a PIR function.
 pub trait PirTransform: fmt::Debug + Send + Sync {
     /// Returns the specific `PirTransformKind` that this trait object
@@ -470,21 +478,13 @@ pub trait PirTransform: fmt::Debug + Send + Sync {
 
     /// Finds all possible application sites for this transform in the given
     /// function.
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation>;
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate>;
 
     /// Applies the transform to the function at the given candidate site.
     ///
     /// The MCMC loop is expected to pass a clone of the function if rejection
     /// implies reverting to the prior state.
     fn apply(&self, f: &mut IrFn, loc: &TransformLocation) -> Result<(), String>;
-
-    /// Indicates whether this transform is always semantics preserving.
-    ///
-    /// When `true`, applying the transform cannot change the functional
-    /// behaviour of the function, so equivalence checks can be skipped.
-    fn always_equivalent(&self) -> bool {
-        true
-    }
 }
 pub fn get_all_pir_transforms() -> Vec<Box<dyn PirTransform>> {
     vec![

--- a/xlsynth-mcmc-pir/src/transforms/mod.rs
+++ b/xlsynth-mcmc-pir/src/transforms/mod.rs
@@ -476,6 +476,17 @@ pub trait PirTransform: fmt::Debug + Send + Sync {
     /// represents.
     fn kind(&self) -> PirTransformKind;
 
+    /// Returns whether this transform class can emit at least one
+    /// `always_equivalent=true` candidate, i.e. a candidate that is
+    /// guaranteed to preserve semantics without a proof.
+    ///
+    /// This is a transform-level pruning hint for no-oracle mode only. Mixed
+    /// transforms should return `true` and mark unsafe instances in
+    /// `find_candidates()`.
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        true
+    }
+
     /// Finds all possible application sites for this transform in the given
     /// function.
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate>;

--- a/xlsynth-mcmc-pir/src/transforms/nand_not_and_fold.rs
+++ b/xlsynth-mcmc-pir/src/transforms/nand_not_and_fold.rs
@@ -46,16 +46,23 @@ impl PirTransform for NandNotAndFoldTransform {
         PirTransformKind::NandNotAndFold
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Nary(NaryOp::Nand, ops) if !ops.is_empty() => {
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 NodePayload::Unop(Unop::Not, arg) => {
                     if matches!(f.get_node(*arg).payload, NodePayload::Nary(NaryOp::And, _)) {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -116,9 +123,5 @@ impl PirTransform for NandNotAndFoldTransform {
             }
             _ => Err("NandNotAndFoldTransform: expected nand(...) or not(and(...))".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/narrow_add_from_wide_add_fold.rs
+++ b/xlsynth-mcmc-pir/src/transforms/narrow_add_from_wide_add_fold.rs
@@ -117,6 +117,10 @@ impl PirTransform for NarrowAddFromWideAddFoldTransform {
         PirTransformKind::NarrowAddFromWideAddFold
     }
 
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        false
+    }
+
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
         let always_equivalent = false;
         let mut out = Vec::<TransformCandidate>::new();

--- a/xlsynth-mcmc-pir/src/transforms/narrow_add_from_wide_add_fold.rs
+++ b/xlsynth-mcmc-pir/src/transforms/narrow_add_from_wide_add_fold.rs
@@ -3,7 +3,7 @@
 use xlsynth::{IrBits, IrValue};
 use xlsynth_pir::ir::{Binop, Fn as IrFn, NaryOp, NodePayload, NodeRef, Type};
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 /// A non-always-equivalent transform that folds a narrow add from a matching
 /// wide add on zero-extended operands.
@@ -117,8 +117,9 @@ impl PirTransform for NarrowAddFromWideAddFoldTransform {
         PirTransformKind::NarrowAddFromWideAddFold
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = false;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             let Some((lhs, rhs)) = Self::add_parts(&node.payload) else {
@@ -133,7 +134,10 @@ impl PirTransform for NarrowAddFromWideAddFoldTransform {
                 continue;
             }
             if Self::find_matching_wide_add(f, lhs, rhs, narrow_w).is_some() {
-                out.push(TransformLocation::Node(nr));
+                out.push(TransformCandidate {
+                    location: TransformLocation::Node(nr),
+                    always_equivalent,
+                });
             }
         }
         out
@@ -186,10 +190,6 @@ impl PirTransform for NarrowAddFromWideAddFoldTransform {
             };
             Ok(())
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        false
     }
 }
 

--- a/xlsynth-mcmc-pir/src/transforms/nary_hoist.rs
+++ b/xlsynth-mcmc-pir/src/transforms/nary_hoist.rs
@@ -2,7 +2,7 @@
 
 use xlsynth_pir::ir::{Binop, Fn as IrFn, NaryOp, Node, NodePayload, NodeRef, Type, Unop};
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 /// A non-always-equivalent transform that hoists unary/binary ops over n-ary
 /// ops.
@@ -82,8 +82,9 @@ impl PirTransform for NaryHoistTransform {
         PirTransformKind::NaryHoist
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = false;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -102,7 +103,10 @@ impl PirTransform for NaryHoistTransform {
                         .iter()
                         .all(|op| Self::bits_width(&f.get_node(*op).ty) == Some(w))
                     {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 NodePayload::Binop(_, lhs, rhs) => {
@@ -138,7 +142,10 @@ impl PirTransform for NaryHoistTransform {
                             continue;
                         }
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 _ => {}
             }
@@ -247,10 +254,6 @@ impl PirTransform for NaryHoistTransform {
             }
             _ => Err("NaryHoistTransform: expected unop or binop target".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        false
     }
 }
 

--- a/xlsynth-mcmc-pir/src/transforms/nary_hoist.rs
+++ b/xlsynth-mcmc-pir/src/transforms/nary_hoist.rs
@@ -82,6 +82,10 @@ impl PirTransform for NaryHoistTransform {
         PirTransformKind::NaryHoist
     }
 
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        false
+    }
+
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
         let always_equivalent = false;
         let mut out = Vec::<TransformCandidate>::new();

--- a/xlsynth-mcmc-pir/src/transforms/ne_zero_or_reduce.rs
+++ b/xlsynth-mcmc-pir/src/transforms/ne_zero_or_reduce.rs
@@ -68,8 +68,9 @@ impl PirTransform for NeZeroOrReduceTransform {
         PirTransformKind::NeZeroOrReduce
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Binop(Binop::Ne, lhs, rhs) => {
@@ -82,10 +83,16 @@ impl PirTransform for NeZeroOrReduceTransform {
                     if Self::is_zero_literal_node(f, *lhs, w)
                         || Self::is_zero_literal_node(f, *rhs, w)
                     {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
-                NodePayload::Unop(Unop::OrReduce, _) => out.push(TransformLocation::Node(nr)),
+                NodePayload::Unop(Unop::OrReduce, _) => out.push(TransformCandidate {
+                    location: TransformLocation::Node(nr),
+                    always_equivalent,
+                }),
                 _ => {}
             }
         }
@@ -143,9 +150,5 @@ impl PirTransform for NeZeroOrReduceTransform {
             }
             _ => Err("NeZeroOrReduceTransform: expected ne(x,0) or or_reduce(x)".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/neg_neg_cancel.rs
+++ b/xlsynth-mcmc-pir/src/transforms/neg_neg_cancel.rs
@@ -47,16 +47,23 @@ impl PirTransform for NegNegCancelTransform {
         PirTransformKind::NegNegCancel
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Unop(Unop::Neg, inner) => {
                     if matches!(f.get_node(*inner).payload, NodePayload::Unop(Unop::Neg, _)) {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
-                NodePayload::Unop(Unop::Identity, _) => out.push(TransformLocation::Node(nr)),
+                NodePayload::Unop(Unop::Identity, _) => out.push(TransformCandidate {
+                    location: TransformLocation::Node(nr),
+                    always_equivalent,
+                }),
                 _ => {}
             }
         }
@@ -104,9 +111,5 @@ impl PirTransform for NegNegCancelTransform {
             }
             _ => Err("NegNegCancelTransform: expected neg(neg(x)) or identity(x)".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/neg_sel_distribute.rs
+++ b/xlsynth-mcmc-pir/src/transforms/neg_sel_distribute.rs
@@ -86,8 +86,9 @@ impl PirTransform for NegSelDistributeTransform {
         PirTransformKind::NegSelDistribute
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -101,7 +102,10 @@ impl PirTransform for NegSelDistributeTransform {
                         let wb = Self::bits_width(f, b);
                         let wout = Self::bits_width(f, nr);
                         if wa.is_some() && wa == wb && wa == wout {
-                            out.push(TransformLocation::Node(nr));
+                            out.push(TransformCandidate {
+                                location: TransformLocation::Node(nr),
+                                always_equivalent,
+                            });
                         }
                     }
                 }
@@ -129,7 +133,10 @@ impl PirTransform for NegSelDistributeTransform {
                     let wb = Self::bits_width(f, b);
                     let wout = Self::bits_width(f, nr);
                     if wa.is_some() && wa == wb && wa == wout {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -217,9 +224,5 @@ impl PirTransform for NegSelDistributeTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/neg_sub_swap.rs
+++ b/xlsynth-mcmc-pir/src/transforms/neg_sub_swap.rs
@@ -44,8 +44,9 @@ impl PirTransform for NegSubSwapTransform {
         PirTransformKind::NegSubSwap
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Unop(Unop::Neg, arg) => {
@@ -53,10 +54,16 @@ impl PirTransform for NegSubSwapTransform {
                         f.get_node(*arg).payload,
                         NodePayload::Binop(Binop::Sub, _, _)
                     ) {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
-                NodePayload::Binop(Binop::Sub, _, _) => out.push(TransformLocation::Node(nr)),
+                NodePayload::Binop(Binop::Sub, _, _) => out.push(TransformCandidate {
+                    location: TransformLocation::Node(nr),
+                    always_equivalent,
+                }),
                 _ => {}
             }
         }
@@ -103,9 +110,5 @@ impl PirTransform for NegSubSwapTransform {
 
             _ => Err("NegSubSwapTransform: expected neg(sub(..)) or sub(..)".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/nor_not_or_fold.rs
+++ b/xlsynth-mcmc-pir/src/transforms/nor_not_or_fold.rs
@@ -46,16 +46,23 @@ impl PirTransform for NorNotOrFoldTransform {
         PirTransformKind::NorNotOrFold
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Nary(NaryOp::Nor, ops) if !ops.is_empty() => {
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 NodePayload::Unop(Unop::Not, arg) => {
                     if matches!(f.get_node(*arg).payload, NodePayload::Nary(NaryOp::Or, _)) {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -115,9 +122,5 @@ impl PirTransform for NorNotOrFoldTransform {
             }
             _ => Err("NorNotOrFoldTransform: expected nor(...) or not(or(...))".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/not_eq_ne_flip.rs
+++ b/xlsynth-mcmc-pir/src/transforms/not_eq_ne_flip.rs
@@ -43,8 +43,9 @@ impl PirTransform for NotEqNeFlipTransform {
         PirTransformKind::NotEqNeFlip
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Unop(Unop::Not, arg) => {
@@ -52,11 +53,17 @@ impl PirTransform for NotEqNeFlipTransform {
                         f.get_node(*arg).payload,
                         NodePayload::Binop(Binop::Eq, _, _) | NodePayload::Binop(Binop::Ne, _, _)
                     ) {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 NodePayload::Binop(Binop::Eq, _, _) | NodePayload::Binop(Binop::Ne, _, _) => {
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 _ => {}
             }
@@ -114,9 +121,5 @@ impl PirTransform for NotEqNeFlipTransform {
             }
             _ => Err("NotEqNeFlipTransform: expected not(eq/ne(..)) or eq/ne(..)".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/not_not_cancel.rs
+++ b/xlsynth-mcmc-pir/src/transforms/not_not_cancel.rs
@@ -47,17 +47,24 @@ impl PirTransform for NotNotCancelTransform {
         PirTransformKind::NotNotCancel
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Unop(Unop::Not, inner) => {
                     if matches!(f.get_node(*inner).payload, NodePayload::Unop(Unop::Not, _)) {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 NodePayload::Unop(Unop::Identity, _) => {
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 _ => {}
             }
@@ -106,9 +113,5 @@ impl PirTransform for NotNotCancelTransform {
             }
             _ => Err("NotNotCancelTransform: expected not(not(x)) or identity(x)".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/not_sel_distribute.rs
+++ b/xlsynth-mcmc-pir/src/transforms/not_sel_distribute.rs
@@ -85,8 +85,9 @@ impl PirTransform for NotSelDistributeTransform {
         PirTransformKind::NotSelDistribute
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -100,7 +101,10 @@ impl PirTransform for NotSelDistributeTransform {
                         let wb = Self::bits_width(f, b);
                         let wout = Self::bits_width(f, nr);
                         if wa.is_some() && wa == wb && wa == wout {
-                            out.push(TransformLocation::Node(nr));
+                            out.push(TransformCandidate {
+                                location: TransformLocation::Node(nr),
+                                always_equivalent,
+                            });
                         }
                     }
                 }
@@ -128,7 +132,10 @@ impl PirTransform for NotSelDistributeTransform {
                     let wb = Self::bits_width(f, b);
                     let wout = Self::bits_width(f, nr);
                     if wa.is_some() && wa == wb && wa == wout {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -216,9 +223,5 @@ impl PirTransform for NotSelDistributeTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/or_mask_sign_ext_to_sel.rs
+++ b/xlsynth-mcmc-pir/src/transforms/or_mask_sign_ext_to_sel.rs
@@ -84,8 +84,9 @@ impl PirTransform for OrMaskSignExtToSelTransform {
         PirTransformKind::OrMaskSignExtToSel
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 // Expand: or(x, sign_ext(b,w))
@@ -102,7 +103,10 @@ impl PirTransform for OrMaskSignExtToSelTransform {
                         }
                     }
                     if ok {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 // Fold: sel(b, cases=[x, all_ones_w])
@@ -129,7 +133,10 @@ impl PirTransform for OrMaskSignExtToSelTransform {
                     if !Self::is_all_ones_literal_node(f, ones, w) {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 _ => {}
             }
@@ -232,9 +239,5 @@ impl PirTransform for OrMaskSignExtToSelTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/priority_sel_1_to_sel.rs
+++ b/xlsynth-mcmc-pir/src/transforms/priority_sel_1_to_sel.rs
@@ -26,8 +26,9 @@ impl PirTransform for PrioritySel1ToSelTransform {
         PirTransformKind::PrioritySel1ToSel
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 // priority_sel(p, cases=[a], default=b) -> sel(p, cases=[b,a])
@@ -51,7 +52,10 @@ impl PirTransform for PrioritySel1ToSelTransform {
                     let wb = Self::bits_width(f, b);
                     let wout = Self::bits_width(f, nr);
                     if wa.is_some() && wa == wb && wa == wout {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 // sel(p, cases=[b,a]) -> priority_sel(p, cases=[a], default=b)
@@ -72,7 +76,10 @@ impl PirTransform for PrioritySel1ToSelTransform {
                     let wb = Self::bits_width(f, b);
                     let wout = Self::bits_width(f, nr);
                     if wa.is_some() && wa == wb && wa == wout {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -172,9 +179,5 @@ impl PirTransform for PrioritySel1ToSelTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/priority_sel_to_sel_chain.rs
+++ b/xlsynth-mcmc-pir/src/transforms/priority_sel_to_sel_chain.rs
@@ -66,8 +66,9 @@ impl PirTransform for PrioritySelToSelChainTransform {
         PirTransformKind::PrioritySelToSelChain
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             if let NodePayload::PrioritySel {
                 selector,
@@ -82,7 +83,10 @@ impl PirTransform for PrioritySelToSelChainTransform {
                     continue;
                 };
                 if cases.len() == m && m > 0 {
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
             }
         }
@@ -134,9 +138,5 @@ impl PirTransform for PrioritySelToSelChainTransform {
         }
         f.get_node_mut(target_ref).payload = NodePayload::Unop(Unop::Identity, acc);
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/reassociate_add_sub.rs
+++ b/xlsynth-mcmc-pir/src/transforms/reassociate_add_sub.rs
@@ -54,15 +54,19 @@ impl PirTransform for ReassociateAddSubTransform {
         PirTransformKind::ReassociateAddSub
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 NodePayload::Binop(Binop::Add, a, b) => {
                     if matches!(f.get_node(*a).payload, NodePayload::Binop(Binop::Add, _, _))
                         || matches!(f.get_node(*b).payload, NodePayload::Binop(Binop::Add, _, _))
                     {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 NodePayload::Binop(Binop::Sub, a, b) => {
@@ -70,7 +74,10 @@ impl PirTransform for ReassociateAddSubTransform {
                         || matches!(f.get_node(*b).payload, NodePayload::Binop(Binop::Sub, _, _))
                         || matches!(f.get_node(*b).payload, NodePayload::Binop(Binop::Add, _, _))
                     {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -196,9 +203,5 @@ impl PirTransform for ReassociateAddSubTransform {
         }
 
         Err("ReassociateAddSubTransform: no matching reshape pattern at target".to_string())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/rewire_operand_to_same_type.rs
+++ b/xlsynth-mcmc-pir/src/transforms/rewire_operand_to_same_type.rs
@@ -53,14 +53,15 @@ impl PirTransform for RewireOperandToSameTypeTransform {
         PirTransformKind::RewireOperandToSameType
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = false;
         let users_map = compute_users(f);
 
         // Deterministic enumeration order:
         //   - node index ascending
         //   - operand slot ascending (as reported by remap_payload_with)
         //   - replacement node index ascending
-        let mut out: Vec<TransformLocation> = Vec::new();
+        let mut out = Vec::<TransformCandidate>::new();
 
         for i in 0..f.nodes.len() {
             if out.len() >= Self::MAX_CANDIDATES {
@@ -106,10 +107,13 @@ impl PirTransform for RewireOperandToSameTypeTransform {
                     if Self::node_type(f, new_operand) != old_ty {
                         continue;
                     }
-                    out.push(TransformLocation::RewireOperand {
-                        node: node_ref,
-                        operand_slot: slot,
-                        new_operand,
+                    out.push(TransformCandidate {
+                        location: TransformLocation::RewireOperand {
+                            node: node_ref,
+                            operand_slot: slot,
+                            new_operand,
+                        },
+                        always_equivalent,
                     });
                 }
             }
@@ -160,9 +164,5 @@ impl PirTransform for RewireOperandToSameTypeTransform {
 
         f.get_node_mut(node_ref).payload = new_payload;
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        false
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/rewire_operand_to_same_type.rs
+++ b/xlsynth-mcmc-pir/src/transforms/rewire_operand_to_same_type.rs
@@ -53,6 +53,10 @@ impl PirTransform for RewireOperandToSameTypeTransform {
         PirTransformKind::RewireOperandToSameType
     }
 
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        false
+    }
+
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
         let always_equivalent = false;
         let users_map = compute_users(f);

--- a/xlsynth-mcmc-pir/src/transforms/rewire_users_to_sibling_add.rs
+++ b/xlsynth-mcmc-pir/src/transforms/rewire_users_to_sibling_add.rs
@@ -3,7 +3,10 @@
 use xlsynth::{IrBits, IrValue};
 use xlsynth_pir::ir::{Binop, Fn as IrFn, NaryOp, NodePayload, NodeRef, Type};
 
-use super::{PirTransform, PirTransformKind, TransformLocation, compute_users, remap_payload_with};
+use super::{
+    PirTransform, PirTransformKind, TransformCandidate, TransformLocation, compute_users,
+    remap_payload_with,
+};
 
 /// A non-always-equivalent transform that rewires users between sibling adds:
 /// - wide: add(zext(a), zext(b)) (zext via zero_ext or concat(0_k, x))
@@ -164,11 +167,15 @@ impl PirTransform for RewireUsersToSiblingAddTransform {
         PirTransformKind::RewireUsersToSiblingAdd
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = false;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             if Self::find_pair_for_add(f, nr).is_some() {
-                out.push(TransformLocation::Node(nr));
+                out.push(TransformCandidate {
+                    location: TransformLocation::Node(nr),
+                    always_equivalent,
+                });
             }
         }
         out
@@ -227,10 +234,6 @@ impl PirTransform for RewireUsersToSiblingAddTransform {
         }
 
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        false
     }
 }
 

--- a/xlsynth-mcmc-pir/src/transforms/rewire_users_to_sibling_add.rs
+++ b/xlsynth-mcmc-pir/src/transforms/rewire_users_to_sibling_add.rs
@@ -167,6 +167,10 @@ impl PirTransform for RewireUsersToSiblingAddTransform {
         PirTransformKind::RewireUsersToSiblingAdd
     }
 
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        false
+    }
+
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
         let always_equivalent = false;
         let mut out = Vec::<TransformCandidate>::new();

--- a/xlsynth-mcmc-pir/src/transforms/sel_chain_to_priority_sel.rs
+++ b/xlsynth-mcmc-pir/src/transforms/sel_chain_to_priority_sel.rs
@@ -122,8 +122,9 @@ impl PirTransform for SelChainToPrioritySelTransform {
         PirTransformKind::SelChainToPrioritySel
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             // PrioritySelToSelChainTransform wraps the chain in an identity.
             let start_sel = match &f.get_node(nr).payload {
@@ -136,7 +137,10 @@ impl PirTransform for SelChainToPrioritySelTransform {
                 _ => continue,
             };
             if Self::match_sel_chain(f, start_sel).is_some() {
-                out.push(TransformLocation::Node(nr));
+                out.push(TransformCandidate {
+                    location: TransformLocation::Node(nr),
+                    always_equivalent,
+                });
             }
         }
         out
@@ -183,10 +187,6 @@ impl PirTransform for SelChainToPrioritySelTransform {
             default: Some(default),
         };
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }
 

--- a/xlsynth-mcmc-pir/src/transforms/sel_hoist.rs
+++ b/xlsynth-mcmc-pir/src/transforms/sel_hoist.rs
@@ -2,7 +2,7 @@
 
 use xlsynth_pir::ir::{Binop, Fn as IrFn, Node, NodePayload, NodeRef, Type, Unop};
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 /// A semantics-preserving transform that hoists unary/binary ops over `sel`.
 ///
@@ -80,8 +80,9 @@ impl PirTransform for SelHoistTransform {
         PirTransformKind::SelHoist
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -99,7 +100,10 @@ impl PirTransform for SelHoistTransform {
                     if !Self::sel_cases_match_type(f, cases, default, &sel_node.ty) {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 NodePayload::Binop(_, lhs, rhs) => {
                     if !Self::is_bits_type(&node.ty) {
@@ -122,7 +126,10 @@ impl PirTransform for SelHoistTransform {
                         if !Self::sel_cases_match_type(f, cases, default, &lhs_node.ty) {
                             continue;
                         }
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     } else {
                         let NodePayload::Sel { cases, default, .. } = &rhs_node.payload else {
                             continue;
@@ -133,7 +140,10 @@ impl PirTransform for SelHoistTransform {
                         if !Self::sel_cases_match_type(f, cases, default, &rhs_node.ty) {
                             continue;
                         }
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -266,10 +276,6 @@ impl PirTransform for SelHoistTransform {
             }
             _ => Err("SelHoistTransform: expected unop or binop target".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }
 

--- a/xlsynth-mcmc-pir/src/transforms/sel_same_arms_fold.rs
+++ b/xlsynth-mcmc-pir/src/transforms/sel_same_arms_fold.rs
@@ -56,8 +56,9 @@ impl PirTransform for SelSameArmsFoldTransform {
         PirTransformKind::SelSameArmsFold
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
 
         for nr in f.node_refs() {
             let node = f.get_node(nr);
@@ -80,7 +81,10 @@ impl PirTransform for SelSameArmsFoldTransform {
                     // Must be able to represent result as identity(bits[w]).
                     let w = Self::bits_width(f, cases[0]);
                     if w.is_some() && w == Self::bits_width(f, nr) {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
 
@@ -111,7 +115,10 @@ impl PirTransform for SelSameArmsFoldTransform {
                         break;
                     }
                     if chosen_p.is_some() && w > 0 {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
             }
@@ -210,9 +217,5 @@ impl PirTransform for SelSameArmsFoldTransform {
                 Ok(())
             }
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/sel_swap_arms_by_not_pred.rs
+++ b/xlsynth-mcmc-pir/src/transforms/sel_swap_arms_by_not_pred.rs
@@ -59,8 +59,9 @@ impl PirTransform for SelSwapArmsByNotPredTransform {
         PirTransformKind::SelSwapArmsByNotPred
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let Some((sel, a, b)) = Self::sel2_parts(&f.get_node(nr).payload) else {
                 continue;
@@ -70,7 +71,10 @@ impl PirTransform for SelSwapArmsByNotPredTransform {
             // - selector == not(p)  => remove not, swap arms
             // - selector == p       => add not, swap arms
             if Self::is_u1_selector(f, sel) {
-                out.push(TransformLocation::Node(nr));
+                out.push(TransformCandidate {
+                    location: TransformLocation::Node(nr),
+                    always_equivalent,
+                });
             }
         }
         out
@@ -123,9 +127,5 @@ impl PirTransform for SelSwapArmsByNotPredTransform {
             default: None,
         };
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/shift_clamp.rs
+++ b/xlsynth-mcmc-pir/src/transforms/shift_clamp.rs
@@ -3,7 +3,7 @@
 use xlsynth::{IrBits, IrValue};
 use xlsynth_pir::ir::{Binop, Fn as IrFn, Node, NodePayload, NodeRef, Type};
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 /// A non-always-equivalent transform that clamps shift amounts:
 ///
@@ -98,8 +98,9 @@ impl PirTransform for ShiftClampTransform {
         PirTransformKind::ShiftClamp
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = false;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::Binop(op, x, amount) = f.get_node(nr).payload else {
                 continue;
@@ -119,7 +120,10 @@ impl PirTransform for ShiftClampTransform {
             if Self::compute_max_amount(x_width, amount_bits).is_none() {
                 continue;
             }
-            out.push(TransformLocation::Node(nr));
+            out.push(TransformCandidate {
+                location: TransformLocation::Node(nr),
+                always_equivalent,
+            });
         }
         out
     }
@@ -158,10 +162,6 @@ impl PirTransform for ShiftClampTransform {
 
         f.get_node_mut(target_ref).payload = NodePayload::Binop(op, x, clamped);
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        false
     }
 }
 

--- a/xlsynth-mcmc-pir/src/transforms/shift_clamp.rs
+++ b/xlsynth-mcmc-pir/src/transforms/shift_clamp.rs
@@ -98,6 +98,10 @@ impl PirTransform for ShiftClampTransform {
         PirTransformKind::ShiftClamp
     }
 
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        false
+    }
+
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
         let always_equivalent = false;
         let mut out = Vec::<TransformCandidate>::new();

--- a/xlsynth-mcmc-pir/src/transforms/shift_hoist.rs
+++ b/xlsynth-mcmc-pir/src/transforms/shift_hoist.rs
@@ -74,6 +74,10 @@ impl PirTransform for ShiftHoistTransform {
         PirTransformKind::ShiftHoist
     }
 
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        false
+    }
+
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
         let always_equivalent = false;
         let mut out = Vec::<TransformCandidate>::new();

--- a/xlsynth-mcmc-pir/src/transforms/shift_hoist.rs
+++ b/xlsynth-mcmc-pir/src/transforms/shift_hoist.rs
@@ -2,7 +2,7 @@
 
 use xlsynth_pir::ir::{Binop, Fn as IrFn, Node, NodePayload, NodeRef, Type, Unop};
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 /// A non-always-equivalent transform that hoists ops across shifts.
 ///
@@ -74,8 +74,9 @@ impl PirTransform for ShiftHoistTransform {
         PirTransformKind::ShiftHoist
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = false;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -93,7 +94,10 @@ impl PirTransform for ShiftHoistTransform {
                     if Self::is_bits_type(&f.get_node(x).ty) != Some(w) {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 NodePayload::Binop(_, lhs, rhs) => {
                     let lhs_node = f.get_node(*lhs);
@@ -111,7 +115,10 @@ impl PirTransform for ShiftHoistTransform {
                     {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 payload => {
                     let Some((_, x, _k)) = Self::shift_parts(payload) else {
@@ -123,7 +130,10 @@ impl PirTransform for ShiftHoistTransform {
                     if Self::is_bits_type(&f.get_node(x).ty) != Some(w) {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
             }
         }
@@ -237,10 +247,6 @@ impl PirTransform for ShiftHoistTransform {
                 _ => Err("ShiftHoistTransform: expected unop or binop target".to_string()),
             }
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        false
     }
 }
 

--- a/xlsynth-mcmc-pir/src/transforms/shift_reclamp.rs
+++ b/xlsynth-mcmc-pir/src/transforms/shift_reclamp.rs
@@ -136,6 +136,10 @@ impl PirTransform for ShiftReclampTransform {
         PirTransformKind::ShiftReclamp
     }
 
+    fn can_emit_always_equivalent_candidates(&self) -> bool {
+        false
+    }
+
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
         let always_equivalent = false;
         let mut out = Vec::<TransformCandidate>::new();

--- a/xlsynth-mcmc-pir/src/transforms/shift_reclamp.rs
+++ b/xlsynth-mcmc-pir/src/transforms/shift_reclamp.rs
@@ -3,7 +3,7 @@
 use xlsynth::{IrBits, IrValue};
 use xlsynth_pir::ir::{Binop, Fn as IrFn, Node, NodePayload, NodeRef, Type};
 
-use super::{PirTransform, PirTransformKind, TransformLocation};
+use super::{PirTransform, PirTransformKind, TransformCandidate, TransformLocation};
 
 /// A non-always-equivalent transform that replaces a complicated shift-amount
 /// expression with a shallow canonical clamp.
@@ -136,8 +136,9 @@ impl PirTransform for ShiftReclampTransform {
         PirTransformKind::ShiftReclamp
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = false;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let NodePayload::Binop(op, x, amount) = f.get_node(nr).payload else {
                 continue;
@@ -163,7 +164,10 @@ impl PirTransform for ShiftReclampTransform {
             if Self::is_canonical_shift_clamp(f, amount) {
                 continue;
             }
-            out.push(TransformLocation::Node(nr));
+            out.push(TransformCandidate {
+                location: TransformLocation::Node(nr),
+                always_equivalent,
+            });
         }
         out
     }
@@ -197,9 +201,5 @@ impl PirTransform for ShiftReclampTransform {
         let clamped = Self::mk_sel2(f, Type::Bits(amount_bits), pred, max_lit, amount);
         f.get_node_mut(target_ref).payload = NodePayload::Binop(op, x, clamped);
         Ok(())
-    }
-
-    fn always_equivalent(&self) -> bool {
-        false
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/sign_ext_sel_distribute.rs
+++ b/xlsynth-mcmc-pir/src/transforms/sign_ext_sel_distribute.rs
@@ -93,8 +93,9 @@ impl PirTransform for SignExtSelDistributeTransform {
         PirTransformKind::SignExtSelDistribute
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -109,7 +110,10 @@ impl PirTransform for SignExtSelDistributeTransform {
                         let wout = Self::bits_width(f, nr);
                         if wa.is_some() && wa == wb && wout == Some(*new_bit_count) {
                             if *new_bit_count >= wa.unwrap() {
-                                out.push(TransformLocation::Node(nr));
+                                out.push(TransformCandidate {
+                                    location: TransformLocation::Node(nr),
+                                    always_equivalent,
+                                });
                             }
                         }
                     }
@@ -142,7 +146,10 @@ impl PirTransform for SignExtSelDistributeTransform {
                     let wout = Self::bits_width(f, nr);
                     if wa.is_some() && wa == wb && wout == Some(a_n) {
                         if a_n >= wa.unwrap() {
-                            out.push(TransformLocation::Node(nr));
+                            out.push(TransformCandidate {
+                                location: TransformLocation::Node(nr),
+                                always_equivalent,
+                            });
                         }
                     }
                 }
@@ -267,9 +274,5 @@ impl PirTransform for SignExtSelDistributeTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/smul_sign_ext_u1_to_sel_neg.rs
+++ b/xlsynth-mcmc-pir/src/transforms/smul_sign_ext_u1_to_sel_neg.rs
@@ -110,8 +110,9 @@ impl PirTransform for SmulSignExtU1ToSelNegTransform {
         PirTransformKind::SmulSignExtU1ToSelNeg
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 // Expand: smul(x, sign_ext(b,w)) (either operand).
@@ -131,7 +132,10 @@ impl PirTransform for SmulSignExtU1ToSelNegTransform {
                         }
                     }
                     if ok {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
 
@@ -165,7 +169,10 @@ impl PirTransform for SmulSignExtU1ToSelNegTransform {
                     if Self::bits_width(f, x) != Some(w) {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
 
                 _ => {}
@@ -273,9 +280,5 @@ impl PirTransform for SmulSignExtU1ToSelNegTransform {
 
             _ => Err("SmulSignExtU1ToSelNegTransform: expected smul(..) or sel(..)".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/sub_sign_ext_u1_to_add_zero_ext_u1.rs
+++ b/xlsynth-mcmc-pir/src/transforms/sub_sign_ext_u1_to_add_zero_ext_u1.rs
@@ -121,8 +121,9 @@ impl PirTransform for SubSignExtU1ToAddZeroExtU1Transform {
         PirTransformKind::SubSignExtU1ToAddZeroExtU1
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 // Expand: sub(x, sign_ext(b,w)) (sign_ext on RHS only).
@@ -135,7 +136,10 @@ impl PirTransform for SubSignExtU1ToAddZeroExtU1Transform {
                         continue;
                     }
                     if Self::sign_ext_u1_parts(f, *sext).is_some() {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
 
@@ -157,7 +161,10 @@ impl PirTransform for SubSignExtU1ToAddZeroExtU1Transform {
                         }
                     }
                     if ok {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -240,9 +247,5 @@ impl PirTransform for SubSignExtU1ToAddZeroExtU1Transform {
                 Err("SubSignExtU1ToAddZeroExtU1Transform: expected sub(..) or add(..)".to_string())
             }
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/sub_to_add_neg.rs
+++ b/xlsynth-mcmc-pir/src/transforms/sub_to_add_neg.rs
@@ -44,16 +44,23 @@ impl PirTransform for SubToAddNegTransform {
         PirTransformKind::SubToAddNeg
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
-                NodePayload::Binop(Binop::Sub, _, _) => out.push(TransformLocation::Node(nr)),
+                NodePayload::Binop(Binop::Sub, _, _) => out.push(TransformCandidate {
+                    location: TransformLocation::Node(nr),
+                    always_equivalent,
+                }),
                 NodePayload::Binop(Binop::Add, a, b) => {
                     if matches!(f.get_node(*a).payload, NodePayload::Unop(Unop::Neg, _))
                         || matches!(f.get_node(*b).payload, NodePayload::Unop(Unop::Neg, _))
                     {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 _ => {}
@@ -106,9 +113,5 @@ impl PirTransform for SubToAddNegTransform {
 
             _ => Err("SubToAddNegTransform: expected sub(..) or add(..)".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/swap_commutative_binop_operands.rs
+++ b/xlsynth-mcmc-pir/src/transforms/swap_commutative_binop_operands.rs
@@ -13,7 +13,8 @@ impl PirTransform for SwapCommutativeBinopOperandsTransform {
         PirTransformKind::SwapCommutativeBinopOperands
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
         f.node_refs()
             .into_iter()
             .filter(|nr| {
@@ -22,7 +23,10 @@ impl PirTransform for SwapCommutativeBinopOperandsTransform {
                     NodePayload::Binop(Binop::Add, _, _)
                 )
             })
-            .map(TransformLocation::Node)
+            .map(|nr| TransformCandidate {
+                location: TransformLocation::Node(nr),
+                always_equivalent,
+            })
             .collect()
     }
 
@@ -46,9 +50,5 @@ impl PirTransform for SwapCommutativeBinopOperandsTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/umul_sign_ext_u1_to_sel_neg.rs
+++ b/xlsynth-mcmc-pir/src/transforms/umul_sign_ext_u1_to_sel_neg.rs
@@ -110,8 +110,9 @@ impl PirTransform for UmulSignExtU1ToSelNegTransform {
         PirTransformKind::UmulSignExtU1ToSelNeg
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 // Expand: umul(x, sign_ext(b,w)) (either operand).
@@ -131,7 +132,10 @@ impl PirTransform for UmulSignExtU1ToSelNegTransform {
                         }
                     }
                     if ok {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
 
@@ -165,7 +169,10 @@ impl PirTransform for UmulSignExtU1ToSelNegTransform {
                     if Self::bits_width(f, x) != Some(w) {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
 
                 _ => {}
@@ -273,9 +280,5 @@ impl PirTransform for UmulSignExtU1ToSelNegTransform {
 
             _ => Err("UmulSignExtU1ToSelNegTransform: expected umul(..) or sel(..)".to_string()),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/xor_mask_sign_ext_to_sel_not.rs
+++ b/xlsynth-mcmc-pir/src/transforms/xor_mask_sign_ext_to_sel_not.rs
@@ -57,8 +57,9 @@ impl PirTransform for XorMaskSignExtToSelNotTransform {
         PirTransformKind::XorMaskSignExtToSelNot
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             match &f.get_node(nr).payload {
                 // Expand: xor(x, sign_ext(b,w))
@@ -76,7 +77,10 @@ impl PirTransform for XorMaskSignExtToSelNotTransform {
                         }
                     }
                     if ok {
-                        out.push(TransformLocation::Node(nr));
+                        out.push(TransformCandidate {
+                            location: TransformLocation::Node(nr),
+                            always_equivalent,
+                        });
                     }
                 }
                 // Fold: sel(b, cases=[x, not(x)])
@@ -106,7 +110,10 @@ impl PirTransform for XorMaskSignExtToSelNotTransform {
                     if Self::not_arg(f, not_x) != Some(x) {
                         continue;
                     }
-                    out.push(TransformLocation::Node(nr));
+                    out.push(TransformCandidate {
+                        location: TransformLocation::Node(nr),
+                        always_equivalent,
+                    });
                 }
                 _ => {}
             }
@@ -225,9 +232,5 @@ impl PirTransform for XorMaskSignExtToSelNotTransform {
                     .to_string(),
             ),
         }
-    }
-
-    fn always_equivalent(&self) -> bool {
-        true
     }
 }

--- a/xlsynth-mcmc-pir/src/transforms/zero_ext_sel_distribute.rs
+++ b/xlsynth-mcmc-pir/src/transforms/zero_ext_sel_distribute.rs
@@ -93,8 +93,9 @@ impl PirTransform for ZeroExtSelDistributeTransform {
         PirTransformKind::ZeroExtSelDistribute
     }
 
-    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformLocation> {
-        let mut out: Vec<TransformLocation> = Vec::new();
+    fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
+        let always_equivalent = true;
+        let mut out = Vec::<TransformCandidate>::new();
         for nr in f.node_refs() {
             let node = f.get_node(nr);
             match &node.payload {
@@ -109,7 +110,10 @@ impl PirTransform for ZeroExtSelDistributeTransform {
                         let wout = Self::bits_width(f, nr);
                         if wa.is_some() && wa == wb && wout == Some(*new_bit_count) {
                             if *new_bit_count >= wa.unwrap() {
-                                out.push(TransformLocation::Node(nr));
+                                out.push(TransformCandidate {
+                                    location: TransformLocation::Node(nr),
+                                    always_equivalent,
+                                });
                             }
                         }
                     }
@@ -142,7 +146,10 @@ impl PirTransform for ZeroExtSelDistributeTransform {
                     let wout = Self::bits_width(f, nr);
                     if wa.is_some() && wa == wb && wout == Some(a_n) {
                         if a_n >= wa.unwrap() {
-                            out.push(TransformLocation::Node(nr));
+                            out.push(TransformCandidate {
+                                location: TransformLocation::Node(nr),
+                                always_equivalent,
+                            });
                         }
                     }
                 }

--- a/xlsynth-pir/src/ir_outline.rs
+++ b/xlsynth-pir/src/ir_outline.rs
@@ -300,9 +300,7 @@ pub fn outline_with_ordering(
 
     // Build inner params in specified order
     let mut inner_params: Vec<Param> = Vec::new();
-    let mut outer_paramid_to_inner: HashMap<usize, ParamId> = HashMap::new();
     let mut param_index_to_inner_param_id: Vec<ParamId> = Vec::new();
-    let mut param_index_to_source_outer_node: Vec<Option<usize>> = Vec::new();
     let mut used_names: HashSet<String> = HashSet::new();
     let mut next_param_pos: usize = 1;
     for (idx, ps) in ordering.params.iter().enumerate() {
@@ -331,9 +329,7 @@ pub fn outline_with_ordering(
                     ty: ty.clone(),
                     id: inner_id,
                 });
-                outer_paramid_to_inner.insert(id_number, inner_id);
                 param_index_to_inner_param_id.push(inner_id);
-                param_index_to_source_outer_node.push(Some(node.index));
                 if required_param_ids.contains(&id_number) {
                     required_param_ids.remove(&id_number);
                 }
@@ -365,7 +361,6 @@ pub fn outline_with_ordering(
                     id: inner_id,
                 });
                 param_index_to_inner_param_id.push(inner_id);
-                param_index_to_source_outer_node.push(Some(node.index));
                 if required_nonparam_inputs.contains(&node.index) {
                     required_nonparam_inputs.remove(&node.index);
                 }
@@ -384,59 +379,40 @@ pub fn outline_with_ordering(
         required_nonparam_inputs
     );
 
-    // Build inner nodes: create GetParam nodes for any ParamIds that do not already
-    // exist inside the selected set (i.e. when the GetParam node itself is
-    // external), and for all external non-param inputs. Track a map from outer
-    // NodeRef -> inner NodeRef for remapping payload operands.
-    let mut inner_nodes: Vec<Node> = Vec::new();
-    let mut ext_ref_to_inner_ref: HashMap<usize, NodeRef> = HashMap::new();
+    // Build inner nodes in canonical PIR layout:
+    // - node[0] is reserved Nil
+    // - node[1..=params.len()] are GetParam nodes in signature order
+    // Track a map from each source outer node used as an inner parameter to the
+    // canonical inner GetParam node so body cloning and return wiring can reuse it.
+    let mut inner_nodes: Vec<Node> = vec![Node {
+        text_id: 0,
+        name: Some("reserved_zero_node".to_string()),
+        ty: Type::nil(),
+        payload: NodePayload::Nil,
+        pos: None,
+    }];
+    let mut outer_source_to_inner_ref: HashMap<usize, NodeRef> = HashMap::new();
     let mut next_inner_text_id: usize = next_text_id(&outer.nodes);
 
-    // Create synthesized GetParam nodes in inner for any external GetParam inputs.
+    // Create one canonical GetParam node for each inner parameter, preserving the
+    // caller-requested ordering.
     for (pidx, ps) in ordering.params.iter().enumerate() {
         let node = ps.node;
-        if !to_outline_set.contains(&node.index) {
-            if let NodePayload::GetParam(_) = outer.nodes[node.index].payload {
-                let inner_pid = param_index_to_inner_param_id[pidx];
-                let src_node = &outer.nodes[node.index];
-                inner_nodes.push(Node {
-                    text_id: next_inner_text_id,
-                    name: Some(inner_params[pidx].name.clone()),
-                    ty: src_node.ty.clone(),
-                    payload: NodePayload::GetParam(inner_pid),
-                    pos: src_node.pos.clone(),
-                });
-                let new_ref = NodeRef {
-                    index: inner_nodes.len() - 1,
-                };
-                ext_ref_to_inner_ref.insert(node.index, new_ref);
-                next_inner_text_id += 1;
-            }
-        }
-    }
-
-    // Now create GetParam nodes for each external non-param input, in the same
-    // order they were appended to inner_params after the ParamIds.
-    // Compute the ParamIds (and names) assigned to nonparam inputs in order.
-    for (pidx, ps) in ordering.params.iter().enumerate() {
-        let node = ps.node;
-        if !to_outline_set.contains(&node.index) {
-            if !matches!(outer.nodes[node.index].payload, NodePayload::GetParam(_)) {
-                let src_node = &outer.nodes[node.index];
-                inner_nodes.push(Node {
-                    text_id: next_inner_text_id,
-                    name: Some(inner_params[pidx].name.clone()),
-                    ty: src_node.ty.clone(),
-                    payload: NodePayload::GetParam(param_index_to_inner_param_id[pidx]),
-                    pos: src_node.pos.clone(),
-                });
-                let new_ref = NodeRef {
-                    index: inner_nodes.len() - 1,
-                };
-                ext_ref_to_inner_ref.insert(node.index, new_ref);
-                next_inner_text_id += 1;
-            }
-        }
+        let src_node = &outer.nodes[node.index];
+        inner_nodes.push(Node {
+            text_id: next_inner_text_id,
+            name: Some(inner_params[pidx].name.clone()),
+            ty: src_node.ty.clone(),
+            payload: NodePayload::GetParam(param_index_to_inner_param_id[pidx]),
+            pos: src_node.pos.clone(),
+        });
+        outer_source_to_inner_ref.insert(
+            node.index,
+            NodeRef {
+                index: inner_nodes.len() - 1,
+            },
+        );
+        next_inner_text_id += 1;
     }
 
     // Clone outlined nodes into inner, remapping operands:
@@ -448,6 +424,15 @@ pub fn outline_with_ordering(
     let mut outlined_to_inner: HashMap<usize, NodeRef> = HashMap::new();
     for nr in topo_filtered.into_iter() {
         let old = &outer.nodes[nr.index];
+        if matches!(old.payload, NodePayload::GetParam(_)) {
+            // Selected GetParam nodes are already represented by canonical
+            // signature-order params at node[1..].
+            let new_ref = *outer_source_to_inner_ref
+                .get(&nr.index)
+                .expect("inner param ref must exist for selected GetParam");
+            outlined_to_inner.insert(nr.index, new_ref);
+            continue;
+        }
         // Map operands: internal operands map to already-cloned nodes; external
         // operands map to synthesized GetParam nodes (must exist).
         let mapper = |(_, r): (usize, NodeRef)| -> NodeRef {
@@ -457,20 +442,13 @@ pub fn outline_with_ordering(
                     .copied()
                     .unwrap_or_else(|| panic!("missing mapping for internal operand {:?}", r))
             } else {
-                ext_ref_to_inner_ref
+                outer_source_to_inner_ref
                     .get(&r.index)
                     .copied()
                     .unwrap_or_else(|| panic!("missing mapping for external operand {:?}", r))
             }
         };
-        let mut new_payload = remap_payload_with(&old.payload, mapper);
-        // If cloning a GetParam, remap its ParamId to the inner-assigned id.
-        if let NodePayload::GetParam(pid) = old.payload {
-            let new_pid = *outer_paramid_to_inner
-                .get(&pid.get_wrapped_id())
-                .expect("inner param id must exist for cloned get_param");
-            new_payload = NodePayload::GetParam(new_pid);
-        }
+        let new_payload = remap_payload_with(&old.payload, mapper);
         let new_node = Node {
             text_id: old.text_id,
             name: old.name.clone(),
@@ -526,7 +504,7 @@ pub fn outline_with_ordering(
             ret_elem_tys.push(inner_nodes[ir.index].ty.clone());
             ret_elem_refs.push(ir);
         } else {
-            let ir = *ext_ref_to_inner_ref
+            let ir = *outer_source_to_inner_ref
                 .get(&node.index)
                 .expect("inner ref for passthrough source");
             ret_elem_tys.push(inner_nodes[ir.index].ty.clone());
@@ -708,8 +686,12 @@ pub fn outline_with_ordering(
     }
 
     // Clobber outlined nodes' payloads with Nil (except GetParam nodes, which may
-    // be used as invoke operands)
+    // be used as invoke operands, and protected nodes whose values are still
+    // needed to compute invoke operands).
     for &idx in to_outline_set.iter() {
+        if protected.contains(&idx) {
+            continue;
+        }
         if !matches!(outer_nodes[idx].payload, NodePayload::GetParam(_)) {
             outer_nodes[idx].payload = NodePayload::Nil;
         }
@@ -889,6 +871,76 @@ mod tests {
         assert_eq!(res.inner.params[1].name, "b");
         // Equivalence: original vs outlined outer
         assert_equiv_pkg(&f, &res.outer, Some(&res.inner));
+    }
+
+    #[test]
+    fn outline_param_only_region_preserves_inner_layout() {
+        let ir = r#"fn f(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
+  ret a: bits[1] = param(name=a, id=1)
+}"#;
+        let (mut pkg, f) = parse_single_fn(ir);
+        let mut to_sel: HashSet<NodeRef> = HashSet::new();
+        to_sel.insert(
+            f.node_refs()
+                .into_iter()
+                .find(|nr| {
+                    matches!(
+                        f.nodes[nr.index].payload,
+                        NodePayload::GetParam(pid) if pid.get_wrapped_id() == 1
+                    )
+                })
+                .expect("found param a node"),
+        );
+
+        let res = outline(&f, &to_sel, "f_out", "f_inner", &mut pkg);
+
+        res.outer.check_pir_layout_invariants().unwrap();
+        res.inner.check_pir_layout_invariants().unwrap();
+        assert!(matches!(res.inner.nodes[0].payload, NodePayload::Nil));
+        assert!(matches!(
+            res.inner.nodes[1].payload,
+            NodePayload::GetParam(pid) if pid.get_wrapped_id() == 1
+        ));
+        assert_eq!(res.inner.ret_node_ref, Some(NodeRef { index: 1 }));
+    }
+
+    #[test]
+    fn outline_preserves_protected_selected_producers_for_invoke_operands() {
+        let ir = r#"fn f(p0: bits[6] id=1) -> bits[6] {
+  one_hot.2: bits[7] = one_hot(p0, lsb_prio=true, id=2)
+  bit_slice.3: bits[1] = bit_slice(one_hot.2, start=6, width=1, id=3)
+  dynamic_bit_slice.4: bits[6] = dynamic_bit_slice(p0, bit_slice.3, width=6, id=4)
+  ret p0: bits[6] = param(name=p0, id=1)
+}"#;
+        let (mut pkg, f) = parse_single_fn(ir);
+        let mut to_sel: HashSet<NodeRef> = HashSet::new();
+        for (i, n) in f.nodes.iter().enumerate() {
+            if matches!(
+                n.payload,
+                NodePayload::OneHot { .. } | NodePayload::DynamicBitSlice { .. }
+            ) {
+                to_sel.insert(NodeRef { index: i });
+            }
+        }
+
+        let res = outline(&f, &to_sel, "f_out", "f_inner", &mut pkg);
+
+        res.outer.check_pir_layout_invariants().unwrap();
+        res.inner.check_pir_layout_invariants().unwrap();
+
+        let bit_slice_arg = res
+            .outer
+            .nodes
+            .iter()
+            .find_map(|n| match n.payload {
+                NodePayload::BitSlice { arg, .. } => Some(arg),
+                _ => None,
+            })
+            .expect("found outer bit_slice");
+        assert!(matches!(
+            res.outer.nodes[bit_slice_arg.index].payload,
+            NodePayload::OneHot { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
always_equivalent indicates that the rewrites is always correct (semantics preserving). Previously it was attributed at the rewrite kind scope, however a rewrite could be always safe or not always safe depending on local condtions. This change narrows the scope to rewrite instance. At the moment only nary add takes advantage of this feature. Some of the rewrites which absorb operations are always correct given certain local conditions.

Also fix up some fuzzing failures.