### PR TITLE
[prover] Add interruptible equivalence-class proving.

### DIFF
--- a/xlsynth-autocov/src/lib.rs
+++ b/xlsynth-autocov/src/lib.rs
@@ -259,6 +259,9 @@ pub fn relevant_in_pkg(
                         detail: RelevanceDetail::DisprovedEquivalent { equiv: other },
                     })
                 }
+                EquivResult::Interrupted => {
+                    Err("equivalence check interrupted before reaching a conclusion".to_string())
+                }
                 EquivResult::Error(msg) => Err(msg),
             }
         }

--- a/xlsynth-driver/src/prove_enum_in_bound.rs
+++ b/xlsynth-driver/src/prove_enum_in_bound.rs
@@ -317,6 +317,13 @@ pub fn handle_prove_enum_in_bound(matches: &clap::ArgMatches, config: &Option<To
             }
             std::process::exit(1);
         }
+        BoolPropertyResult::Interrupted => {
+            report_cli_error_and_exit(
+                "enum-in-bound proof was interrupted before reaching a conclusion",
+                Some(SUBCOMMAND),
+                Vec::new(),
+            );
+        }
         BoolPropertyResult::Error(msg) => {
             report_cli_error_and_exit(&msg, Some(SUBCOMMAND), Vec::new());
         }

--- a/xlsynth-driver/src/prove_quickcheck.rs
+++ b/xlsynth-driver/src/prove_quickcheck.rs
@@ -216,6 +216,9 @@ pub fn handle_prove_quickcheck(matches: &clap::ArgMatches, config: &Option<Toolc
                         let cex_str = format!("inputs: {:?}, output: {:?}", inputs, output);
                         (false, Some(cex_str))
                     }
+                    BoolPropertyResult::Interrupted => {
+                        (false, Some("proof interrupted".to_string()))
+                    }
                     BoolPropertyResult::ToolchainDisproved(msg)
                     | BoolPropertyResult::Error(msg) => (false, Some(msg)),
                 };

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ext_nary_add_gatify_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ext_nary_add_gatify_equiv.rs
@@ -193,6 +193,9 @@ fuzz_target!(|data: &[u8]| {
         } => panic!(
             "gatify equivalence disproved for generated ext_nary_add IR:\n{ir_text}\nexported:\n{exported_ir_text}\ngate:\n{gate_ir_text}\nlhs_inputs={lhs_inputs:?}\nrhs_inputs={rhs_inputs:?}\nlhs_output={lhs_output:?}\nrhs_output={rhs_output:?}"
         ),
+        EquivResult::Interrupted => panic!(
+            "in-process formal equivalence was interrupted unexpectedly for generated ext_nary_add IR:\n{ir_text}"
+        ),
         EquivResult::ToolchainDisproved(msg) | EquivResult::Error(msg) => panic!(
             "in-process formal equivalence failed for generated ext_nary_add IR:\n{ir_text}\nmessage: {msg}"
         ),

--- a/xlsynth-mcmc-pir/src/lib.rs
+++ b/xlsynth-mcmc-pir/src/lib.rs
@@ -1388,6 +1388,14 @@ fn pir_equiv_oracle<R: Rng>(
             match prove_ir_fn_equiv(lhs, rhs) {
                 EquivResult::Proved => true,
                 EquivResult::Disproved { .. } | EquivResult::ToolchainDisproved(_) => false,
+                EquivResult::Interrupted => {
+                    log::warn!(
+                        "[pir-mcmc] formal oracle interrupted for '{}' vs '{}'; rejecting candidate",
+                        lhs.name,
+                        rhs.name,
+                    );
+                    false
+                }
                 EquivResult::Error(msg) => {
                     log::warn!(
                         "[pir-mcmc] formal oracle error for '{}' vs '{}': {}; rejecting candidate",

--- a/xlsynth-pir/src/edit_distance.rs
+++ b/xlsynth-pir/src/edit_distance.rs
@@ -2,8 +2,12 @@
 
 //! Computes a graph edit distance between two XLS IR functions.
 
+use std::collections::HashSet;
+
 use crate::ir::{Fn, Node, NodePayload};
 use crate::ir::{binop_to_operator, nary_op_to_operator, unop_to_operator};
+use crate::node_hashing::FwdHash;
+use crate::structural_similarity::collect_structural_entries;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum NodeSignature {
@@ -13,6 +17,106 @@ enum NodeSignature {
         operands: Vec<String>,
     },
     Simple(String),
+}
+
+/// Options for ranking candidate functions against a query function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CandidateRankingOptions {
+    /// Maximum number of candidates to keep after the structural-hash prefilter
+    /// and score with edit distance.
+    pub prefilter_limit: usize,
+}
+
+impl Default for CandidateRankingOptions {
+    fn default() -> Self {
+        Self {
+            prefilter_limit: usize::MAX,
+        }
+    }
+}
+
+/// Ranked candidate produced by structural prefiltering followed by edit
+/// distance scoring.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RankedFnCandidate {
+    pub index: usize,
+    pub shared_structural_hashes: usize,
+    pub query_structural_hashes: usize,
+    pub candidate_structural_hashes: usize,
+    pub edit_distance: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StructuralPrefilterCandidate {
+    index: usize,
+    shared_structural_hashes: usize,
+    query_structural_hashes: usize,
+    candidate_structural_hashes: usize,
+}
+
+/// Ranks candidate functions by first applying a cheap structural-hash
+/// prefilter, then computing edit distance for the survivors.
+pub fn rank_fn_candidates_by_similarity(
+    query: &Fn,
+    candidates: &[&Fn],
+    options: CandidateRankingOptions,
+) -> Vec<RankedFnCandidate> {
+    if candidates.is_empty() || options.prefilter_limit == 0 {
+        return Vec::new();
+    }
+
+    let query_hashes: HashSet<FwdHash> = collect_structural_hashes(query);
+    let query_hash_count = query_hashes.len();
+    let prefilter_limit = std::cmp::min(options.prefilter_limit, candidates.len());
+    let mut prefiltered: Vec<StructuralPrefilterCandidate> = candidates
+        .iter()
+        .enumerate()
+        .map(|(index, candidate)| {
+            let candidate_hashes = collect_structural_hashes(candidate);
+            let shared_structural_hashes = candidate_hashes
+                .iter()
+                .filter(|hash| query_hashes.contains(hash))
+                .count();
+            StructuralPrefilterCandidate {
+                index,
+                shared_structural_hashes,
+                query_structural_hashes: query_hash_count,
+                candidate_structural_hashes: candidate_hashes.len(),
+            }
+        })
+        .collect();
+
+    prefiltered.sort_by(|lhs, rhs| {
+        rhs.shared_structural_hashes
+            .cmp(&lhs.shared_structural_hashes)
+            .then_with(|| {
+                lhs.candidate_structural_hashes
+                    .cmp(&rhs.candidate_structural_hashes)
+            })
+            .then_with(|| lhs.index.cmp(&rhs.index))
+    });
+    prefiltered.truncate(prefilter_limit);
+
+    let mut ranked: Vec<RankedFnCandidate> = prefiltered
+        .into_iter()
+        .map(|candidate| RankedFnCandidate {
+            index: candidate.index,
+            shared_structural_hashes: candidate.shared_structural_hashes,
+            query_structural_hashes: candidate.query_structural_hashes,
+            candidate_structural_hashes: candidate.candidate_structural_hashes,
+            edit_distance: compute_edit_distance(query, candidates[candidate.index]),
+        })
+        .collect();
+    ranked.sort_by(|lhs, rhs| {
+        lhs.edit_distance
+            .cmp(&rhs.edit_distance)
+            .then_with(|| {
+                rhs.shared_structural_hashes
+                    .cmp(&lhs.shared_structural_hashes)
+            })
+            .then_with(|| lhs.index.cmp(&rhs.index))
+    });
+    ranked
 }
 
 /// Compute the edit distance between two functions based on their computational
@@ -114,6 +218,11 @@ fn extract_operand_name(node: &Node) -> String {
     } else {
         node.payload.get_operator().to_string()
     }
+}
+
+fn collect_structural_hashes(f: &Fn) -> HashSet<FwdHash> {
+    let (entries, _) = collect_structural_entries(f);
+    entries.into_iter().map(|entry| entry.hash).collect()
 }
 
 #[cfg(test)]
@@ -242,5 +351,85 @@ mod tests {
         let edit_distance = compute_edit_distance(&two_tuple_fn, &singleton_fn);
         // The only difference is the operator in the node ("tuple" vs "identity").
         assert_eq!(edit_distance, 1);
+    }
+
+    #[test]
+    fn test_rank_fn_candidates_by_similarity_prefilters_before_edit_distance() {
+        let query_pkg = parse_ir_from_string(
+            r#"package query_pkg
+            top fn query(x: bits[8], y: bits[8]) -> bits[8] {
+                add.3: bits[8] = add(x, y, id=3)
+                ret sub.4: bits[8] = sub(add.3, y, id=4)
+            }
+            "#,
+        );
+        let exact_pkg = parse_ir_from_string(
+            r#"package exact_pkg
+            top fn exact(x: bits[8], y: bits[8]) -> bits[8] {
+                add.3: bits[8] = add(x, y, id=3)
+                ret sub.4: bits[8] = sub(add.3, y, id=4)
+            }
+            "#,
+        );
+        let close_pkg = parse_ir_from_string(
+            r#"package close_pkg
+            top fn close(x: bits[8], y: bits[8]) -> bits[8] {
+                add.3: bits[8] = add(x, y, id=3)
+                ret sub.4: bits[8] = sub(add.3, x, id=4)
+            }
+            "#,
+        );
+        let far_pkg = parse_ir_from_string(
+            r#"package far_pkg
+            top fn far(x: bits[8], y: bits[8]) -> bits[8] {
+                umul.3: bits[8] = umul(x, y, id=3)
+                ret not.4: bits[8] = not(umul.3, id=4)
+            }
+            "#,
+        );
+
+        let query = query_pkg.get_top_fn().unwrap();
+        let exact = exact_pkg.get_top_fn().unwrap();
+        let close = close_pkg.get_top_fn().unwrap();
+        let far = far_pkg.get_top_fn().unwrap();
+        let ranked = rank_fn_candidates_by_similarity(
+            query,
+            &[far, close, exact],
+            CandidateRankingOptions { prefilter_limit: 2 },
+        );
+
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].index, 2);
+        assert_eq!(ranked[0].edit_distance, 0);
+        assert_eq!(ranked[1].index, 1);
+        assert_eq!(ranked[1].edit_distance, 1);
+    }
+
+    #[test]
+    fn test_rank_fn_candidates_by_similarity_zero_limit() {
+        let query_pkg = parse_ir_from_string(
+            r#"package query_pkg
+            top fn query(x: bits[1]) -> bits[1] {
+                ret identity.2: bits[1] = identity(x, id=2)
+            }
+            "#,
+        );
+        let candidate_pkg = parse_ir_from_string(
+            r#"package candidate_pkg
+            top fn candidate(x: bits[1]) -> bits[1] {
+                ret not.2: bits[1] = not(x, id=2)
+            }
+            "#,
+        );
+        let query = query_pkg.get_top_fn().unwrap();
+        let candidate = candidate_pkg.get_top_fn().unwrap();
+
+        let ranked = rank_fn_candidates_by_similarity(
+            query,
+            &[candidate],
+            CandidateRankingOptions { prefilter_limit: 0 },
+        );
+
+        assert!(ranked.is_empty());
     }
 }

--- a/xlsynth-prover/README.md
+++ b/xlsynth-prover/README.md
@@ -1,0 +1,102 @@
+# `xlsynth-prover`
+
+Formal proof helpers for XLS IR and DSLX.
+
+This crate exposes both low-level proving primitives and higher-level request
+APIs used by `xlsynth-driver`.
+
+## Main APIs
+
+### Pairwise IR equivalence
+
+Use these when you already have parsed PIR functions or package text and want a
+single equivalence proof:
+
+- `xlsynth_prover::prover::prove_ir_fn_equiv()`
+- `xlsynth_prover::prover::prove_ir_equiv()`
+- `xlsynth_prover::prover::prove_ir_pkg_text_equiv()`
+
+The `prove_ir_equiv()` entry point is the most configurable of the low-level
+APIs. It takes `ProverFn` values plus options such as:
+
+- `EquivParallelism`
+- `AssertionSemantics`
+- assertion label filtering
+- aggregate flattening
+
+### Structured IR-vs-IR proofs
+
+Use `xlsynth_prover::ir_equiv` when the inputs are IR text plus proof options
+and you want a structured request/report API instead of manually building
+`ProverFn` values.
+
+Main types:
+
+- `IrModule`
+- `IrEquivRequest`
+- `run_ir_equiv()`
+
+This API is a good fit for embedding the prover in higher-level tools that need
+stable request/response structs.
+
+### Equivalence-class membership
+
+Use this when you have a candidate `C` and a corpus of known-equivalent members
+`E`, and you want to prove whether `C` belongs to that class.
+
+Main types:
+
+- `EquivClassMember`
+- `EquivClassRequest`
+- `EquivClassShortlistOptions`
+- `EquivClassReport`
+- `EquivClassResult`
+- `run_ir_equiv_class_membership()`
+
+Behavior:
+
+- ranks members with a structural-hash prepass plus edit distance
+- runs bounded parallel pairwise proofs
+- after the first proved match, stops scheduling new work and requests
+  interruption of in-flight losing proofs
+- reports an invariant violation if concurrently completed conclusive proofs
+  disagree during stop propagation
+- excludes interrupted losing proofs from that invariant check
+
+This means the class-membership API usually finishes approximately as soon as
+the first proved match completes, plus a small amount of worker unwind time.
+That prompt stop behavior is currently meaningful with Bitwuzla, which supports
+cooperative interruption inside the solver `check()` call. Other backends still
+use the default no-op interrupt path, so they only stop taking on new work and
+may let already-running solver calls finish naturally.
+
+### QuickCheck-style proof APIs
+
+Use these when proving that boolean-returning functions or DSLX quickchecks are
+always true:
+
+- `xlsynth_prover::prover::prove_ir_fn_quickcheck()`
+- `xlsynth_prover::prover::prove_ir_quickcheck()`
+- `xlsynth_prover::prover::prove_dslx_quickcheck()`
+
+## Solver Selection
+
+The low-level `prover::*` convenience functions use `SolverChoice::Auto`, which
+selects the best available backend for the current build.
+
+If you need explicit control over the backend, use the structured request APIs
+and set:
+
+- `IrEquivRequest::with_solver()`
+- `EquivClassRequest::with_solver()`
+
+Available backends depend on enabled cargo features and local tool
+availability.
+
+## Module Guide
+
+- `ir_equiv`: structured IR proof request/report APIs
+- `prover`: core proving traits, solver selection, and convenience entry points
+- `solver`: SMT solver adapters
+- `dslx_equiv`: DSLX-oriented equivalence helpers
+- `dslx_utils` / `dslx_tactics`: DSLX support utilities

--- a/xlsynth-prover/src/ir_equiv.rs
+++ b/xlsynth-prover/src/ir_equiv.rs
@@ -7,10 +7,17 @@ use crate::prover::types::{
     AssertionSemantics, EquivParallelism, EquivReport, EquivResult, ParamDomains, ProverFn,
 };
 use crate::prover::{SolverChoice, prover_for_choice};
+use crate::solver::{AtomicSolverInterrupt, SolverInterruptHandle};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Instant;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use xlsynth_pir::edit_distance::{
+    CandidateRankingOptions, RankedFnCandidate, rank_fn_candidates_by_similarity,
+};
+use xlsynth_pir::ir;
 
 /// Description of a single IR module participating in equivalence.
 #[derive(Clone)]
@@ -139,48 +146,681 @@ impl<'a> IrEquivRequest<'a> {
     }
 }
 
+/// Member of a candidate equivalence class.
+#[derive(Clone)]
+pub struct EquivClassMember<'a> {
+    pub id: Cow<'a, str>,
+    pub module: IrModule<'a>,
+}
+
+impl<'a> EquivClassMember<'a> {
+    /// Creates a new equivalence-class member description.
+    pub fn new<S: Into<Cow<'a, str>>>(id: S, module: IrModule<'a>) -> Self {
+        Self {
+            id: id.into(),
+            module,
+        }
+    }
+}
+
+/// Controls how aggressively the equivalence-class API shortlists class
+/// members before formal proofs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EquivClassShortlistOptions {
+    /// When the class has more than `max_parallel_proofs` members, compute edit
+    /// distance for at most `prefilter_multiplier * max_parallel_proofs`
+    /// structurally closest members.
+    pub prefilter_multiplier: usize,
+}
+
+impl Default for EquivClassShortlistOptions {
+    fn default() -> Self {
+        Self {
+            prefilter_multiplier: 4,
+        }
+    }
+}
+
+impl EquivClassShortlistOptions {
+    fn effective_prefilter_limit(self, total_members: usize, max_parallel_proofs: usize) -> usize {
+        if total_members <= max_parallel_proofs {
+            total_members
+        } else {
+            std::cmp::min(
+                total_members,
+                self.prefilter_multiplier
+                    .max(1)
+                    .saturating_mul(max_parallel_proofs),
+            )
+        }
+    }
+}
+
+/// Request describing a candidate-vs-class membership proof.
+#[derive(Clone)]
+pub struct EquivClassRequest<'a> {
+    pub candidate: IrModule<'a>,
+    pub members: Vec<EquivClassMember<'a>>,
+    pub drop_params: &'a [String],
+    pub flatten_aggregates: bool,
+    pub parallelism: EquivParallelism,
+    pub assertion_semantics: AssertionSemantics,
+    pub assert_label_filter: Option<&'a str>,
+    pub solver: Option<SolverChoice>,
+    pub tool_path: Option<&'a Path>,
+    pub max_parallel_proofs: usize,
+    pub shortlist: EquivClassShortlistOptions,
+}
+
+impl<'a> EquivClassRequest<'a> {
+    /// Creates a new equivalence-class membership request.
+    pub fn new(candidate: IrModule<'a>, members: Vec<EquivClassMember<'a>>) -> Self {
+        Self {
+            candidate,
+            members,
+            drop_params: &[],
+            flatten_aggregates: false,
+            parallelism: EquivParallelism::SingleThreaded,
+            assertion_semantics: AssertionSemantics::Ignore,
+            assert_label_filter: None,
+            solver: None,
+            tool_path: None,
+            max_parallel_proofs: default_max_parallel_proofs(),
+            shortlist: EquivClassShortlistOptions::default(),
+        }
+    }
+
+    pub fn with_drop_params(mut self, drop_params: &'a [String]) -> Self {
+        self.drop_params = drop_params;
+        self
+    }
+
+    pub fn with_flatten_aggregates(mut self, flatten: bool) -> Self {
+        self.flatten_aggregates = flatten;
+        self
+    }
+
+    pub fn with_parallelism(mut self, parallelism: EquivParallelism) -> Self {
+        self.parallelism = parallelism;
+        self
+    }
+
+    pub fn with_assertion_semantics(mut self, semantics: AssertionSemantics) -> Self {
+        self.assertion_semantics = semantics;
+        self
+    }
+
+    pub fn with_assert_label_filter(mut self, filter: Option<&'a str>) -> Self {
+        self.assert_label_filter = filter;
+        self
+    }
+
+    pub fn with_solver(mut self, solver: Option<SolverChoice>) -> Self {
+        self.solver = solver;
+        self
+    }
+
+    pub fn with_tool_path(mut self, tool_path: Option<&'a Path>) -> Self {
+        self.tool_path = tool_path;
+        self
+    }
+
+    pub fn with_max_parallel_proofs(mut self, max_parallel_proofs: usize) -> Self {
+        self.max_parallel_proofs = max_parallel_proofs;
+        self
+    }
+
+    pub fn with_shortlist_options(mut self, shortlist: EquivClassShortlistOptions) -> Self {
+        self.shortlist = shortlist;
+        self
+    }
+}
+
+/// Ranking metadata for one shortlisted class member.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EquivClassRankingEntry {
+    pub shortlist_rank: usize,
+    pub member_index: usize,
+    pub member_id: String,
+    pub shared_structural_hashes: usize,
+    pub candidate_structural_hashes: usize,
+    pub member_structural_hashes: usize,
+    pub edit_distance: u64,
+}
+
+/// Completed proof attempt against one class member.
+#[derive(Debug, Clone)]
+pub struct EquivClassProofEntry {
+    pub member_index: usize,
+    pub member_id: String,
+    pub ranking: EquivClassRankingEntry,
+    pub report: EquivReport,
+}
+
+/// Metadata for a successful class-membership match.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EquivClassMatch {
+    pub member_index: usize,
+    pub member_id: String,
+    pub shortlist_rank: usize,
+}
+
+/// Reason the class-membership API did not find an equivalent member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EquivClassNoMatchReason {
+    NoMembers,
+    ExhaustedShortlist,
+}
+
+/// Outcome of an equivalence-class membership proof.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EquivClassResult {
+    Matched(EquivClassMatch),
+    NoMatch { reason: EquivClassNoMatchReason },
+    InvariantViolation { message: String },
+    Error { message: String },
+}
+
+/// Detailed report for a class-membership proof run.
+#[derive(Debug, Clone)]
+pub struct EquivClassReport {
+    pub duration: Duration,
+    pub total_members: usize,
+    pub max_parallel_proofs: usize,
+    pub shortlisted_members: Vec<EquivClassRankingEntry>,
+    pub completed_proofs: Vec<EquivClassProofEntry>,
+    pub excluded_by_shortlist_count: usize,
+    pub unstarted_shortlist_count: usize,
+    pub result: EquivClassResult,
+}
+
+struct PreparedIrModule {
+    pkg: ir::Package,
+    func: ir::Fn,
+    param_domains: Option<ParamDomains>,
+    uf_map: HashMap<String, String>,
+    fixed_implicit_activation: bool,
+}
+
+impl PreparedIrModule {
+    fn from_ir_module(module: &IrModule<'_>, drop_params: &[String]) -> Result<Self, String> {
+        let (pkg, func) =
+            ir_utils::parse_package_and_drop_params(module.source, module.top, drop_params)?;
+        Ok(Self {
+            pkg,
+            func,
+            param_domains: module.param_domains.cloned(),
+            uf_map: module.uf_map.clone().into_owned(),
+            fixed_implicit_activation: module.fixed_implicit_activation,
+        })
+    }
+
+    fn as_prover_fn(&self) -> ProverFn<'_> {
+        ProverFn::new(&self.func, Some(&self.pkg))
+            .with_fixed_implicit_activation(self.fixed_implicit_activation)
+            .with_domains(self.param_domains.clone())
+            .with_uf_map(self.uf_map.clone())
+    }
+}
+
+struct PreparedEquivClassMember {
+    id: String,
+    module: PreparedIrModule,
+}
+
+#[derive(Clone, Copy)]
+struct EquivRunConfig<'a> {
+    flatten_aggregates: bool,
+    parallelism: EquivParallelism,
+    assertion_semantics: AssertionSemantics,
+    assert_label_filter: Option<&'a str>,
+    solver: Option<SolverChoice>,
+    tool_path: Option<&'a Path>,
+}
+
+fn default_max_parallel_proofs() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+fn normalize_parallelism(requested: usize) -> usize {
+    requested.max(1)
+}
+
+fn total_free_param_width(module: &PreparedIrModule) -> usize {
+    let skip_params = if module.fixed_implicit_activation {
+        2
+    } else {
+        0
+    };
+    module
+        .func
+        .params
+        .iter()
+        .skip(skip_params)
+        .map(|param| param.ty.bit_count())
+        .sum()
+}
+
+fn validate_equiv_compatibility(
+    lhs: &PreparedIrModule,
+    rhs: &PreparedIrModule,
+    allow_flatten: bool,
+) -> Result<(), String> {
+    if allow_flatten {
+        let lhs_param_width = total_free_param_width(lhs);
+        let rhs_param_width = total_free_param_width(rhs);
+        if lhs_param_width != rhs_param_width {
+            return Err(format!(
+                "flattened input widths differ: lhs={} rhs={}",
+                lhs_param_width, rhs_param_width
+            ));
+        }
+        let lhs_return_width = lhs.func.ret_ty.bit_count();
+        let rhs_return_width = rhs.func.ret_ty.bit_count();
+        if lhs_return_width != rhs_return_width {
+            return Err(format!(
+                "return widths differ: lhs={} rhs={}",
+                lhs_return_width, rhs_return_width
+            ));
+        }
+        Ok(())
+    } else if lhs.func.get_type() != rhs.func.get_type() {
+        Err(format!(
+            "function signatures differ: lhs={:?} rhs={:?}",
+            lhs.func.get_type(),
+            rhs.func.get_type()
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn run_prepared_ir_equiv(
+    config: EquivRunConfig<'_>,
+    lhs: &PreparedIrModule,
+    rhs: &PreparedIrModule,
+    interrupt: Option<SolverInterruptHandle>,
+) -> EquivReport {
+    let start_time = Instant::now();
+    let result = match validate_equiv_compatibility(lhs, rhs, config.flatten_aggregates) {
+        Ok(()) => {
+            let choice = config.solver.unwrap_or(SolverChoice::Auto);
+            let prover = prover_for_choice(choice, config.tool_path);
+            let lhs_side = lhs.as_prover_fn();
+            let rhs_side = rhs.as_prover_fn();
+            prover.prove_ir_equiv_with_interrupt(
+                &lhs_side,
+                &rhs_side,
+                config.parallelism,
+                config.assertion_semantics,
+                config.assert_label_filter,
+                config.flatten_aggregates,
+                interrupt,
+            )
+        }
+        Err(msg) => EquivResult::Error(msg),
+    };
+    EquivReport {
+        duration: start_time.elapsed(),
+        result,
+    }
+}
+
+fn build_ranked_shortlist(
+    candidate: &PreparedIrModule,
+    members: &[PreparedEquivClassMember],
+    max_parallel_proofs: usize,
+    shortlist: EquivClassShortlistOptions,
+) -> Vec<EquivClassRankingEntry> {
+    if members.is_empty() {
+        return Vec::new();
+    }
+    let member_refs: Vec<&ir::Fn> = members.iter().map(|member| &member.module.func).collect();
+    let ranked: Vec<RankedFnCandidate> = rank_fn_candidates_by_similarity(
+        &candidate.func,
+        &member_refs,
+        CandidateRankingOptions {
+            prefilter_limit: shortlist
+                .effective_prefilter_limit(members.len(), max_parallel_proofs),
+        },
+    );
+    ranked
+        .into_iter()
+        .enumerate()
+        .map(
+            |(shortlist_rank, candidate_ranking)| EquivClassRankingEntry {
+                shortlist_rank,
+                member_index: candidate_ranking.index,
+                member_id: members[candidate_ranking.index].id.clone(),
+                shared_structural_hashes: candidate_ranking.shared_structural_hashes,
+                candidate_structural_hashes: candidate_ranking.query_structural_hashes,
+                member_structural_hashes: candidate_ranking.candidate_structural_hashes,
+                edit_distance: candidate_ranking.edit_distance,
+            },
+        )
+        .collect()
+}
+
+fn describe_result_kind(result: &EquivResult) -> String {
+    match result {
+        EquivResult::Proved => "proved".to_string(),
+        EquivResult::Disproved { .. } => "disproved".to_string(),
+        EquivResult::Interrupted => "interrupted".to_string(),
+        EquivResult::ToolchainDisproved(msg) => {
+            format!("toolchain-disproved: {}", msg)
+        }
+        EquivResult::Error(msg) => format!("error: {}", msg),
+    }
+}
+
+fn is_conclusive_equiv_result(result: &EquivResult) -> bool {
+    matches!(
+        result,
+        EquivResult::Proved | EquivResult::Disproved { .. } | EquivResult::ToolchainDisproved(_)
+    )
+}
+
+fn resolve_equiv_class_result(
+    shortlisted_members: &[EquivClassRankingEntry],
+    completed_proofs: &[EquivClassProofEntry],
+) -> EquivClassResult {
+    let proved_members: Vec<&EquivClassProofEntry> = completed_proofs
+        .iter()
+        .filter(|entry| matches!(&entry.report.result, EquivResult::Proved))
+        .collect();
+    if !proved_members.is_empty() {
+        let conflicting: Vec<String> = completed_proofs
+            .iter()
+            .filter(|entry| {
+                is_conclusive_equiv_result(&entry.report.result)
+                    && !matches!(&entry.report.result, EquivResult::Proved)
+            })
+            .map(|entry| {
+                format!(
+                    "{} ({})",
+                    entry.member_id,
+                    describe_result_kind(&entry.report.result)
+                )
+            })
+            .collect();
+        if !conflicting.is_empty() {
+            return EquivClassResult::InvariantViolation {
+                message: format!(
+                    "concurrently completed proofs disagreed after a winning proof: {}",
+                    conflicting.join(", ")
+                ),
+            };
+        }
+        if let Some(first_error) =
+            completed_proofs
+                .iter()
+                .find_map(|entry| match &entry.report.result {
+                    EquivResult::Error(msg) => Some((entry.member_id.clone(), msg.clone())),
+                    _ => None,
+                })
+        {
+            return EquivClassResult::Error {
+                message: format!(
+                    "proof against member '{}' failed: {}",
+                    first_error.0, first_error.1
+                ),
+            };
+        }
+        if let Some(winner) = shortlisted_members.iter().find(|ranking| {
+            proved_members
+                .iter()
+                .any(|entry| entry.member_index == ranking.member_index)
+        }) {
+            return EquivClassResult::Matched(EquivClassMatch {
+                member_index: winner.member_index,
+                member_id: winner.member_id.clone(),
+                shortlist_rank: winner.shortlist_rank,
+            });
+        }
+    }
+    if let Some(first_error) =
+        completed_proofs
+            .iter()
+            .find_map(|entry| match &entry.report.result {
+                EquivResult::Error(msg) => Some((entry.member_id.clone(), msg.clone())),
+                _ => None,
+            })
+    {
+        return EquivClassResult::Error {
+            message: format!(
+                "proof against member '{}' failed: {}",
+                first_error.0, first_error.1
+            ),
+        };
+    }
+    if shortlisted_members.is_empty() {
+        EquivClassResult::NoMatch {
+            reason: EquivClassNoMatchReason::NoMembers,
+        }
+    } else {
+        EquivClassResult::NoMatch {
+            reason: EquivClassNoMatchReason::ExhaustedShortlist,
+        }
+    }
+}
+
 /// Dispatches an IR equivalence comparison using the requested solver.
 pub fn run_ir_equiv(request: &IrEquivRequest<'_>) -> Result<EquivReport, String> {
-    let choice = request.solver.unwrap_or(SolverChoice::Auto);
-    let prover = prover_for_choice(choice, request.tool_path);
-    let (lhs_pkg, lhs_fn_dropped) = ir_utils::parse_package_and_drop_params(
-        request.lhs.source,
-        request.lhs.top,
-        request.drop_params,
-    )?;
-    let (rhs_pkg, rhs_fn_dropped) = ir_utils::parse_package_and_drop_params(
-        request.rhs.source,
-        request.rhs.top,
-        request.drop_params,
-    )?;
-
-    let assert_label_filter = request.assert_label_filter;
-
-    let lhs_side = ProverFn::new(&lhs_fn_dropped, Some(&lhs_pkg))
-        .with_fixed_implicit_activation(request.lhs.fixed_implicit_activation)
-        .with_domains(request.lhs.param_domains.map(|d| d.clone()))
-        .with_uf_map(request.lhs.uf_map.clone().into_owned());
-    let rhs_side = ProverFn::new(&rhs_fn_dropped, Some(&rhs_pkg))
-        .with_fixed_implicit_activation(request.rhs.fixed_implicit_activation)
-        .with_domains(request.rhs.param_domains.map(|d| d.clone()))
-        .with_uf_map(request.rhs.uf_map.clone().into_owned());
-
-    let start_time = Instant::now();
-    let result = prover.prove_ir_equiv(
-        &lhs_side,
-        &rhs_side,
-        request.parallelism,
-        request.assertion_semantics,
-        assert_label_filter,
-        request.flatten_aggregates,
+    let lhs = PreparedIrModule::from_ir_module(&request.lhs, request.drop_params)?;
+    let rhs = PreparedIrModule::from_ir_module(&request.rhs, request.drop_params)?;
+    let report = run_prepared_ir_equiv(
+        EquivRunConfig {
+            flatten_aggregates: request.flatten_aggregates,
+            parallelism: request.parallelism,
+            assertion_semantics: request.assertion_semantics,
+            assert_label_filter: request.assert_label_filter,
+            solver: request.solver,
+            tool_path: request.tool_path,
+        },
+        &lhs,
+        &rhs,
+        None,
     );
-    let duration = start_time.elapsed();
+    match &report.result {
+        EquivResult::Error(msg) => Err(msg.clone()),
+        _ => Ok(report),
+    }
+}
 
-    match result {
-        EquivResult::Error(msg) => Err(msg),
-        other => Ok(EquivReport {
-            duration,
-            result: other,
-        }),
+/// Proves whether the candidate belongs to an existing equivalence class.
+///
+/// The current implementation uses in-process worker threads with cooperative
+/// early stop plus solver-level interruption where supported by the backend.
+pub fn run_ir_equiv_class_membership(
+    request: &EquivClassRequest<'_>,
+) -> Result<EquivClassReport, String> {
+    let start_time = Instant::now();
+    let max_parallel_proofs = normalize_parallelism(request.max_parallel_proofs);
+    let candidate = PreparedIrModule::from_ir_module(&request.candidate, request.drop_params)?;
+    let prepared_members: Vec<PreparedEquivClassMember> = request
+        .members
+        .iter()
+        .map(|member| {
+            Ok(PreparedEquivClassMember {
+                id: member.id.clone().into_owned(),
+                module: PreparedIrModule::from_ir_module(&member.module, request.drop_params)?,
+            })
+        })
+        .collect::<Result<Vec<PreparedEquivClassMember>, String>>()?;
+    let shortlisted_members = build_ranked_shortlist(
+        &candidate,
+        &prepared_members,
+        max_parallel_proofs,
+        request.shortlist,
+    );
+
+    let completed_proofs: Vec<EquivClassProofEntry> = if shortlisted_members.is_empty() {
+        Vec::new()
+    } else {
+        let worker_count = std::cmp::min(shortlisted_members.len(), max_parallel_proofs);
+        let next_shortlist_index = Arc::new(AtomicUsize::new(0));
+        let stop_requested = AtomicSolverInterrupt::new();
+        let completed_proofs = Arc::new(Mutex::new(Vec::<EquivClassProofEntry>::new()));
+        std::thread::scope(|scope| {
+            for _ in 0..worker_count {
+                let next_shortlist_index_cl = Arc::clone(&next_shortlist_index);
+                let stop_requested_cl = stop_requested.clone();
+                let completed_proofs_cl = Arc::clone(&completed_proofs);
+                let candidate_ref = &candidate;
+                let prepared_members_ref = &prepared_members;
+                let shortlisted_members_ref = &shortlisted_members;
+                let run_config = EquivRunConfig {
+                    flatten_aggregates: request.flatten_aggregates,
+                    parallelism: request.parallelism,
+                    assertion_semantics: request.assertion_semantics,
+                    assert_label_filter: request.assert_label_filter,
+                    solver: request.solver,
+                    tool_path: request.tool_path,
+                };
+                scope.spawn(move || {
+                    loop {
+                        if stop_requested_cl.is_interrupted() {
+                            break;
+                        }
+                        let shortlist_index =
+                            next_shortlist_index_cl.fetch_add(1, Ordering::SeqCst);
+                        if shortlist_index >= shortlisted_members_ref.len() {
+                            break;
+                        }
+                        let ranking = shortlisted_members_ref[shortlist_index].clone();
+                        let member = &prepared_members_ref[ranking.member_index];
+                        let report = run_prepared_ir_equiv(
+                            run_config,
+                            candidate_ref,
+                            &member.module,
+                            Some(stop_requested_cl.handle()),
+                        );
+                        let proved = matches!(&report.result, EquivResult::Proved);
+                        completed_proofs_cl
+                            .lock()
+                            .expect("proof result collection lock")
+                            .push(EquivClassProofEntry {
+                                member_index: ranking.member_index,
+                                member_id: member.id.clone(),
+                                ranking,
+                                report,
+                            });
+                        if proved {
+                            stop_requested_cl.interrupt();
+                        }
+                    }
+                });
+            }
+        });
+        let mut completed = Arc::try_unwrap(completed_proofs)
+            .expect("no other proof collectors remain")
+            .into_inner()
+            .expect("proof result collection lock available");
+        completed.sort_by(|lhs, rhs| {
+            lhs.ranking
+                .shortlist_rank
+                .cmp(&rhs.ranking.shortlist_rank)
+                .then_with(|| lhs.member_index.cmp(&rhs.member_index))
+        });
+        completed
+    };
+
+    let excluded_by_shortlist_count = prepared_members
+        .len()
+        .saturating_sub(shortlisted_members.len());
+    let unstarted_shortlist_count = shortlisted_members
+        .len()
+        .saturating_sub(completed_proofs.len());
+    let result = resolve_equiv_class_result(&shortlisted_members, &completed_proofs);
+    Ok(EquivClassReport {
+        duration: start_time.elapsed(),
+        total_members: prepared_members.len(),
+        max_parallel_proofs,
+        shortlisted_members,
+        completed_proofs,
+        excluded_by_shortlist_count,
+        unstarted_shortlist_count,
+        result,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        EquivClassProofEntry, EquivClassRankingEntry, EquivClassResult, EquivReport, EquivResult,
+        resolve_equiv_class_result,
+    };
+
+    fn make_ranking(
+        shortlist_rank: usize,
+        member_index: usize,
+        member_id: &str,
+    ) -> EquivClassRankingEntry {
+        EquivClassRankingEntry {
+            shortlist_rank,
+            member_index,
+            member_id: member_id.to_string(),
+            shared_structural_hashes: 0,
+            candidate_structural_hashes: 0,
+            member_structural_hashes: 0,
+            edit_distance: shortlist_rank as u64,
+        }
+    }
+
+    fn make_completed_proof(
+        ranking: EquivClassRankingEntry,
+        result: EquivResult,
+    ) -> EquivClassProofEntry {
+        EquivClassProofEntry {
+            member_index: ranking.member_index,
+            member_id: ranking.member_id.clone(),
+            ranking,
+            report: EquivReport {
+                duration: std::time::Duration::default(),
+                result,
+            },
+        }
+    }
+
+    #[test]
+    fn test_resolve_equiv_class_result_reports_invariant_violation_on_conflict() {
+        let shortlist = vec![make_ranking(0, 0, "winner"), make_ranking(1, 1, "conflict")];
+        let completed = vec![
+            make_completed_proof(shortlist[0].clone(), EquivResult::Proved),
+            make_completed_proof(
+                shortlist[1].clone(),
+                EquivResult::ToolchainDisproved("counterexample".to_string()),
+            ),
+        ];
+
+        match resolve_equiv_class_result(&shortlist, &completed) {
+            EquivClassResult::InvariantViolation { message } => {
+                assert!(message.contains("conflict"));
+            }
+            other => panic!("expected invariant violation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_resolve_equiv_class_result_ignores_interrupted_losers_after_winner() {
+        let shortlist = vec![
+            make_ranking(0, 0, "winner"),
+            make_ranking(1, 1, "cancelled"),
+        ];
+        let completed = vec![
+            make_completed_proof(shortlist[0].clone(), EquivResult::Proved),
+            make_completed_proof(shortlist[1].clone(), EquivResult::Interrupted),
+        ];
+
+        assert_eq!(
+            resolve_equiv_class_result(&shortlist, &completed),
+            EquivClassResult::Matched(super::EquivClassMatch {
+                member_index: 0,
+                member_id: "winner".to_string(),
+                shortlist_rank: 0,
+            })
+        );
     }
 }

--- a/xlsynth-prover/src/lib.rs
+++ b/xlsynth-prover/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc = include_str!("../README.md")]
+
 pub mod dslx_equiv;
 pub mod dslx_specializer;
 pub mod dslx_tactics;

--- a/xlsynth-prover/src/prover/corner_prover.rs
+++ b/xlsynth-prover/src/prover/corner_prover.rs
@@ -272,6 +272,9 @@ impl<'a, S: Solver> CornerProverSession<'a, S> {
         let r = self.solver.check().map_err(|e| e.to_string())?;
         let out = match r {
             Response::Unsat => CornerOrResult::Unsat,
+            Response::Interrupted => CornerOrResult::Unknown {
+                message: "solver interrupted".to_string(),
+            },
             Response::Unknown => CornerOrResult::Unknown {
                 message: "solver returned unknown".to_string(),
             },

--- a/xlsynth-prover/src/prover/ir_equiv.rs
+++ b/xlsynth-prover/src/prover/ir_equiv.rs
@@ -14,7 +14,7 @@ use super::{
     translate::{get_fn_inputs, ir_to_smt, ir_value_to_bv},
     uf::infer_merged_uf_signatures,
 };
-use crate::solver::{BitVec, Response, Solver};
+use crate::solver::{BitVec, Response, Solver, SolverInterruptHandle};
 use regex::Regex;
 use xlsynth_pir::ir;
 pub struct AlignedFnInputs<'a, R> {
@@ -142,12 +142,41 @@ pub fn align_fn_inputs<'a, S: Solver>(
     }
 }
 
-fn check_aligned_fn_equiv_internal<'a, S: Solver>(
+fn interrupt_requested(interrupt: Option<&SolverInterruptHandle>) -> bool {
+    interrupt
+        .map(|interrupt_handle| interrupt_handle.should_interrupt())
+        .unwrap_or(false)
+}
+
+fn non_proved_result_priority(result: &EquivResult) -> u8 {
+    match result {
+        EquivResult::Disproved { .. } => 3,
+        EquivResult::Error(_) => 2,
+        EquivResult::Interrupted => 1,
+        EquivResult::Proved | EquivResult::ToolchainDisproved(_) => 0,
+    }
+}
+
+fn merge_non_proved_result(existing: &mut Option<EquivResult>, candidate: EquivResult) {
+    if matches!(candidate, EquivResult::Proved) {
+        return;
+    }
+    let should_replace = existing
+        .as_ref()
+        .map(|current| non_proved_result_priority(&candidate) > non_proved_result_priority(current))
+        .unwrap_or(true);
+    if should_replace {
+        *existing = Some(candidate);
+    }
+}
+
+fn check_aligned_fn_equiv_internal_with_interrupt<'a, S: Solver>(
     solver: &mut S,
     lhs: &SmtFn<'a, S::Term>,
     rhs: &SmtFn<'a, S::Term>,
     assertion_semantics: AssertionSemantics,
     assert_label_include: Option<&Regex>,
+    interrupt: Option<SolverInterruptHandle>,
 ) -> EquivResult {
     // --------------------------------------------
     // Helper: build a 1-bit "failed" flag for each
@@ -214,7 +243,7 @@ fn check_aligned_fn_equiv_internal<'a, S: Solver>(
 
     solver.assert(&condition).unwrap();
 
-    match solver.check().unwrap() {
+    match solver.check_with_interrupt(interrupt).unwrap() {
         Response::Sat => {
             // Helper to fetch first violated assertion (if any)
             let get_assertion =
@@ -282,7 +311,8 @@ fn check_aligned_fn_equiv_internal<'a, S: Solver>(
             }
         }
         Response::Unsat => EquivResult::Proved,
-        Response::Unknown => panic!("Solver returned unknown result"),
+        Response::Interrupted => EquivResult::Interrupted,
+        Response::Unknown => EquivResult::Error("solver returned unknown result".to_string()),
     }
 }
 
@@ -296,6 +326,29 @@ pub fn prove_ir_fn_equiv<'a, S: Solver>(
     assert_label_include: Option<&Regex>,
     allow_flatten: bool,
 ) -> EquivResult {
+    prove_ir_fn_equiv_with_interrupt::<S>(
+        solver_config,
+        lhs,
+        rhs,
+        assertion_semantics,
+        assert_label_include,
+        allow_flatten,
+        None,
+    )
+}
+
+pub fn prove_ir_fn_equiv_with_interrupt<'a, S: Solver>(
+    solver_config: &S::Config,
+    lhs: &ProverFn<'a>,
+    rhs: &ProverFn<'a>,
+    assertion_semantics: AssertionSemantics,
+    assert_label_include: Option<&Regex>,
+    allow_flatten: bool,
+    interrupt: Option<SolverInterruptHandle>,
+) -> EquivResult {
+    if interrupt_requested(interrupt.as_ref()) {
+        return EquivResult::Interrupted;
+    }
     let uf_signatures: HashMap<String, UfSignature> =
         if lhs.uf_map.is_empty() && rhs.uf_map.is_empty() {
             HashMap::new()
@@ -356,12 +409,16 @@ pub fn prove_ir_fn_equiv<'a, S: Solver>(
     let aligned = align_fn_inputs(&mut solver, &fn_inputs_lhs, &fn_inputs_rhs, allow_flatten);
     let smt_lhs = ir_to_smt(&mut solver, &aligned.lhs, &lhs.uf_map, &uf_registry);
     let smt_rhs = ir_to_smt(&mut solver, &aligned.rhs, &rhs.uf_map, &uf_registry);
-    check_aligned_fn_equiv_internal(
+    if interrupt_requested(interrupt.as_ref()) {
+        return EquivResult::Interrupted;
+    }
+    check_aligned_fn_equiv_internal_with_interrupt(
         &mut solver,
         &smt_lhs,
         &smt_rhs,
         assertion_semantics,
         assert_label_include,
+        interrupt,
     )
 }
 
@@ -407,6 +464,26 @@ pub fn prove_ir_fn_equiv_output_bits_parallel<'a, S: Solver>(
     assert_label_include: Option<&Regex>,
     allow_flatten: bool,
 ) -> EquivResult {
+    prove_ir_fn_equiv_output_bits_parallel_with_interrupt::<S>(
+        solver_config,
+        lhs,
+        rhs,
+        assertion_semantics,
+        assert_label_include,
+        allow_flatten,
+        None,
+    )
+}
+
+pub fn prove_ir_fn_equiv_output_bits_parallel_with_interrupt<'a, S: Solver>(
+    solver_config: &S::Config,
+    lhs: &ProverFn<'a>,
+    rhs: &ProverFn<'a>,
+    assertion_semantics: AssertionSemantics,
+    assert_label_include: Option<&Regex>,
+    allow_flatten: bool,
+    interrupt: Option<SolverInterruptHandle>,
+) -> EquivResult {
     let width = lhs.fn_ref.ret_ty.bit_count();
     assert_eq!(
         width,
@@ -416,18 +493,19 @@ pub fn prove_ir_fn_equiv_output_bits_parallel<'a, S: Solver>(
     if width == 0 {
         // Zero-width values – fall back to the standard equivalence prover because
         // there is no bit to split on.
-        return prove_ir_fn_equiv::<S>(
+        return prove_ir_fn_equiv_with_interrupt::<S>(
             solver_config,
             lhs,
             rhs,
             assertion_semantics,
             assert_label_include,
             allow_flatten,
+            interrupt,
         );
     };
 
-    let found = Arc::new(AtomicBool::new(false));
-    let counterexample: Arc<Mutex<Option<EquivResult>>> = Arc::new(Mutex::new(None));
+    let stop_requested = Arc::new(AtomicBool::new(false));
+    let non_proved_result: Arc<Mutex<Option<EquivResult>>> = Arc::new(Mutex::new(None));
     let next_bit = Arc::new(AtomicUsize::new(0));
 
     let thread_cnt = std::cmp::min(width, num_cpus::get());
@@ -436,13 +514,16 @@ pub fn prove_ir_fn_equiv_output_bits_parallel<'a, S: Solver>(
         for _ in 0..thread_cnt {
             let lhs_cl = lhs.clone();
             let rhs_cl = rhs.clone();
-            let found_cl = found.clone();
-            let cex_cl = counterexample.clone();
+            let stop_requested_cl = stop_requested.clone();
+            let non_proved_result_cl = non_proved_result.clone();
             let next_cl = next_bit.clone();
+            let interrupt_cl = interrupt.clone();
 
             scope.spawn(move || {
                 loop {
-                    if found_cl.load(Ordering::SeqCst) {
+                    if stop_requested_cl.load(Ordering::SeqCst)
+                        || interrupt_requested(interrupt_cl.as_ref())
+                    {
                         break;
                     }
                     let idx = next_cl.fetch_add(1, Ordering::SeqCst);
@@ -458,18 +539,19 @@ pub fn prove_ir_fn_equiv_output_bits_parallel<'a, S: Solver>(
                     let rf = ProverFn::new(&rf_ir, None)
                         .with_fixed_implicit_activation(rhs_cl.fixed_implicit_activation)
                         .with_domains(rhs_cl.domains.clone());
-                    let res = prove_ir_fn_equiv::<S>(
+                    let res = prove_ir_fn_equiv_with_interrupt::<S>(
                         solver_config,
                         &lf,
                         &rf,
-                        assertion_semantics.clone(),
+                        assertion_semantics,
                         assert_label_include,
                         allow_flatten,
+                        interrupt_cl.clone(),
                     );
-                    if let EquivResult::Disproved { .. } = &res {
-                        let mut guard = cex_cl.lock().unwrap();
-                        *guard = Some(res.clone());
-                        found_cl.store(true, Ordering::SeqCst);
+                    if !matches!(res, EquivResult::Proved) {
+                        let mut guard = non_proved_result_cl.lock().unwrap();
+                        merge_non_proved_result(&mut guard, res.clone());
+                        stop_requested_cl.store(true, Ordering::SeqCst);
                         break;
                     }
                 }
@@ -477,11 +559,11 @@ pub fn prove_ir_fn_equiv_output_bits_parallel<'a, S: Solver>(
         }
     });
 
-    let maybe_cex = {
-        let mut guard = counterexample.lock().unwrap();
+    let maybe_non_proved = {
+        let mut guard = non_proved_result.lock().unwrap();
         guard.take()
     };
-    if let Some(res) = maybe_cex {
+    if let Some(res) = maybe_non_proved {
         res
     } else {
         EquivResult::Proved
@@ -501,14 +583,39 @@ pub fn prove_ir_fn_equiv_split_input_bit<'a, S: Solver>(
     assert_label_include: Option<&Regex>,
     allow_flatten: bool,
 ) -> EquivResult {
+    prove_ir_fn_equiv_split_input_bit_with_interrupt::<S>(
+        solver_config,
+        lhs,
+        rhs,
+        split_input_index,
+        split_input_bit_index,
+        assertion_semantics,
+        assert_label_include,
+        allow_flatten,
+        None,
+    )
+}
+
+pub fn prove_ir_fn_equiv_split_input_bit_with_interrupt<'a, S: Solver>(
+    solver_config: &S::Config,
+    lhs: &ProverFn<'a>,
+    rhs: &ProverFn<'a>,
+    split_input_index: usize,
+    split_input_bit_index: usize,
+    assertion_semantics: AssertionSemantics,
+    assert_label_include: Option<&Regex>,
+    allow_flatten: bool,
+    interrupt: Option<SolverInterruptHandle>,
+) -> EquivResult {
     if lhs.fn_ref.params.is_empty() || rhs.fn_ref.params.is_empty() {
-        return prove_ir_fn_equiv::<S>(
+        return prove_ir_fn_equiv_with_interrupt::<S>(
             solver_config,
             lhs,
             rhs,
             assertion_semantics,
             assert_label_include,
             allow_flatten,
+            interrupt,
         );
     }
 
@@ -526,7 +633,11 @@ pub fn prove_ir_fn_equiv_split_input_bit<'a, S: Solver>(
         "split_input_bit_index out of bounds"
     );
 
+    let mut non_proved_result: Option<EquivResult> = None;
     for bit_val in 0..=1u64 {
+        if interrupt_requested(interrupt.as_ref()) {
+            return non_proved_result.unwrap_or(EquivResult::Interrupted);
+        }
         let mut solver = S::new(solver_config).unwrap();
         // Build aligned SMT representations first so we can assert the bit-constraint.
         let fn_inputs_lhs = get_fn_inputs(&mut solver, lhs.clone(), Some("lhs"));
@@ -554,16 +665,28 @@ pub fn prove_ir_fn_equiv_split_input_bit<'a, S: Solver>(
         let eq_bv = solver.eq(&bit_bv, &val_bv);
         solver.assert(&eq_bv).unwrap();
 
-        check_aligned_fn_equiv_internal(
+        let result = check_aligned_fn_equiv_internal_with_interrupt(
             &mut solver,
             &smt_lhs,
             &smt_rhs,
             assertion_semantics,
             assert_label_include,
+            interrupt.clone(),
         );
+        match result {
+            EquivResult::Proved => {}
+            EquivResult::Disproved { .. } | EquivResult::Error(_) | EquivResult::Interrupted => {
+                merge_non_proved_result(&mut non_proved_result, result.clone());
+                return result;
+            }
+            EquivResult::ToolchainDisproved(_) => {
+                merge_non_proved_result(&mut non_proved_result, result.clone());
+                return result;
+            }
+        }
     }
 
-    EquivResult::Proved
+    non_proved_result.unwrap_or(EquivResult::Proved)
 }
 
 #[cfg(test)]

--- a/xlsynth-prover/src/prover/mod.rs
+++ b/xlsynth-prover/src/prover/mod.rs
@@ -22,7 +22,7 @@ use self::types::{
     AssertionSemantics, BoolPropertyResult, EquivParallelism, EquivResult, ProverFn,
     QuickCheckAssertionSemantics, QuickCheckRunResult,
 };
-use crate::solver::SolverConfig;
+use crate::solver::{SolverConfig, SolverInterruptHandle};
 use std::str::FromStr;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -98,13 +98,14 @@ pub trait Prover {
     fn prove_ir_fn_equiv(self: &Self, lhs: &ir::Fn, rhs: &ir::Fn) -> EquivResult {
         let lhs_fn = ProverFn::new(lhs, None);
         let rhs_fn = ProverFn::new(rhs, None);
-        self.prove_ir_equiv(
+        self.prove_ir_equiv_with_interrupt(
             &lhs_fn,
             &rhs_fn,
             EquivParallelism::SingleThreaded,
             AssertionSemantics::Same,
             None,
             false,
+            None,
         )
     }
     fn prove_ir_pkg_text_equiv(
@@ -122,6 +123,27 @@ pub trait Prover {
         assert_label_filter: Option<&str>,
         allow_flatten: bool,
     ) -> EquivResult;
+
+    fn prove_ir_equiv_with_interrupt<'a>(
+        self: &Self,
+        lhs: &ProverFn<'a>,
+        rhs: &ProverFn<'a>,
+        strategy: EquivParallelism,
+        assertion_semantics: AssertionSemantics,
+        assert_label_filter: Option<&str>,
+        allow_flatten: bool,
+        interrupt: Option<SolverInterruptHandle>,
+    ) -> EquivResult {
+        let _ = interrupt;
+        self.prove_ir_equiv(
+            lhs,
+            rhs,
+            strategy,
+            assertion_semantics,
+            assert_label_filter,
+            allow_flatten,
+        )
+    }
 
     fn prove_ir_fn_quickcheck<'a>(self: &Self, ir_fn: &ProverFn<'a>) -> BoolPropertyResult {
         self.prove_ir_quickcheck(ir_fn, QuickCheckAssertionSemantics::Never, None)
@@ -195,6 +217,27 @@ impl<S: SolverConfig> Prover for S {
         assert_label_filter: Option<&str>,
         allow_flatten: bool,
     ) -> EquivResult {
+        self.prove_ir_equiv_with_interrupt(
+            lhs,
+            rhs,
+            strategy,
+            assertion_semantics,
+            assert_label_filter,
+            allow_flatten,
+            None,
+        )
+    }
+
+    fn prove_ir_equiv_with_interrupt<'a>(
+        self: &Self,
+        lhs: &ProverFn<'a>,
+        rhs: &ProverFn<'a>,
+        strategy: EquivParallelism,
+        assertion_semantics: AssertionSemantics,
+        assert_label_filter: Option<&str>,
+        allow_flatten: bool,
+        interrupt: Option<SolverInterruptHandle>,
+    ) -> EquivResult {
         if strategy != EquivParallelism::SingleThreaded
             && (!lhs.uf_map.is_empty() || !rhs.uf_map.is_empty())
         {
@@ -210,26 +253,30 @@ impl<S: SolverConfig> Prover for S {
         }
         let assert_label_regex = build_assert_label_regex(assert_label_filter);
         match strategy {
-            EquivParallelism::SingleThreaded => ir_equiv::prove_ir_fn_equiv::<S::Solver>(
-                self,
-                lhs,
-                rhs,
-                assertion_semantics,
-                assert_label_regex.as_ref(),
-                allow_flatten,
-            ),
-            EquivParallelism::OutputBits => {
-                ir_equiv::prove_ir_fn_equiv_output_bits_parallel::<S::Solver>(
+            EquivParallelism::SingleThreaded => {
+                ir_equiv::prove_ir_fn_equiv_with_interrupt::<S::Solver>(
                     self,
                     lhs,
                     rhs,
                     assertion_semantics,
                     assert_label_regex.as_ref(),
                     allow_flatten,
+                    interrupt,
+                )
+            }
+            EquivParallelism::OutputBits => {
+                ir_equiv::prove_ir_fn_equiv_output_bits_parallel_with_interrupt::<S::Solver>(
+                    self,
+                    lhs,
+                    rhs,
+                    assertion_semantics,
+                    assert_label_regex.as_ref(),
+                    allow_flatten,
+                    interrupt,
                 )
             }
             EquivParallelism::InputBitSplit => {
-                ir_equiv::prove_ir_fn_equiv_split_input_bit::<S::Solver>(
+                ir_equiv::prove_ir_fn_equiv_split_input_bit_with_interrupt::<S::Solver>(
                     self,
                     lhs,
                     rhs,
@@ -238,6 +285,7 @@ impl<S: SolverConfig> Prover for S {
                     assertion_semantics,
                     assert_label_regex.as_ref(),
                     allow_flatten,
+                    interrupt,
                 )
             }
         }

--- a/xlsynth-prover/src/prover/quickcheck.rs
+++ b/xlsynth-prover/src/prover/quickcheck.rs
@@ -191,7 +191,8 @@ where
 
             BoolPropertyResult::Disproved { inputs, output }
         }
-        Response::Unknown => panic!("Solver returned unknown"),
+        Response::Interrupted => BoolPropertyResult::Interrupted,
+        Response::Unknown => BoolPropertyResult::Error("solver returned unknown".to_string()),
     }
 }
 

--- a/xlsynth-prover/src/prover/types.rs
+++ b/xlsynth-prover/src/prover/types.rs
@@ -339,6 +339,7 @@ pub enum EquivResult {
         lhs_output: FnOutput,
         rhs_output: FnOutput,
     },
+    Interrupted,
     ToolchainDisproved(String),
     Error(String),
 }
@@ -366,6 +367,7 @@ impl EquivReport {
                 "lhs_inputs: {:?}, rhs_inputs: {:?}, lhs_output: {:?}, rhs_output: {:?}",
                 lhs_inputs, rhs_inputs, lhs_output, rhs_output
             )),
+            EquivResult::Interrupted => Some("solver interrupted".to_string()),
             EquivResult::ToolchainDisproved(msg) => Some(msg.clone()),
             EquivResult::Error(msg) => Some(msg.clone()),
         }
@@ -411,6 +413,9 @@ pub enum BoolPropertyResult {
         /// counter-example.
         output: FnOutput,
     },
+    /// The underlying solver was interrupted before it could prove or disprove
+    /// the property.
+    Interrupted,
     /// External toolchain reported failure without a structured counterexample.
     ///
     /// This is used by the `ExternalProver` implementation where the

--- a/xlsynth-prover/src/solver/bitwuzla.rs
+++ b/xlsynth-prover/src/solver/bitwuzla.rs
@@ -5,7 +5,10 @@
 use std::{
     ffi::{CStr, CString},
     io,
+    os::raw::c_void,
     sync::Arc,
+    sync::Mutex,
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use bitwuzla_sys::{
@@ -44,25 +47,89 @@ use bitwuzla_sys::{
     bitwuzla_mk_const, bitwuzla_mk_fun_sort, bitwuzla_mk_term, bitwuzla_mk_term1,
     bitwuzla_mk_term1_indexed1, bitwuzla_mk_term1_indexed2, bitwuzla_mk_term2, bitwuzla_mk_term3,
     bitwuzla_new, bitwuzla_options_delete, bitwuzla_options_new, bitwuzla_pop, bitwuzla_push,
-    bitwuzla_set_option, bitwuzla_set_option_mode, bitwuzla_term_manager_delete,
-    bitwuzla_term_manager_new, bitwuzla_term_to_string, bitwuzla_term_value_get_str,
+    bitwuzla_set_option, bitwuzla_set_option_mode, bitwuzla_set_termination_callback,
+    bitwuzla_term_manager_delete, bitwuzla_term_manager_new, bitwuzla_term_to_string,
+    bitwuzla_term_value_get_str,
 };
 use xlsynth::IrBits;
 
-use super::{BitVec, Response, Solver, SolverConfig, Uf};
+use super::{BitVec, Response, Solver, SolverConfig, SolverInterruptHandle, Uf};
 use xlsynth_pir::ir;
 use xlsynth_pir::ir_value_utils::ir_value_from_bits_with_type;
+
+struct BitwuzlaTerminationState {
+    current_interrupt: Mutex<Option<SolverInterruptHandle>>,
+    fired: AtomicBool,
+}
+
+impl BitwuzlaTerminationState {
+    fn new() -> Self {
+        Self {
+            current_interrupt: Mutex::new(None),
+            fired: AtomicBool::new(false),
+        }
+    }
+
+    fn set_interrupt(&self, interrupt: Option<SolverInterruptHandle>) {
+        let mut guard = self
+            .current_interrupt
+            .lock()
+            .expect("bitwuzla termination state lock");
+        *guard = interrupt;
+    }
+
+    fn clear_fired(&self) {
+        self.fired.store(false, Ordering::SeqCst);
+    }
+
+    fn fired(&self) -> bool {
+        self.fired.load(Ordering::SeqCst)
+    }
+}
+
+unsafe extern "C" fn bitwuzla_termination_callback(state: *mut c_void) -> i32 {
+    if state.is_null() {
+        return 0;
+    }
+    let termination_state = unsafe { &*(state as *const BitwuzlaTerminationState) };
+    let should_interrupt = match termination_state.current_interrupt.lock() {
+        Ok(guard) => guard
+            .as_ref()
+            .map(|interrupt| interrupt.should_interrupt())
+            .unwrap_or(false),
+        Err(_) => true,
+    };
+    if should_interrupt {
+        termination_state.fired.store(true, Ordering::SeqCst);
+        1
+    } else {
+        0
+    }
+}
 
 struct RawBitwuzla {
     term_manager: *mut bitwuzla_sys::BitwuzlaTermManager,
     raw: *mut bitwuzla_sys::Bitwuzla,
+    termination_state: Box<BitwuzlaTerminationState>,
 }
 
 impl RawBitwuzla {
     pub fn new(options: *const bitwuzla_sys::BitwuzlaOptions) -> Self {
         let term_manager = unsafe { bitwuzla_term_manager_new() };
         let raw = unsafe { bitwuzla_new(term_manager, options) };
-        RawBitwuzla { raw, term_manager }
+        let mut termination_state = Box::new(BitwuzlaTerminationState::new());
+        unsafe {
+            bitwuzla_set_termination_callback(
+                raw,
+                Some(bitwuzla_termination_callback),
+                termination_state.as_mut() as *mut BitwuzlaTerminationState as *mut c_void,
+            );
+        }
+        RawBitwuzla {
+            raw,
+            term_manager,
+            termination_state,
+        }
     }
 }
 
@@ -89,6 +156,40 @@ impl Bitwuzla {
 
     pub fn raw_bitwuzla(&self) -> *mut bitwuzla_sys::Bitwuzla {
         self.bitwuzla.raw
+    }
+
+    fn set_interrupt(&self, interrupt: Option<SolverInterruptHandle>) {
+        self.bitwuzla.termination_state.set_interrupt(interrupt);
+    }
+
+    fn clear_interrupt_state(&self) {
+        self.bitwuzla.termination_state.set_interrupt(None);
+    }
+
+    fn clear_interrupt_fired(&self) {
+        self.bitwuzla.termination_state.clear_fired();
+    }
+
+    fn interrupt_fired(&self) -> bool {
+        self.bitwuzla.termination_state.fired()
+    }
+
+    fn map_check_result(&self, raw_result: u32) -> io::Result<Response> {
+        match raw_result {
+            BITWUZLA_SAT => Ok(Response::Sat),
+            BITWUZLA_UNSAT => Ok(Response::Unsat),
+            BITWUZLA_UNKNOWN => {
+                if self.interrupt_fired() {
+                    Ok(Response::Interrupted)
+                } else {
+                    Ok(Response::Unknown)
+                }
+            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "bitwuzla_check_sat failed",
+            )),
+        }
     }
 }
 
@@ -1194,16 +1295,18 @@ impl Solver for Bitwuzla {
     }
 
     fn check(&mut self) -> io::Result<Response> {
+        self.check_with_interrupt(None)
+    }
+
+    fn check_with_interrupt(
+        &mut self,
+        interrupt: Option<SolverInterruptHandle>,
+    ) -> io::Result<Response> {
+        self.clear_interrupt_fired();
+        self.set_interrupt(interrupt);
         let r = unsafe { bitwuzla_check_sat(self.bitwuzla.raw) };
-        match r {
-            BITWUZLA_SAT => Ok(Response::Sat),
-            BITWUZLA_UNSAT => Ok(Response::Unsat),
-            BITWUZLA_UNKNOWN => Ok(Response::Unknown),
-            _ => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "bitwuzla_check_sat failed",
-            )),
-        }
+        self.clear_interrupt_state();
+        self.map_check_result(r)
     }
 
     fn assert(&mut self, bv: &BitVec<Self::Term>) -> io::Result<()> {
@@ -1225,6 +1328,88 @@ impl Solver for Bitwuzla {
 
 #[cfg(test)]
 use crate::test_solver;
+
+#[cfg(test)]
+mod interrupt_tests {
+    use super::{BITWUZLA_UNKNOWN, Bitwuzla, BitwuzlaOptions};
+    use crate::solver::{AtomicSolverInterrupt, Response, Solver};
+    use std::sync::atomic::Ordering;
+
+    fn add_nontrivial_constraint(solver: &mut Bitwuzla) {
+        let x = solver.declare("x", 64).unwrap();
+        let y = solver.declare("y", 64).unwrap();
+        let z = solver.declare("z", 64).unwrap();
+        let xy = solver.mul(&x, &y);
+        let yz = solver.mul(&y, &z);
+        let sum = solver.add(&xy, &yz);
+        let target = solver.numerical(64, 0x1234);
+        let eq = solver.eq(&sum, &target);
+        solver.assert(&eq).unwrap();
+    }
+
+    #[test]
+    fn test_check_with_interrupt_returns_interrupted_when_pretriggered() {
+        let mut solver = Bitwuzla::new(&BitwuzlaOptions::new()).unwrap();
+        add_nontrivial_constraint(&mut solver);
+
+        let interrupt = AtomicSolverInterrupt::new();
+        interrupt.interrupt();
+
+        assert_eq!(
+            solver
+                .check_with_interrupt(Some(interrupt.handle()))
+                .unwrap(),
+            Response::Interrupted
+        );
+    }
+
+    #[test]
+    fn test_check_with_interrupt_preserves_sat_and_unsat_without_interrupt() {
+        let mut sat_solver = Bitwuzla::new(&BitwuzlaOptions::new()).unwrap();
+        let sat_symbol = sat_solver.declare("sat_symbol", 8).unwrap();
+        let sat_value = sat_solver.numerical(8, 7);
+        let sat_eq = sat_solver.eq(&sat_symbol, &sat_value);
+        sat_solver.assert(&sat_eq).unwrap();
+        assert_eq!(
+            sat_solver.check_with_interrupt(None).unwrap(),
+            Response::Sat
+        );
+
+        let mut unsat_solver = Bitwuzla::new(&BitwuzlaOptions::new()).unwrap();
+        let unsat_symbol = unsat_solver.declare("unsat_symbol", 8).unwrap();
+        let seven = unsat_solver.numerical(8, 7);
+        let eight = unsat_solver.numerical(8, 8);
+        let eq_seven = unsat_solver.eq(&unsat_symbol, &seven);
+        let eq_eight = unsat_solver.eq(&unsat_symbol, &eight);
+        unsat_solver.assert(&eq_seven).unwrap();
+        unsat_solver.assert(&eq_eight).unwrap();
+        assert_eq!(
+            unsat_solver.check_with_interrupt(None).unwrap(),
+            Response::Unsat
+        );
+    }
+
+    #[test]
+    fn test_unknown_mapping_only_uses_interrupted_when_callback_fired() {
+        let solver = Bitwuzla::new(&BitwuzlaOptions::new()).unwrap();
+
+        solver.clear_interrupt_fired();
+        assert_eq!(
+            solver.map_check_result(BITWUZLA_UNKNOWN).unwrap(),
+            Response::Unknown
+        );
+
+        solver
+            .bitwuzla
+            .termination_state
+            .fired
+            .store(true, Ordering::SeqCst);
+        assert_eq!(
+            solver.map_check_result(BITWUZLA_UNKNOWN).unwrap(),
+            Response::Interrupted
+        );
+    }
+}
 
 #[cfg(test)]
 test_solver!(

--- a/xlsynth-prover/src/solver/mod.rs
+++ b/xlsynth-prover/src/solver/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use xlsynth::IrValue;
 
@@ -13,11 +15,53 @@ pub mod boolector;
 #[cfg(feature = "has-easy-smt")]
 pub mod easy_smt;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Response {
     Sat,
     Unsat,
     Unknown,
+    Interrupted,
+}
+
+/// Cooperative interruption hook for long-running solver checks.
+pub trait SolverInterrupt: Send + Sync {
+    fn should_interrupt(&self) -> bool;
+}
+
+pub type SolverInterruptHandle = Arc<dyn SolverInterrupt>;
+
+/// Shared atomic flag that can be passed to interrupt-aware solver checks.
+#[derive(Clone, Default)]
+pub struct AtomicSolverInterrupt {
+    interrupted: Arc<AtomicBool>,
+}
+
+impl AtomicSolverInterrupt {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn interrupt(&self) {
+        self.interrupted.store(true, Ordering::SeqCst);
+    }
+
+    pub fn reset(&self) {
+        self.interrupted.store(false, Ordering::SeqCst);
+    }
+
+    pub fn is_interrupted(&self) -> bool {
+        self.interrupted.load(Ordering::SeqCst)
+    }
+
+    pub fn handle(&self) -> SolverInterruptHandle {
+        Arc::new(self.clone())
+    }
+}
+
+impl SolverInterrupt for AtomicSolverInterrupt {
+    fn should_interrupt(&self) -> bool {
+        self.is_interrupted()
+    }
 }
 
 // Generic helper: left-fold a vector with a binary operator implemented by the
@@ -242,6 +286,13 @@ pub trait Solver: Sized {
     fn push(&mut self) -> io::Result<()>;
     fn pop(&mut self) -> io::Result<()>;
     fn check(&mut self) -> io::Result<Response>;
+    fn check_with_interrupt(
+        &mut self,
+        interrupt: Option<SolverInterruptHandle>,
+    ) -> io::Result<Response> {
+        let _ = interrupt;
+        self.check()
+    }
     fn assert(&mut self, bit_vec: &BitVec<Self::Term>) -> io::Result<()>;
     fn render(&mut self, bit_vec: &BitVec<Self::Term>) -> String;
     fn smax(&mut self, lhs: &BitVec<Self::Term>, rhs: &BitVec<Self::Term>) -> BitVec<Self::Term> {

--- a/xlsynth-prover/tests/bitwuzla_interrupt.rs
+++ b/xlsynth-prover/tests/bitwuzla_interrupt.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "has-bitwuzla")]
+
+use std::fmt::Write;
+
+use xlsynth_pir::ir::Package;
+use xlsynth_pir::ir_parser;
+use xlsynth_prover::ir_equiv::{
+    EquivClassMember, EquivClassRequest, EquivClassResult, IrModule, run_ir_equiv_class_membership,
+};
+use xlsynth_prover::prover::SolverChoice;
+use xlsynth_prover::prover::ir_equiv::prove_ir_fn_equiv_with_interrupt;
+use xlsynth_prover::prover::types::{AssertionSemantics, EquivResult, ProverFn};
+use xlsynth_prover::solver::AtomicSolverInterrupt;
+use xlsynth_prover::solver::bitwuzla::{Bitwuzla, BitwuzlaOptions};
+
+fn make_param_list(width: usize, aux_param_count: usize) -> String {
+    let mut params = format!("x: bits[{width}] id=1");
+    for i in 0..aux_param_count {
+        let _ = write!(&mut params, ", a{i}: bits[{width}] id={}", i + 2);
+    }
+    params
+}
+
+fn make_exact_projection_ir(
+    package_name: &str,
+    top_name: &str,
+    width: usize,
+    aux_param_count: usize,
+) -> String {
+    format!(
+        "package {package_name}\n\
+top fn {top_name}({}) -> bits[{width}] {{\n  ret identity.{}: bits[{width}] = identity(x, id={})\n}}\n",
+        make_param_list(width, aux_param_count),
+        aux_param_count + 2,
+        aux_param_count + 2,
+    )
+}
+
+fn make_canceling_chain_ir(
+    package_name: &str,
+    top_name: &str,
+    width: usize,
+    aux_param_count: usize,
+    rounds: usize,
+) -> String {
+    let mut ir_text = String::new();
+    let _ = writeln!(&mut ir_text, "package {package_name}");
+    let _ = writeln!(
+        &mut ir_text,
+        "top fn {top_name}({}) -> bits[{width}] {{",
+        make_param_list(width, aux_param_count)
+    );
+    let mut current = "x".to_string();
+    let mut node_id = aux_param_count + 2;
+    for round in 0..rounds {
+        let param_name = format!("a{}", round % aux_param_count);
+        let add_name = format!("add.{node_id}");
+        let _ = writeln!(
+            &mut ir_text,
+            "  {add_name}: bits[{width}] = add({current}, {param_name}, id={node_id})"
+        );
+        node_id += 1;
+        let sub_name = format!("sub.{node_id}");
+        let _ = writeln!(
+            &mut ir_text,
+            "  {sub_name}: bits[{width}] = sub({add_name}, {param_name}, id={node_id})"
+        );
+        node_id += 1;
+        current = sub_name;
+    }
+    let _ = writeln!(
+        &mut ir_text,
+        "  ret identity.{node_id}: bits[{width}] = identity({current}, id={node_id})"
+    );
+    let _ = writeln!(&mut ir_text, "}}");
+    ir_text
+}
+
+fn parse_package(ir_text: &str) -> Package {
+    ir_parser::Parser::new(ir_text)
+        .parse_package()
+        .expect("package parses")
+}
+
+#[test]
+fn test_bitwuzla_pairwise_equiv_returns_interrupted_when_preinterrupted() {
+    let lhs_text = make_exact_projection_ir("lhs_pkg", "lhs", 64, 4);
+    let rhs_text = make_exact_projection_ir("rhs_pkg", "rhs", 64, 4);
+    let lhs_pkg = parse_package(&lhs_text);
+    let rhs_pkg = parse_package(&rhs_text);
+    let lhs_top = lhs_pkg.get_top_fn().expect("lhs top exists");
+    let rhs_top = rhs_pkg.get_top_fn().expect("rhs top exists");
+    let lhs = ProverFn::new(lhs_top, Some(&lhs_pkg));
+    let rhs = ProverFn::new(rhs_top, Some(&rhs_pkg));
+    let interrupt = AtomicSolverInterrupt::new();
+    interrupt.interrupt();
+
+    let result = prove_ir_fn_equiv_with_interrupt::<Bitwuzla>(
+        &BitwuzlaOptions::new(),
+        &lhs,
+        &rhs,
+        AssertionSemantics::Same,
+        None,
+        false,
+        Some(interrupt.handle()),
+    );
+
+    assert_eq!(result, EquivResult::Interrupted);
+}
+
+#[test]
+fn test_bitwuzla_pairwise_equiv_still_proves_without_interrupt() {
+    let lhs_text = make_exact_projection_ir("lhs_pkg", "lhs", 64, 4);
+    let rhs_text = make_exact_projection_ir("rhs_pkg", "rhs", 64, 4);
+    let lhs_pkg = parse_package(&lhs_text);
+    let rhs_pkg = parse_package(&rhs_text);
+    let lhs_top = lhs_pkg.get_top_fn().expect("lhs top exists");
+    let rhs_top = rhs_pkg.get_top_fn().expect("rhs top exists");
+    let lhs = ProverFn::new(lhs_top, Some(&lhs_pkg));
+    let rhs = ProverFn::new(rhs_top, Some(&rhs_pkg));
+
+    let result = prove_ir_fn_equiv_with_interrupt::<Bitwuzla>(
+        &BitwuzlaOptions::new(),
+        &lhs,
+        &rhs,
+        AssertionSemantics::Same,
+        None,
+        false,
+        None,
+    );
+
+    assert_eq!(result, EquivResult::Proved);
+}
+
+#[test]
+fn test_bitwuzla_class_membership_interrupts_losing_proofs() {
+    let candidate_text = make_exact_projection_ir("candidate_pkg", "candidate", 128, 16);
+    let exact_text = make_exact_projection_ir("exact_pkg", "exact", 128, 16);
+    let deep_one_text = make_canceling_chain_ir("deep_one_pkg", "deep_one", 128, 16, 512);
+    let deep_two_text = make_canceling_chain_ir("deep_two_pkg", "deep_two", 128, 16, 768);
+
+    let request = EquivClassRequest::new(
+        IrModule::new(&candidate_text).with_top(Some("candidate")),
+        vec![
+            EquivClassMember::new("exact", IrModule::new(&exact_text).with_top(Some("exact"))),
+            EquivClassMember::new(
+                "deep_one",
+                IrModule::new(&deep_one_text).with_top(Some("deep_one")),
+            ),
+            EquivClassMember::new(
+                "deep_two",
+                IrModule::new(&deep_two_text).with_top(Some("deep_two")),
+            ),
+        ],
+    )
+    .with_solver(Some(SolverChoice::Bitwuzla))
+    .with_max_parallel_proofs(3);
+
+    let report = run_ir_equiv_class_membership(&request).expect("class membership succeeds");
+
+    match &report.result {
+        EquivClassResult::Matched(matched) => assert_eq!(matched.member_id, "exact"),
+        other => panic!("expected matched result, got {other:?}"),
+    }
+    assert!(
+        report
+            .completed_proofs
+            .iter()
+            .any(|entry| matches!(entry.report.result, EquivResult::Interrupted)),
+        "expected at least one interrupted loser, got {:?}",
+        report
+            .completed_proofs
+            .iter()
+            .map(|entry| (&entry.member_id, &entry.report.result))
+            .collect::<Vec<_>>()
+    );
+}

--- a/xlsynth-prover/tests/equiv_class_membership.rs
+++ b/xlsynth-prover/tests/equiv_class_membership.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use xlsynth_prover::ir_equiv::{
+    EquivClassMember, EquivClassNoMatchReason, EquivClassRequest, EquivClassResult,
+    EquivClassShortlistOptions, IrModule, run_ir_equiv_class_membership,
+};
+use xlsynth_prover::prover::types::EquivResult;
+
+const CANDIDATE_IDENTITY_IR: &str = r#"package candidate
+top fn candidate(x: bits[1] id=1) -> bits[1] {
+  ret identity.2: bits[1] = identity(x, id=2)
+}
+"#;
+
+const EXACT_IDENTITY_IR: &str = r#"package exact
+top fn exact(x: bits[1] id=1) -> bits[1] {
+  ret identity.2: bits[1] = identity(x, id=2)
+}
+"#;
+
+const DOUBLE_NOT_IR: &str = r#"package double_not
+top fn double_not(x: bits[1] id=1) -> bits[1] {
+  not.2: bits[1] = not(x, id=2)
+  ret not.3: bits[1] = not(not.2, id=3)
+}
+"#;
+
+const INVERT_IR: &str = r#"package invert
+top fn invert(x: bits[1] id=1) -> bits[1] {
+  ret not.2: bits[1] = not(x, id=2)
+}
+"#;
+
+const ZERO_IR: &str = r#"package zero
+top fn zero(x: bits[1] id=1) -> bits[1] {
+  ret literal.2: bits[1] = literal(value=0, id=2)
+}
+"#;
+
+const QUERY_IR: &str = r#"package query_pkg
+top fn query(x: bits[8] id=1, y: bits[8] id=2) -> bits[8] {
+  add.3: bits[8] = add(x, y, id=3)
+  ret sub.4: bits[8] = sub(add.3, y, id=4)
+}
+"#;
+
+const QUERY_EXACT_IR: &str = r#"package exact_pkg
+top fn exact(x: bits[8] id=1, y: bits[8] id=2) -> bits[8] {
+  add.3: bits[8] = add(x, y, id=3)
+  ret sub.4: bits[8] = sub(add.3, y, id=4)
+}
+"#;
+
+const QUERY_CLOSE_IR: &str = r#"package close_pkg
+top fn close(x: bits[8] id=1, y: bits[8] id=2) -> bits[8] {
+  add.3: bits[8] = add(x, y, id=3)
+  ret sub.4: bits[8] = sub(add.3, x, id=4)
+}
+"#;
+
+const QUERY_FAR_ONE_IR: &str = r#"package far_one_pkg
+top fn far_one(x: bits[8] id=1, y: bits[8] id=2) -> bits[8] {
+  umul.3: bits[8] = umul(x, y, id=3)
+  ret not.4: bits[8] = not(umul.3, id=4)
+}
+"#;
+
+const QUERY_FAR_TWO_IR: &str = r#"package far_two_pkg
+top fn far_two(x: bits[8] id=1, y: bits[8] id=2) -> bits[8] {
+  literal.3: bits[8] = literal(value=1, id=3)
+  ret xor.4: bits[8] = xor(x, literal.3, id=4)
+}
+"#;
+
+fn make_module<'a>(source: &'a str, top: &'a str) -> IrModule<'a> {
+    IrModule::new(source).with_top(Some(top))
+}
+
+fn make_member<'a>(id: &'a str, source: &'a str, top: &'a str) -> EquivClassMember<'a> {
+    EquivClassMember::new(id, make_module(source, top))
+}
+
+fn shortlisted_ids(report: &xlsynth_prover::ir_equiv::EquivClassReport) -> Vec<String> {
+    report
+        .shortlisted_members
+        .iter()
+        .map(|entry| entry.member_id.clone())
+        .collect()
+}
+
+#[test]
+fn test_equiv_class_membership_matches_best_ranked_equivalent_member() {
+    let request = EquivClassRequest::new(
+        make_module(CANDIDATE_IDENTITY_IR, "candidate"),
+        vec![
+            make_member("double_not", DOUBLE_NOT_IR, "double_not"),
+            make_member("exact", EXACT_IDENTITY_IR, "exact"),
+        ],
+    )
+    .with_max_parallel_proofs(2);
+
+    let report = run_ir_equiv_class_membership(&request).expect("class proof succeeds");
+
+    assert_eq!(
+        shortlisted_ids(&report),
+        vec!["exact".to_string(), "double_not".to_string()]
+    );
+    assert_eq!(report.excluded_by_shortlist_count, 0);
+    assert_eq!(report.unstarted_shortlist_count, 0);
+    assert!(
+        report
+            .completed_proofs
+            .iter()
+            .all(|entry| matches!(&entry.report.result, EquivResult::Proved))
+    );
+    match &report.result {
+        EquivClassResult::Matched(matched) => {
+            assert_eq!(matched.member_id, "exact");
+            assert_eq!(matched.shortlist_rank, 0);
+        }
+        other => panic!("expected matched result, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_equiv_class_membership_reports_no_match_when_all_members_fail() {
+    let request = EquivClassRequest::new(
+        make_module(CANDIDATE_IDENTITY_IR, "candidate"),
+        vec![
+            make_member("invert", INVERT_IR, "invert"),
+            make_member("zero", ZERO_IR, "zero"),
+        ],
+    )
+    .with_max_parallel_proofs(1);
+
+    let report = run_ir_equiv_class_membership(&request).expect("class proof succeeds");
+
+    assert_eq!(report.completed_proofs.len(), 2);
+    match report.result {
+        EquivClassResult::NoMatch { reason } => {
+            assert_eq!(reason, EquivClassNoMatchReason::ExhaustedShortlist);
+        }
+        other => panic!("expected no-match result, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_equiv_class_membership_shortlists_and_stops_after_first_match() {
+    let request = EquivClassRequest::new(
+        make_module(QUERY_IR, "query"),
+        vec![
+            make_member("far_one", QUERY_FAR_ONE_IR, "far_one"),
+            make_member("exact", QUERY_EXACT_IR, "exact"),
+            make_member("far_two", QUERY_FAR_TWO_IR, "far_two"),
+            make_member("close", QUERY_CLOSE_IR, "close"),
+        ],
+    )
+    .with_max_parallel_proofs(1)
+    .with_shortlist_options(EquivClassShortlistOptions {
+        prefilter_multiplier: 2,
+    });
+
+    let report = run_ir_equiv_class_membership(&request).expect("class proof succeeds");
+
+    assert_eq!(
+        shortlisted_ids(&report),
+        vec!["exact".to_string(), "close".to_string()]
+    );
+    assert_eq!(report.excluded_by_shortlist_count, 2);
+    assert_eq!(report.completed_proofs.len(), 1);
+    assert_eq!(report.unstarted_shortlist_count, 1);
+    match &report.result {
+        EquivClassResult::Matched(matched) => {
+            assert_eq!(matched.member_id, "exact");
+        }
+        other => panic!("expected matched result, got {:?}", other),
+    }
+}

--- a/xlsynth-prover/tests/ext_carry_out_desugar_equiv.rs
+++ b/xlsynth-prover/tests/ext_carry_out_desugar_equiv.rs
@@ -53,6 +53,9 @@ fn ext_carry_out_equivalent_to_desugared_export_form_and_exports_to_upstream() {
         );
         match res {
             EquivResult::Proved => {}
+            EquivResult::Interrupted => {
+                panic!("equivalence unexpectedly interrupted for ext_carry_out desugaring");
+            }
             EquivResult::ToolchainDisproved(msg)
                 if msg.contains("Unknown operation")
                     && msg.contains("ext_carry_out")

--- a/xlsynth-prover/tests/ext_clz_desugar_equiv.rs
+++ b/xlsynth-prover/tests/ext_clz_desugar_equiv.rs
@@ -48,6 +48,9 @@ fn ext_clz_equivalent_to_desugared_export_form_and_exports_to_upstream() {
         );
         match res {
             EquivResult::Proved => {}
+            EquivResult::Interrupted => {
+                panic!("equivalence unexpectedly interrupted for ext_clz desugaring");
+            }
             EquivResult::ToolchainDisproved(msg)
                 if msg.contains("Unknown operation")
                     && msg.contains("ext_clz")

--- a/xlsynth-prover/tests/ext_nary_add_desugar_equiv.rs
+++ b/xlsynth-prover/tests/ext_nary_add_desugar_equiv.rs
@@ -49,6 +49,9 @@ fn f(a: bits[3] id=1, b: bits[5] id=2, c: bits[9] id=3) -> bits[6] {
     );
     match res {
         EquivResult::Proved => {}
+        EquivResult::Interrupted => {
+            panic!("equivalence unexpectedly interrupted for ext_nary_add desugaring");
+        }
         EquivResult::ToolchainDisproved(msg)
             if msg.contains("Unknown operation")
                 && msg.contains("ext_nary_add")


### PR DESCRIPTION
Rank class candidates up front and surface explicit interrupted outcomes so Bitwuzla-backed class membership can stop close to the first winning proof while downstream callers handle cancelled solver runs cleanly.