### PR TITLE
Meheff/2026 04 10 nary add specializations

### DIFF
--- a/xlsynth-g8r/src/gatify/ir2gate.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate.rs
@@ -1430,7 +1430,7 @@ fn gatify_add_const_pow2_minus1(
     k: usize,
 ) -> AigBitVector {
     let bit_count = lhs_bits.get_bit_count();
-    assert!(k > 0 && k < bit_count);
+    assert!(k > 0 && k <= bit_count);
 
     let mut sum = Vec::with_capacity(bit_count);
     // For low bits where rhs_i=1, carry recurrence is c_{i+1} = lhs_i | c_i,
@@ -1454,6 +1454,36 @@ fn gatify_add_const_pow2_minus1(
     }
 
     AigBitVector::from_lsb_is_index_0(&sum)
+}
+
+/// Adds one literal to an already-lowered dynamic sum, preserving the plain-Add
+/// specialization for `(1<<k)-1` constants.
+fn gatify_add_literal_to_dynamic_sum(
+    gb: &mut GateBuilder,
+    sum_bits: &AigBitVector,
+    literal_bits: &xlsynth::IrBits,
+    adder_mapping: AdderMapping,
+) -> AigBitVector {
+    assert_eq!(sum_bits.get_bit_count(), literal_bits.get_bit_count());
+    if let Some(k) = get_pow2_minus1_k(literal_bits) {
+        if k == 0 {
+            return sum_bits.clone();
+        }
+        if k <= sum_bits.get_bit_count() {
+            return gatify_add_const_pow2_minus1(gb, sum_bits, k);
+        }
+    }
+
+    let literal_vec = gb.add_literal(literal_bits);
+    let (_c_out, sum) = gatify_add_with_mapping(
+        adder_mapping,
+        sum_bits,
+        &literal_vec,
+        gb.get_false(),
+        None,
+        gb,
+    );
+    sum
 }
 
 fn get_neg_pow2_k(bits: &xlsynth::IrBits) -> Option<usize> {
@@ -3021,15 +3051,12 @@ fn gatify_node(
                         lowered_terms.push(resized);
                     }
                 }
-                let carry_in = if is_one(&literal_sum) && !lowered_terms.is_empty() {
+                let carry_in = if is_one(&literal_sum) && lowered_terms.len() >= 2 {
                     literal_sum = xlsynth::IrBits::zero(output_width);
                     Some(g8_builder.get_true())
                 } else {
                     None
                 };
-                if !literal_sum.is_zero() {
-                    lowered_terms.push(g8_builder.add_literal(&literal_sum));
-                }
                 let selected_adder_mapping = (*arch)
                     .map(AdderMapping::from)
                     .unwrap_or(options.adder_mapping);
@@ -3040,7 +3067,31 @@ fn gatify_node(
                 };
                 let sum = if lowered_terms.is_empty() {
                     g8_builder.add_literal(&literal_sum)
+                } else if lowered_terms.len() == 1 && carry_in.is_none() {
+                    gatify_add_literal_to_dynamic_sum(
+                        g8_builder,
+                        &lowered_terms[0],
+                        &literal_sum,
+                        selected_adder_mapping,
+                    )
+                } else if get_pow2_minus1_k(&literal_sum).is_some() {
+                    let dynamic_sum = array_add_with_carry_out(
+                        g8_builder,
+                        &lowered_terms,
+                        carry_in,
+                        selected_adder_mapping,
+                    )
+                    .sum;
+                    gatify_add_literal_to_dynamic_sum(
+                        g8_builder,
+                        &dynamic_sum,
+                        &literal_sum,
+                        selected_adder_mapping,
+                    )
                 } else {
+                    if !literal_sum.is_zero() {
+                        lowered_terms.push(g8_builder.add_literal(&literal_sum));
+                    }
                     array_add_with_carry_out(
                         g8_builder,
                         &lowered_terms,
@@ -3273,20 +3324,6 @@ fn gatify_node(
                     assert_eq!(lhs_gate_refs.get_bit_count(), rhs_bits.get_bit_count());
                     let gates = if k == 0 {
                         lhs_gate_refs.clone()
-                    } else if k == lhs_gate_refs.get_bit_count() {
-                        // (2^N - 1) for N-bit values is all ones; adding this is the same
-                        // as subtracting one modulo 2^N.
-                        let ones = g8_builder.add_literal(&rhs_bits);
-                        let add_tag = format!("add_{}", node.text_id);
-                        let (_c_out, gates) = gatify_add_with_mapping(
-                            options.adder_mapping,
-                            &lhs_gate_refs,
-                            &ones,
-                            g8_builder.get_false(),
-                            Some(&add_tag),
-                            g8_builder,
-                        );
-                        gates
                     } else {
                         gatify_add_const_pow2_minus1(g8_builder, &lhs_gate_refs, k)
                     };

--- a/xlsynth-g8r/src/gatify/ir2gate.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate.rs
@@ -1321,6 +1321,28 @@ fn accumulate_ext_nary_add_literal(
     *literal_sum = literal_sum.add(&contribution);
 }
 
+/// Returns whether `bits` is exactly the unsigned value 1.
+fn is_one(bits: &xlsynth::IrBits) -> bool {
+    if bits.get_bit_count() == 0 {
+        return false;
+    }
+    if !bits
+        .get_bit(0)
+        .expect("literal bit 0 should be in bounds for non-empty bits")
+    {
+        return false;
+    }
+    for i in 1..bits.get_bit_count() {
+        if bits
+            .get_bit(i)
+            .expect("literal bit index should be in bounds during one-check")
+        {
+            return false;
+        }
+    }
+    true
+}
+
 fn is_all_zeros(bits: &xlsynth::IrBits) -> bool {
     for i in 0..bits.get_bit_count() {
         if bits.get_bit(i).unwrap() {
@@ -2999,6 +3021,12 @@ fn gatify_node(
                         lowered_terms.push(resized);
                     }
                 }
+                let carry_in = if is_one(&literal_sum) && !lowered_terms.is_empty() {
+                    literal_sum = xlsynth::IrBits::zero(output_width);
+                    Some(g8_builder.get_true())
+                } else {
+                    None
+                };
                 if !literal_sum.is_zero() {
                     lowered_terms.push(g8_builder.add_literal(&literal_sum));
                 }
@@ -3016,7 +3044,7 @@ fn gatify_node(
                     array_add_with_carry_out(
                         g8_builder,
                         &lowered_terms,
-                        None,
+                        carry_in,
                         selected_adder_mapping,
                     )
                     .sum

--- a/xlsynth-g8r/src/gatify/ir2gate.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate.rs
@@ -6,6 +6,7 @@
 use crate::aig::gate::{AigBitVector, AigOperand, GateFn, Split};
 use crate::check_equivalence;
 use crate::gate_builder::{GateBuilder, GateBuilderOptions};
+use crate::gatify::ir2gate_arithmetic::{gatify_add_binop, gatify_ext_nary_add, gatify_sub_binop};
 use crate::gatify::mul_by_const_csd::{SignedDigitSign, decompose_umul_const_terms};
 use crate::gatify::prep_for_gatify::{PrepForGatifyOptions, prep_for_gatify};
 use std::collections::HashMap;
@@ -166,7 +167,7 @@ fn maybe_warn_shift_amount_truncatable(
     }
 }
 
-struct GateEnv {
+pub(super) struct GateEnv {
     ir_to_g8: HashMap<ir::NodeRef, GateOrVec>,
 }
 
@@ -177,11 +178,11 @@ impl GateEnv {
         }
     }
 
-    pub fn contains(&self, ir_node_ref: ir::NodeRef) -> bool {
+    fn contains(&self, ir_node_ref: ir::NodeRef) -> bool {
         self.ir_to_g8.contains_key(&ir_node_ref)
     }
 
-    pub fn add(&mut self, ir_node_ref: ir::NodeRef, gate_or_vec: GateOrVec) {
+    fn add(&mut self, ir_node_ref: ir::NodeRef, gate_or_vec: GateOrVec) {
         log::debug!(
             "add; ir_node_ref: {:?}; gate_or_vec: {:?}",
             ir_node_ref,
@@ -195,7 +196,7 @@ impl GateEnv {
         }
     }
 
-    pub fn apply_known_bits_if_any(
+    fn apply_known_bits_if_any(
         &mut self,
         ir_node_ref: ir::NodeRef,
         _f: &ir::Fn,
@@ -267,7 +268,7 @@ impl GateEnv {
         }
     }
 
-    pub fn get_bit_vector(&self, ir_node_ref: ir::NodeRef) -> Result<AigBitVector, String> {
+    pub(super) fn get_bit_vector(&self, ir_node_ref: ir::NodeRef) -> Result<AigBitVector, String> {
         match self.ir_to_g8.get(&ir_node_ref) {
             Some(GateOrVec::BitVector(bv)) => Ok(bv.clone()),
             Some(GateOrVec::Gate(gate_ref)) => Ok(AigBitVector::from_bit(*gate_ref)),
@@ -285,7 +286,7 @@ pub enum Signedness {
     Signed,
 }
 
-fn gatify_add_with_mapping(
+pub(super) fn gatify_add_with_mapping(
     adder_mapping: AdderMapping,
     lhs_bits: &AigBitVector,
     rhs_bits: &AigBitVector,
@@ -728,7 +729,10 @@ fn gatify_zero_ext(new_bit_count: usize, arg_bits: &AigBitVector) -> AigBitVecto
     AigBitVector::concat(zeros, arg_bits.clone())
 }
 
-fn gatify_zext_or_truncate(new_bit_count: usize, arg_bits: &AigBitVector) -> AigBitVector {
+pub(super) fn gatify_zext_or_truncate(
+    new_bit_count: usize,
+    arg_bits: &AigBitVector,
+) -> AigBitVector {
     match arg_bits.get_bit_count().cmp(&new_bit_count) {
         std::cmp::Ordering::Less => gatify_zero_ext(new_bit_count, arg_bits),
         std::cmp::Ordering::Equal => arg_bits.clone(),
@@ -736,7 +740,7 @@ fn gatify_zext_or_truncate(new_bit_count: usize, arg_bits: &AigBitVector) -> Aig
     }
 }
 
-fn gatify_sext_or_truncate(
+pub(super) fn gatify_sext_or_truncate(
     gb: &mut GateBuilder,
     text_id: usize,
     new_bit_count: usize,
@@ -1277,70 +1281,14 @@ pub enum CmpKind {
     Gt,
 }
 
-fn literal_bits_if_bits_node(f: &ir::Fn, node_ref: ir::NodeRef) -> Option<xlsynth::IrBits> {
+pub(super) fn literal_bits_if_bits_node(
+    f: &ir::Fn,
+    node_ref: ir::NodeRef,
+) -> Option<xlsynth::IrBits> {
     match &f.get_node(node_ref).payload {
         ir::NodePayload::Literal(literal) => literal.to_bits().ok(),
         _ => None,
     }
-}
-
-/// Resizes a literal term to the ext_nary_add output width.
-fn resize_literal_bits_for_ext_nary_add(
-    bits: &xlsynth::IrBits,
-    output_width: usize,
-    signed: bool,
-) -> xlsynth::IrBits {
-    match bits.get_bit_count().cmp(&output_width) {
-        std::cmp::Ordering::Less => {
-            let fill_bit = signed && bits.get_bit_count() != 0 && bits.msb();
-            let mut resized_bits = Vec::with_capacity(output_width);
-            for i in 0..bits.get_bit_count() {
-                resized_bits.push(
-                    bits.get_bit(i)
-                        .expect("literal bit index should be in bounds during resize"),
-                );
-            }
-            resized_bits.resize(output_width, fill_bit);
-            xlsynth::IrBits::from_lsb_is_0(&resized_bits)
-        }
-        std::cmp::Ordering::Equal => bits.clone(),
-        std::cmp::Ordering::Greater => bits.width_slice(0, output_width as i64),
-    }
-}
-
-/// Adds one literal contribution into the ext_nary_add constant accumulator.
-fn accumulate_ext_nary_add_literal(
-    literal_sum: &mut xlsynth::IrBits,
-    term_bits: &xlsynth::IrBits,
-    output_width: usize,
-    signed: bool,
-    negated: bool,
-) {
-    let resized = resize_literal_bits_for_ext_nary_add(term_bits, output_width, signed);
-    let contribution = if negated { resized.negate() } else { resized };
-    *literal_sum = literal_sum.add(&contribution);
-}
-
-/// Returns whether `bits` is exactly the unsigned value 1.
-fn is_one(bits: &xlsynth::IrBits) -> bool {
-    if bits.get_bit_count() == 0 {
-        return false;
-    }
-    if !bits
-        .get_bit(0)
-        .expect("literal bit 0 should be in bounds for non-empty bits")
-    {
-        return false;
-    }
-    for i in 1..bits.get_bit_count() {
-        if bits
-            .get_bit(i)
-            .expect("literal bit index should be in bounds during one-check")
-        {
-            return false;
-        }
-    }
-    true
 }
 
 fn is_all_zeros(bits: &xlsynth::IrBits) -> bool {
@@ -1376,7 +1324,7 @@ fn get_pow2_lsb_index(bits: &xlsynth::IrBits) -> Option<usize> {
     found
 }
 
-fn get_pow2_minus1_k(bits: &xlsynth::IrBits) -> Option<usize> {
+pub(super) fn get_pow2_minus1_k(bits: &xlsynth::IrBits) -> Option<usize> {
     // Recognizes values of the form (1<<k)-1, i.e. k low bits are 1 and the rest
     // are 0. k=0 => 0, k=bit_count => all ones.
     let bit_count = bits.get_bit_count();
@@ -1392,23 +1340,6 @@ fn get_pow2_minus1_k(bits: &xlsynth::IrBits) -> Option<usize> {
     Some(k)
 }
 
-fn normalize_add_literal_rhs(
-    f: &ir::Fn,
-    a: ir::NodeRef,
-    b: ir::NodeRef,
-) -> Option<(ir::NodeRef, xlsynth::IrBits)> {
-    let a_lit = literal_bits_if_bits_node(f, a);
-    let b_lit = literal_bits_if_bits_node(f, b);
-
-    match (a_lit, b_lit) {
-        (None, Some(rhs_bits)) => Some((a, rhs_bits)),
-        (Some(rhs_bits), None) => Some((b, rhs_bits)),
-        // If both are literals, we expect folding to have handled this.
-        (Some(_), Some(_)) => None,
-        (None, None) => None,
-    }
-}
-
 fn normalize_umul_literal_rhs(
     f: &ir::Fn,
     a: ir::NodeRef,
@@ -1422,68 +1353,6 @@ fn normalize_umul_literal_rhs(
         (Some(_), Some(_)) => None,
         (None, None) => None,
     }
-}
-
-fn gatify_add_const_pow2_minus1(
-    gb: &mut GateBuilder,
-    lhs_bits: &AigBitVector,
-    k: usize,
-) -> AigBitVector {
-    let bit_count = lhs_bits.get_bit_count();
-    assert!(k > 0 && k <= bit_count);
-
-    let mut sum = Vec::with_capacity(bit_count);
-    // For low bits where rhs_i=1, carry recurrence is c_{i+1} = lhs_i | c_i,
-    // and sum_i = !(lhs_i ^ c_i).
-    let mut carry = gb.get_false();
-    for i in 0..k {
-        let lhs_i = *lhs_bits.get_lsb(i);
-        let lhs_xor_carry = gb.add_xor_binary(lhs_i, carry);
-        let sum_i = gb.add_not(lhs_xor_carry);
-        sum.push(sum_i);
-        carry = gb.add_or_binary(lhs_i, carry);
-    }
-
-    // For upper bits where rhs_i=0, this is an increment-by-carry chain:
-    // sum_i = lhs_i ^ carry and c_{i+1} = lhs_i & carry.
-    for i in k..bit_count {
-        let lhs_i = *lhs_bits.get_lsb(i);
-        let sum_i = gb.add_xor_binary(lhs_i, carry);
-        sum.push(sum_i);
-        carry = gb.add_and_binary(lhs_i, carry);
-    }
-
-    AigBitVector::from_lsb_is_index_0(&sum)
-}
-
-/// Adds one literal to an already-lowered dynamic sum, preserving the plain-Add
-/// specialization for `(1<<k)-1` constants.
-fn gatify_add_literal_to_dynamic_sum(
-    gb: &mut GateBuilder,
-    sum_bits: &AigBitVector,
-    literal_bits: &xlsynth::IrBits,
-    adder_mapping: AdderMapping,
-) -> AigBitVector {
-    assert_eq!(sum_bits.get_bit_count(), literal_bits.get_bit_count());
-    if let Some(k) = get_pow2_minus1_k(literal_bits) {
-        if k == 0 {
-            return sum_bits.clone();
-        }
-        if k <= sum_bits.get_bit_count() {
-            return gatify_add_const_pow2_minus1(gb, sum_bits, k);
-        }
-    }
-
-    let literal_vec = gb.add_literal(literal_bits);
-    let (_c_out, sum) = gatify_add_with_mapping(
-        adder_mapping,
-        sum_bits,
-        &literal_vec,
-        gb.get_false(),
-        None,
-        gb,
-    );
-    sum
 }
 
 fn get_neg_pow2_k(bits: &xlsynth::IrBits) -> Option<usize> {
@@ -3012,105 +2881,17 @@ fn gatify_node(
             let ir::Type::Bits(output_width) = node.ty else {
                 return Err("ExtNaryAdd result must be bits-typed".to_string());
             };
-            if output_width == 0 {
-                env.add(node_ref, GateOrVec::BitVector(AigBitVector::zeros(0)));
-            } else if terms.is_empty() {
-                env.add(
-                    node_ref,
-                    GateOrVec::BitVector(AigBitVector::zeros(output_width)),
-                );
-            } else {
-                let one_bits = xlsynth::IrBits::make_ubits(output_width, 1)
-                    .expect("bits[output_width]:1 should construct");
-                let mut literal_sum = xlsynth::IrBits::zero(output_width);
-                let mut lowered_terms: Vec<AigBitVector> = Vec::with_capacity(terms.len());
-                for term in terms {
-                    if let Some(literal_bits) = literal_bits_if_bits_node(f, term.operand) {
-                        accumulate_ext_nary_add_literal(
-                            &mut literal_sum,
-                            &literal_bits,
-                            output_width,
-                            term.signed,
-                            term.negated,
-                        );
-                        continue;
-                    }
-
-                    let bits = env
-                        .get_bit_vector(term.operand)
-                        .expect("ext_nary_add operand should be present");
-                    let resized = if term.signed {
-                        gatify_sext_or_truncate(g8_builder, node.text_id, output_width, &bits)
-                    } else {
-                        gatify_zext_or_truncate(output_width, &bits)
-                    };
-                    if term.negated {
-                        lowered_terms.push(g8_builder.add_not_vec(&resized));
-                        literal_sum = literal_sum.add(&one_bits);
-                    } else {
-                        lowered_terms.push(resized);
-                    }
-                }
-                let carry_in = if is_one(&literal_sum) && lowered_terms.len() >= 2 {
-                    literal_sum = xlsynth::IrBits::zero(output_width);
-                    Some(g8_builder.get_true())
-                } else {
-                    None
-                };
-                let selected_adder_mapping = (*arch)
-                    .map(AdderMapping::from)
-                    .unwrap_or(options.adder_mapping);
-                let selected_adder_mapping_name = match selected_adder_mapping {
-                    AdderMapping::RippleCarry => "ripple_carry",
-                    AdderMapping::BrentKung => "brent_kung",
-                    AdderMapping::KoggeStone => "kogge_stone",
-                };
-                let sum = if lowered_terms.is_empty() {
-                    g8_builder.add_literal(&literal_sum)
-                } else if lowered_terms.len() == 1 && carry_in.is_none() {
-                    gatify_add_literal_to_dynamic_sum(
-                        g8_builder,
-                        &lowered_terms[0],
-                        &literal_sum,
-                        selected_adder_mapping,
-                    )
-                } else if get_pow2_minus1_k(&literal_sum).is_some() {
-                    let dynamic_sum = array_add_with_carry_out(
-                        g8_builder,
-                        &lowered_terms,
-                        carry_in,
-                        selected_adder_mapping,
-                    )
-                    .sum;
-                    gatify_add_literal_to_dynamic_sum(
-                        g8_builder,
-                        &dynamic_sum,
-                        &literal_sum,
-                        selected_adder_mapping,
-                    )
-                } else {
-                    if !literal_sum.is_zero() {
-                        lowered_terms.push(g8_builder.add_literal(&literal_sum));
-                    }
-                    array_add_with_carry_out(
-                        g8_builder,
-                        &lowered_terms,
-                        carry_in,
-                        selected_adder_mapping,
-                    )
-                    .sum
-                };
-                for (i, gate) in sum.iter_lsb_to_msb().enumerate() {
-                    g8_builder.add_tag(
-                        gate.node,
-                        format!(
-                            "ext_nary_add_{}_{}_output_bit_{}",
-                            node.text_id, selected_adder_mapping_name, i
-                        ),
-                    );
-                }
-                env.add(node_ref, GateOrVec::BitVector(sum));
-            }
+            let gates = gatify_ext_nary_add(
+                f,
+                &env,
+                node.text_id,
+                terms,
+                *arch,
+                output_width,
+                options.adder_mapping,
+                g8_builder,
+            );
+            env.add(node_ref, GateOrVec::BitVector(gates));
         }
 
         // -- binary operations
@@ -3316,70 +3097,27 @@ fn gatify_node(
             env.add(node_ref, GateOrVec::BitVector(gates));
         }
         ir::NodePayload::Binop(ir::Binop::Add, a, b) => {
-            if let Some((lhs, rhs_bits)) = normalize_add_literal_rhs(f, *a, *b) {
-                if let Some(k) = get_pow2_minus1_k(&rhs_bits) {
-                    let lhs_gate_refs = env
-                        .get_bit_vector(lhs)
-                        .expect("add lhs should be present for literal-rhs rewrite");
-                    assert_eq!(lhs_gate_refs.get_bit_count(), rhs_bits.get_bit_count());
-                    let gates = if k == 0 {
-                        lhs_gate_refs.clone()
-                    } else {
-                        gatify_add_const_pow2_minus1(g8_builder, &lhs_gate_refs, k)
-                    };
-                    env.add(node_ref, GateOrVec::BitVector(gates));
-                } else {
-                    let a_gate_refs = env.get_bit_vector(*a).expect("add lhs should be present");
-                    let b_gate_refs = env.get_bit_vector(*b).expect("add rhs should be present");
-                    assert_eq!(a_gate_refs.get_bit_count(), b_gate_refs.get_bit_count());
-                    let add_tag = format!("add_{}", node.text_id);
-                    let (_c_out, gates) = gatify_add_with_mapping(
-                        options.adder_mapping,
-                        &a_gate_refs,
-                        &b_gate_refs,
-                        g8_builder.get_false(),
-                        Some(&add_tag),
-                        g8_builder,
-                    );
-                    assert_eq!(gates.get_bit_count(), a_gate_refs.get_bit_count());
-                    env.add(node_ref, GateOrVec::BitVector(gates));
-                }
-            } else {
-                let a_gate_refs = env.get_bit_vector(*a).expect("add lhs should be present");
-                let b_gate_refs = env.get_bit_vector(*b).expect("add rhs should be present");
-                assert_eq!(a_gate_refs.get_bit_count(), b_gate_refs.get_bit_count());
-                let add_tag = format!("add_{}", node.text_id);
-                let (_c_out, gates) = gatify_add_with_mapping(
-                    options.adder_mapping,
-                    &a_gate_refs,
-                    &b_gate_refs,
-                    g8_builder.get_false(),
-                    Some(&add_tag),
-                    g8_builder,
-                );
-                assert_eq!(gates.get_bit_count(), a_gate_refs.get_bit_count());
-                env.add(node_ref, GateOrVec::BitVector(gates));
-            }
-        }
-        ir::NodePayload::Binop(ir::Binop::Sub, a, b) => {
-            let a_gate_refs = env.get_bit_vector(*a).expect("sub lhs should be present");
-            let b_gate_refs = env.get_bit_vector(*b).expect("sub rhs should be present");
-            assert_eq!(a_gate_refs.get_bit_count(), b_gate_refs.get_bit_count());
-            let b_complement = g8_builder.add_not_vec(&b_gate_refs);
-            let sub_tag = format!("sub_{}", node.text_id);
-            let (_c_out, gates) = gatify_add_with_mapping(
+            let gates = gatify_add_binop(
+                f,
+                &env,
+                node.text_id,
+                *a,
+                *b,
                 options.adder_mapping,
-                &a_gate_refs,
-                &b_complement,
-                g8_builder.get_true(),
-                Some(&sub_tag),
                 g8_builder,
             );
-            let output_bit_count = node.ty.bit_count();
-            assert_eq!(gates.get_bit_count(), output_bit_count);
-            for (i, gate) in gates.iter_lsb_to_msb().enumerate() {
-                g8_builder.add_tag(gate.node, format!("sub_{}_output_bit_{}", node.text_id, i));
-            }
+            env.add(node_ref, GateOrVec::BitVector(gates));
+        }
+        ir::NodePayload::Binop(ir::Binop::Sub, a, b) => {
+            let gates = gatify_sub_binop(
+                &env,
+                node.text_id,
+                node.ty.bit_count(),
+                *a,
+                *b,
+                options.adder_mapping,
+                g8_builder,
+            );
             env.add(node_ref, GateOrVec::BitVector(gates));
         }
         ir::NodePayload::BitSlice { arg, start, width } => {

--- a/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
@@ -118,6 +118,35 @@ fn gatify_add_const_pow2_minus1(
     gatify_add_const_single_ones_run(gb, lhs_bits, 0..k, gb.get_false())
 }
 
+/// Lowers `lhs_bits + (1 << one_bit_position)` through `adder_mapping`.
+fn gatify_add_const_pow2_with_mapping(
+    gb: &mut GateBuilder,
+    lhs_bits: &AigBitVector,
+    one_bit_position: usize,
+    adder_mapping: AdderMapping,
+) -> AigBitVector {
+    let bit_count = lhs_bits.get_bit_count();
+    assert!(one_bit_position < bit_count);
+
+    let mut sum_bits = Vec::with_capacity(bit_count);
+    for i in 0..one_bit_position {
+        sum_bits.push(*lhs_bits.get_lsb(i));
+    }
+
+    let upper_lhs_bits = lhs_bits.get_lsb_slice(one_bit_position, bit_count - one_bit_position);
+    let upper_rhs_bits = AigBitVector::zeros(bit_count - one_bit_position);
+    let (_, upper_sum_bits) = gatify_add_with_mapping(
+        adder_mapping,
+        &upper_lhs_bits,
+        &upper_rhs_bits,
+        gb.get_true(),
+        None,
+        gb,
+    );
+    sum_bits.extend(upper_sum_bits.iter_lsb_to_msb().copied());
+    AigBitVector::from_lsb_is_index_0(&sum_bits)
+}
+
 /// Recognizes literals with one contiguous run of 1s and zeros elsewhere.
 fn get_single_ones_run(bits: &xlsynth::IrBits) -> Option<Range<usize>> {
     let bit_count = bits.get_bit_count();
@@ -149,6 +178,24 @@ fn get_single_ones_run(bits: &xlsynth::IrBits) -> Option<Range<usize>> {
     }
 
     Some(run_start..run_end)
+}
+
+/// Returns the one-hot bit position if `bits` is exactly `1 << k`.
+fn get_single_one_bit_position(bits: &xlsynth::IrBits) -> Option<usize> {
+    let mut one_bit_position = None;
+    for i in 0..bits.get_bit_count() {
+        if !bits
+            .get_bit(i)
+            .expect("literal bit index should be in bounds during one-hot detection")
+        {
+            continue;
+        }
+        if one_bit_position.is_some() {
+            return None;
+        }
+        one_bit_position = Some(i);
+    }
+    one_bit_position
 }
 
 /// Lowers `lhs_bits + literal_run + carry_in` where `literal_run` has one
@@ -204,17 +251,8 @@ fn gatify_add_literal_to_dynamic_sum(
     adder_mapping: AdderMapping,
 ) -> AigBitVector {
     assert_eq!(sum_bits.get_bit_count(), literal_bits.get_bit_count());
-    if is_one(literal_bits) {
-        let zero_bits = AigBitVector::zeros(literal_bits.get_bit_count());
-        return gatify_add_with_mapping(
-            adder_mapping,
-            sum_bits,
-            &zero_bits,
-            gb.get_true(),
-            None,
-            gb,
-        )
-        .1;
+    if let Some(one_bit_position) = get_single_one_bit_position(literal_bits) {
+        return gatify_add_const_pow2_with_mapping(gb, sum_bits, one_bit_position, adder_mapping);
     }
     if let Some(k) = get_pow2_minus1_k(literal_bits) {
         if k == 0 {

--- a/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
@@ -2,14 +2,36 @@
 
 //! Arithmetic lowering helpers for `ir2gate`.
 
-use crate::aig::gate::AigBitVector;
+use crate::aig::gate::{AigBitVector, AigOperand};
 use crate::gate_builder::GateBuilder;
 use crate::gatify::ir2gate::{
     GateEnv, gatify_add_with_mapping, gatify_sext_or_truncate, gatify_zext_or_truncate,
     get_pow2_minus1_k, literal_bits_if_bits_node,
 };
 use crate::ir2gate_utils::{AdderMapping, array_add_with_carry_out};
+use std::ops::Range;
 use xlsynth_pir::ir;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ExtNaryAddFillKind {
+    Zero,
+    Sign,
+}
+
+#[derive(Clone, Debug)]
+struct ExtNaryAddTermDimensions {
+    term_bits: AigBitVector,
+    weight_shift: usize,
+    active_range: Range<usize>,
+    fill_kind: ExtNaryAddFillKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ExtNaryAddUnitCorrection {
+    control: AigOperand,
+    weight_shift: usize,
+    is_decrement: bool,
+}
 
 /// Resizes a literal term to the `ExtNaryAdd` output width.
 fn resize_literal_bits_for_ext_nary_add(
@@ -150,6 +172,165 @@ fn gatify_add_literal_to_dynamic_sum(
     sum
 }
 
+fn classify_ext_nary_add_term_dimensions(
+    bits: &AigBitVector,
+    false_bit: AigOperand,
+) -> ExtNaryAddTermDimensions {
+    let bit_count = bits.get_bit_count();
+    let mut weight_shift = 0usize;
+    while weight_shift < bit_count && *bits.get_lsb(weight_shift) == false_bit {
+        weight_shift += 1;
+    }
+    if weight_shift == bit_count {
+        return ExtNaryAddTermDimensions {
+            term_bits: AigBitVector::zeros(0),
+            weight_shift,
+            active_range: weight_shift..weight_shift,
+            fill_kind: ExtNaryAddFillKind::Zero,
+        };
+    }
+
+    let msb = *bits.get_lsb(bit_count - 1);
+    if msb == false_bit {
+        let mut active_end = bit_count;
+        while active_end > weight_shift && *bits.get_lsb(active_end - 1) == false_bit {
+            active_end -= 1;
+        }
+        return ExtNaryAddTermDimensions {
+            term_bits: bits.get_lsb_slice(weight_shift, active_end - weight_shift),
+            weight_shift,
+            active_range: weight_shift..active_end,
+            fill_kind: ExtNaryAddFillKind::Zero,
+        };
+    }
+
+    let mut active_end = bit_count;
+    while active_end > weight_shift + 1 && *bits.get_lsb(active_end - 2) == msb {
+        active_end -= 1;
+    }
+    ExtNaryAddTermDimensions {
+        term_bits: bits.get_lsb_slice(weight_shift, active_end - weight_shift),
+        weight_shift,
+        active_range: weight_shift..active_end,
+        fill_kind: ExtNaryAddFillKind::Sign,
+    }
+}
+
+fn classify_ext_nary_add_unit_correction(
+    dimensions: &ExtNaryAddTermDimensions,
+    negated: bool,
+) -> Option<ExtNaryAddUnitCorrection> {
+    if dimensions.term_bits.get_bit_count() != 1 {
+        return None;
+    }
+    if dimensions.active_range != (dimensions.weight_shift..dimensions.weight_shift + 1) {
+        return None;
+    }
+
+    Some(ExtNaryAddUnitCorrection {
+        control: *dimensions.term_bits.get_lsb(0),
+        weight_shift: dimensions.weight_shift,
+        is_decrement: negated ^ (dimensions.fill_kind == ExtNaryAddFillKind::Sign),
+    })
+}
+
+/// Adds 1 modulo the bit width of `literal_sum`.
+fn increment_literal_sum_by_one(literal_sum: &mut xlsynth::IrBits) {
+    let one_bits = xlsynth::IrBits::make_ubits(literal_sum.get_bit_count(), 1)
+        .expect("bits[output_width]:1 should construct");
+    *literal_sum = literal_sum.add(&one_bits);
+}
+
+/// Subtracts 1 modulo the bit width of `literal_sum`.
+fn decrement_literal_sum_by_one(literal_sum: &mut xlsynth::IrBits) {
+    let one_bits = xlsynth::IrBits::make_ubits(literal_sum.get_bit_count(), 1)
+        .expect("bits[output_width]:1 should construct");
+    *literal_sum = literal_sum.add(&one_bits.negate());
+}
+
+/// Tries to fuse one bit-0 unit correction into the final CPA carry-in.
+fn try_fuse_ext_nary_add_unit_correction_into_carry_in(
+    gb: &mut GateBuilder,
+    unit_correction: ExtNaryAddUnitCorrection,
+    literal_sum: &mut xlsynth::IrBits,
+    carry_in: &mut Option<AigOperand>,
+) -> bool {
+    if unit_correction.weight_shift != 0 || carry_in.is_some() {
+        return false;
+    }
+    if unit_correction.is_decrement {
+        decrement_literal_sum_by_one(literal_sum);
+        *carry_in = Some(gb.add_not(unit_correction.control));
+    } else {
+        *carry_in = Some(unit_correction.control);
+    }
+    true
+}
+
+/// Falls back to the dense representation for a unit correction.
+fn push_ext_nary_add_unit_correction_as_dense_term(
+    gb: &mut GateBuilder,
+    output_width: usize,
+    unit_correction: ExtNaryAddUnitCorrection,
+    lowered_terms: &mut Vec<AigBitVector>,
+    literal_sum: &mut xlsynth::IrBits,
+) {
+    if unit_correction.weight_shift >= output_width {
+        return;
+    }
+    let mut shifted_bits = vec![gb.get_false(); output_width];
+    shifted_bits[unit_correction.weight_shift] = unit_correction.control;
+    let shifted_operand = AigBitVector::from_lsb_is_index_0(&shifted_bits);
+    if unit_correction.is_decrement {
+        lowered_terms.push(gb.add_not_vec(&shifted_operand));
+        increment_literal_sum_by_one(literal_sum);
+    } else {
+        lowered_terms.push(shifted_operand);
+    }
+}
+
+fn gatify_dense_ext_nary_add_terms(
+    gb: &mut GateBuilder,
+    mut lowered_terms: Vec<AigBitVector>,
+    literal_sum: &xlsynth::IrBits,
+    carry_in: Option<AigOperand>,
+    adder_mapping: AdderMapping,
+) -> AigBitVector {
+    if lowered_terms.is_empty() {
+        if carry_in.is_none() {
+            return gb.add_literal(literal_sum);
+        }
+        lowered_terms.push(AigBitVector::zeros(literal_sum.get_bit_count()));
+    }
+
+    let mut literal_sum = literal_sum.clone();
+    let carry_in = if carry_in.is_none() && is_one(&literal_sum) && lowered_terms.len() >= 2 {
+        literal_sum = xlsynth::IrBits::zero(literal_sum.get_bit_count());
+        Some(gb.get_true())
+    } else {
+        carry_in
+    };
+
+    if lowered_terms.len() == 1 && carry_in.is_none() {
+        return gatify_add_literal_to_dynamic_sum(
+            gb,
+            &lowered_terms[0],
+            &literal_sum,
+            adder_mapping,
+        );
+    }
+
+    if carry_in.is_none() && get_pow2_minus1_k(&literal_sum).is_some() {
+        let dynamic_sum = array_add_with_carry_out(gb, &lowered_terms, carry_in, adder_mapping).sum;
+        return gatify_add_literal_to_dynamic_sum(gb, &dynamic_sum, &literal_sum, adder_mapping);
+    }
+
+    if !literal_sum.is_zero() {
+        lowered_terms.push(gb.add_literal(&literal_sum));
+    }
+    array_add_with_carry_out(gb, &lowered_terms, carry_in, adder_mapping).sum
+}
+
 /// Lowers a plain `add` node.
 pub(super) fn gatify_add_binop(
     f: &ir::Fn,
@@ -238,10 +419,10 @@ pub(super) fn gatify_ext_nary_add(
         return AigBitVector::zeros(output_width);
     }
 
-    let one_bits = xlsynth::IrBits::make_ubits(output_width, 1)
-        .expect("bits[output_width]:1 should construct");
     let mut literal_sum = xlsynth::IrBits::zero(output_width);
     let mut lowered_terms: Vec<AigBitVector> = Vec::with_capacity(terms.len());
+    let mut carry_in: Option<AigOperand> = None;
+    let false_bit = g8_builder.get_false();
     for term in terms {
         if let Some(literal_bits) = literal_bits_if_bits_node(f, term.operand) {
             accumulate_ext_nary_add_literal(
@@ -262,19 +443,36 @@ pub(super) fn gatify_ext_nary_add(
         } else {
             gatify_zext_or_truncate(output_width, &bits)
         };
+
+        let dimensions = classify_ext_nary_add_term_dimensions(&resized, false_bit);
+        if let Some(unit_correction) =
+            classify_ext_nary_add_unit_correction(&dimensions, term.negated)
+        {
+            if !try_fuse_ext_nary_add_unit_correction_into_carry_in(
+                g8_builder,
+                unit_correction,
+                &mut literal_sum,
+                &mut carry_in,
+            ) {
+                push_ext_nary_add_unit_correction_as_dense_term(
+                    g8_builder,
+                    output_width,
+                    unit_correction,
+                    &mut lowered_terms,
+                    &mut literal_sum,
+                );
+            }
+            continue;
+        }
+
         if term.negated {
             lowered_terms.push(g8_builder.add_not_vec(&resized));
-            literal_sum = literal_sum.add(&one_bits);
+            increment_literal_sum_by_one(&mut literal_sum);
         } else {
             lowered_terms.push(resized);
         }
     }
-    let carry_in = if is_one(&literal_sum) && lowered_terms.len() >= 2 {
-        literal_sum = xlsynth::IrBits::zero(output_width);
-        Some(g8_builder.get_true())
-    } else {
-        None
-    };
+
     let selected_adder_mapping = arch
         .map(AdderMapping::from)
         .unwrap_or(default_adder_mapping);
@@ -283,31 +481,13 @@ pub(super) fn gatify_ext_nary_add(
         AdderMapping::BrentKung => "brent_kung",
         AdderMapping::KoggeStone => "kogge_stone",
     };
-    let sum = if lowered_terms.is_empty() {
-        g8_builder.add_literal(&literal_sum)
-    } else if lowered_terms.len() == 1 && carry_in.is_none() {
-        gatify_add_literal_to_dynamic_sum(
-            g8_builder,
-            &lowered_terms[0],
-            &literal_sum,
-            selected_adder_mapping,
-        )
-    } else if get_pow2_minus1_k(&literal_sum).is_some() {
-        let dynamic_sum =
-            array_add_with_carry_out(g8_builder, &lowered_terms, carry_in, selected_adder_mapping)
-                .sum;
-        gatify_add_literal_to_dynamic_sum(
-            g8_builder,
-            &dynamic_sum,
-            &literal_sum,
-            selected_adder_mapping,
-        )
-    } else {
-        if !literal_sum.is_zero() {
-            lowered_terms.push(g8_builder.add_literal(&literal_sum));
-        }
-        array_add_with_carry_out(g8_builder, &lowered_terms, carry_in, selected_adder_mapping).sum
-    };
+    let sum = gatify_dense_ext_nary_add_terms(
+        g8_builder,
+        lowered_terms,
+        &literal_sum,
+        carry_in,
+        selected_adder_mapping,
+    );
     for (i, gate) in sum.iter_lsb_to_msb().enumerate() {
         g8_builder.add_tag(
             gate.node,

--- a/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Arithmetic lowering helpers for `ir2gate`.
+
+use crate::aig::gate::AigBitVector;
+use crate::gate_builder::GateBuilder;
+use crate::gatify::ir2gate::{
+    GateEnv, gatify_add_with_mapping, gatify_sext_or_truncate, gatify_zext_or_truncate,
+    get_pow2_minus1_k, literal_bits_if_bits_node,
+};
+use crate::ir2gate_utils::{AdderMapping, array_add_with_carry_out};
+use xlsynth_pir::ir;
+
+/// Resizes a literal term to the `ExtNaryAdd` output width.
+fn resize_literal_bits_for_ext_nary_add(
+    bits: &xlsynth::IrBits,
+    output_width: usize,
+    signed: bool,
+) -> xlsynth::IrBits {
+    match bits.get_bit_count().cmp(&output_width) {
+        std::cmp::Ordering::Less => {
+            let fill_bit = signed && bits.get_bit_count() != 0 && bits.msb();
+            let mut resized_bits = Vec::with_capacity(output_width);
+            for i in 0..bits.get_bit_count() {
+                resized_bits.push(
+                    bits.get_bit(i)
+                        .expect("literal bit index should be in bounds during resize"),
+                );
+            }
+            resized_bits.resize(output_width, fill_bit);
+            xlsynth::IrBits::from_lsb_is_0(&resized_bits)
+        }
+        std::cmp::Ordering::Equal => bits.clone(),
+        std::cmp::Ordering::Greater => bits.width_slice(0, output_width as i64),
+    }
+}
+
+/// Adds one literal contribution into the `ExtNaryAdd` constant accumulator.
+fn accumulate_ext_nary_add_literal(
+    literal_sum: &mut xlsynth::IrBits,
+    term_bits: &xlsynth::IrBits,
+    output_width: usize,
+    signed: bool,
+    negated: bool,
+) {
+    let resized = resize_literal_bits_for_ext_nary_add(term_bits, output_width, signed);
+    let contribution = if negated { resized.negate() } else { resized };
+    *literal_sum = literal_sum.add(&contribution);
+}
+
+/// Returns whether `bits` is exactly the unsigned value 1.
+fn is_one(bits: &xlsynth::IrBits) -> bool {
+    if bits.get_bit_count() == 0 {
+        return false;
+    }
+    if !bits
+        .get_bit(0)
+        .expect("literal bit 0 should be in bounds for non-empty bits")
+    {
+        return false;
+    }
+    for i in 1..bits.get_bit_count() {
+        if bits
+            .get_bit(i)
+            .expect("literal bit index should be in bounds during one-check")
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn normalize_add_literal_rhs(
+    f: &ir::Fn,
+    a: ir::NodeRef,
+    b: ir::NodeRef,
+) -> Option<(ir::NodeRef, xlsynth::IrBits)> {
+    let a_lit = literal_bits_if_bits_node(f, a);
+    let b_lit = literal_bits_if_bits_node(f, b);
+
+    match (a_lit, b_lit) {
+        (None, Some(rhs_bits)) => Some((a, rhs_bits)),
+        (Some(rhs_bits), None) => Some((b, rhs_bits)),
+        // If both are literals, we expect folding to have handled this.
+        (Some(_), Some(_)) => None,
+        (None, None) => None,
+    }
+}
+
+fn gatify_add_const_pow2_minus1(
+    gb: &mut GateBuilder,
+    lhs_bits: &AigBitVector,
+    k: usize,
+) -> AigBitVector {
+    let bit_count = lhs_bits.get_bit_count();
+    assert!(k > 0 && k <= bit_count);
+
+    let mut sum = Vec::with_capacity(bit_count);
+    // For low bits where rhs_i=1, carry recurrence is c_{i+1} = lhs_i | c_i,
+    // and sum_i = !(lhs_i ^ c_i).
+    let mut carry = gb.get_false();
+    for i in 0..k {
+        let lhs_i = *lhs_bits.get_lsb(i);
+        let lhs_xor_carry = gb.add_xor_binary(lhs_i, carry);
+        let sum_i = gb.add_not(lhs_xor_carry);
+        sum.push(sum_i);
+        carry = gb.add_or_binary(lhs_i, carry);
+    }
+
+    // For upper bits where rhs_i=0, this is an increment-by-carry chain:
+    // sum_i = lhs_i ^ carry and c_{i+1} = lhs_i & carry.
+    for i in k..bit_count {
+        let lhs_i = *lhs_bits.get_lsb(i);
+        let sum_i = gb.add_xor_binary(lhs_i, carry);
+        sum.push(sum_i);
+        carry = gb.add_and_binary(lhs_i, carry);
+    }
+
+    AigBitVector::from_lsb_is_index_0(&sum)
+}
+
+/// Adds one literal to an already-lowered dynamic sum.
+///
+/// Preserves the plain `Add` specialization for `(1<<k)-1` constants.
+fn gatify_add_literal_to_dynamic_sum(
+    gb: &mut GateBuilder,
+    sum_bits: &AigBitVector,
+    literal_bits: &xlsynth::IrBits,
+    adder_mapping: AdderMapping,
+) -> AigBitVector {
+    assert_eq!(sum_bits.get_bit_count(), literal_bits.get_bit_count());
+    if let Some(k) = get_pow2_minus1_k(literal_bits) {
+        if k == 0 {
+            return sum_bits.clone();
+        }
+        if k <= sum_bits.get_bit_count() {
+            return gatify_add_const_pow2_minus1(gb, sum_bits, k);
+        }
+    }
+
+    let literal_vec = gb.add_literal(literal_bits);
+    let (_c_out, sum) = gatify_add_with_mapping(
+        adder_mapping,
+        sum_bits,
+        &literal_vec,
+        gb.get_false(),
+        None,
+        gb,
+    );
+    sum
+}
+
+/// Lowers a plain `add` node.
+pub(super) fn gatify_add_binop(
+    f: &ir::Fn,
+    env: &GateEnv,
+    text_id: usize,
+    a: ir::NodeRef,
+    b: ir::NodeRef,
+    adder_mapping: AdderMapping,
+    g8_builder: &mut GateBuilder,
+) -> AigBitVector {
+    if let Some((lhs, rhs_bits)) = normalize_add_literal_rhs(f, a, b) {
+        if let Some(k) = get_pow2_minus1_k(&rhs_bits) {
+            let lhs_gate_refs = env
+                .get_bit_vector(lhs)
+                .expect("add lhs should be present for literal-rhs rewrite");
+            assert_eq!(lhs_gate_refs.get_bit_count(), rhs_bits.get_bit_count());
+            return if k == 0 {
+                lhs_gate_refs
+            } else {
+                gatify_add_const_pow2_minus1(g8_builder, &lhs_gate_refs, k)
+            };
+        }
+    }
+
+    let a_gate_refs = env.get_bit_vector(a).expect("add lhs should be present");
+    let b_gate_refs = env.get_bit_vector(b).expect("add rhs should be present");
+    assert_eq!(a_gate_refs.get_bit_count(), b_gate_refs.get_bit_count());
+    let add_tag = format!("add_{}", text_id);
+    let (_c_out, gates) = gatify_add_with_mapping(
+        adder_mapping,
+        &a_gate_refs,
+        &b_gate_refs,
+        g8_builder.get_false(),
+        Some(&add_tag),
+        g8_builder,
+    );
+    assert_eq!(gates.get_bit_count(), a_gate_refs.get_bit_count());
+    gates
+}
+
+/// Lowers a plain `sub` node.
+pub(super) fn gatify_sub_binop(
+    env: &GateEnv,
+    text_id: usize,
+    output_bit_count: usize,
+    a: ir::NodeRef,
+    b: ir::NodeRef,
+    adder_mapping: AdderMapping,
+    g8_builder: &mut GateBuilder,
+) -> AigBitVector {
+    let a_gate_refs = env.get_bit_vector(a).expect("sub lhs should be present");
+    let b_gate_refs = env.get_bit_vector(b).expect("sub rhs should be present");
+    assert_eq!(a_gate_refs.get_bit_count(), b_gate_refs.get_bit_count());
+    let b_complement = g8_builder.add_not_vec(&b_gate_refs);
+    let sub_tag = format!("sub_{}", text_id);
+    let (_c_out, gates) = gatify_add_with_mapping(
+        adder_mapping,
+        &a_gate_refs,
+        &b_complement,
+        g8_builder.get_true(),
+        Some(&sub_tag),
+        g8_builder,
+    );
+    assert_eq!(gates.get_bit_count(), output_bit_count);
+    for (i, gate) in gates.iter_lsb_to_msb().enumerate() {
+        g8_builder.add_tag(gate.node, format!("sub_{}_output_bit_{}", text_id, i));
+    }
+    gates
+}
+
+/// Lowers an `ext_nary_add` node.
+pub(super) fn gatify_ext_nary_add(
+    f: &ir::Fn,
+    env: &GateEnv,
+    text_id: usize,
+    terms: &[ir::ExtNaryAddTerm],
+    arch: Option<ir::ExtNaryAddArchitecture>,
+    output_width: usize,
+    default_adder_mapping: AdderMapping,
+    g8_builder: &mut GateBuilder,
+) -> AigBitVector {
+    if output_width == 0 {
+        return AigBitVector::zeros(0);
+    }
+    if terms.is_empty() {
+        return AigBitVector::zeros(output_width);
+    }
+
+    let one_bits = xlsynth::IrBits::make_ubits(output_width, 1)
+        .expect("bits[output_width]:1 should construct");
+    let mut literal_sum = xlsynth::IrBits::zero(output_width);
+    let mut lowered_terms: Vec<AigBitVector> = Vec::with_capacity(terms.len());
+    for term in terms {
+        if let Some(literal_bits) = literal_bits_if_bits_node(f, term.operand) {
+            accumulate_ext_nary_add_literal(
+                &mut literal_sum,
+                &literal_bits,
+                output_width,
+                term.signed,
+                term.negated,
+            );
+            continue;
+        }
+
+        let bits = env
+            .get_bit_vector(term.operand)
+            .expect("ext_nary_add operand should be present");
+        let resized = if term.signed {
+            gatify_sext_or_truncate(g8_builder, text_id, output_width, &bits)
+        } else {
+            gatify_zext_or_truncate(output_width, &bits)
+        };
+        if term.negated {
+            lowered_terms.push(g8_builder.add_not_vec(&resized));
+            literal_sum = literal_sum.add(&one_bits);
+        } else {
+            lowered_terms.push(resized);
+        }
+    }
+    let carry_in = if is_one(&literal_sum) && lowered_terms.len() >= 2 {
+        literal_sum = xlsynth::IrBits::zero(output_width);
+        Some(g8_builder.get_true())
+    } else {
+        None
+    };
+    let selected_adder_mapping = arch
+        .map(AdderMapping::from)
+        .unwrap_or(default_adder_mapping);
+    let selected_adder_mapping_name = match selected_adder_mapping {
+        AdderMapping::RippleCarry => "ripple_carry",
+        AdderMapping::BrentKung => "brent_kung",
+        AdderMapping::KoggeStone => "kogge_stone",
+    };
+    let sum = if lowered_terms.is_empty() {
+        g8_builder.add_literal(&literal_sum)
+    } else if lowered_terms.len() == 1 && carry_in.is_none() {
+        gatify_add_literal_to_dynamic_sum(
+            g8_builder,
+            &lowered_terms[0],
+            &literal_sum,
+            selected_adder_mapping,
+        )
+    } else if get_pow2_minus1_k(&literal_sum).is_some() {
+        let dynamic_sum =
+            array_add_with_carry_out(g8_builder, &lowered_terms, carry_in, selected_adder_mapping)
+                .sum;
+        gatify_add_literal_to_dynamic_sum(
+            g8_builder,
+            &dynamic_sum,
+            &literal_sum,
+            selected_adder_mapping,
+        )
+    } else {
+        if !literal_sum.is_zero() {
+            lowered_terms.push(g8_builder.add_literal(&literal_sum));
+        }
+        array_add_with_carry_out(g8_builder, &lowered_terms, carry_in, selected_adder_mapping).sum
+    };
+    for (i, gate) in sum.iter_lsb_to_msb().enumerate() {
+        g8_builder.add_tag(
+            gate.node,
+            format!(
+                "ext_nary_add_{}_{}_output_bit_{}",
+                text_id, selected_adder_mapping_name, i
+            ),
+        );
+    }
+    sum
+}

--- a/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
@@ -365,7 +365,24 @@ fn gatify_dense_ext_nary_add_terms(
     };
 
     if lowered_terms.len() == 1 {
-        if let Some(ones_run) = get_single_ones_run(&literal_sum) {
+        if literal_sum.is_zero() {
+            if let Some(carry_in) = carry_in {
+                let zero_bits = AigBitVector::zeros(literal_sum.get_bit_count());
+                return gatify_add_with_mapping(
+                    adder_mapping,
+                    &lowered_terms[0],
+                    &zero_bits,
+                    carry_in,
+                    None,
+                    gb,
+                )
+                .1;
+            }
+            return lowered_terms[0].clone();
+        }
+        if let Some(ones_run) = get_single_ones_run(&literal_sum)
+            && (carry_in.is_some() || ones_run.start == 0 || ones_run.len() != 1)
+        {
             return gatify_add_const_single_ones_run(
                 gb,
                 &lowered_terms[0],

--- a/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
@@ -204,6 +204,18 @@ fn gatify_add_literal_to_dynamic_sum(
     adder_mapping: AdderMapping,
 ) -> AigBitVector {
     assert_eq!(sum_bits.get_bit_count(), literal_bits.get_bit_count());
+    if is_one(literal_bits) {
+        let zero_bits = AigBitVector::zeros(literal_bits.get_bit_count());
+        return gatify_add_with_mapping(
+            adder_mapping,
+            sum_bits,
+            &zero_bits,
+            gb.get_true(),
+            None,
+            gb,
+        )
+        .1;
+    }
     if let Some(k) = get_pow2_minus1_k(literal_bits) {
         if k == 0 {
             return sum_bits.clone();
@@ -357,7 +369,7 @@ fn gatify_dense_ext_nary_add_terms(
     }
 
     let mut literal_sum = literal_sum.clone();
-    let carry_in = if carry_in.is_none() && is_one(&literal_sum) && lowered_terms.len() >= 2 {
+    let carry_in = if carry_in.is_none() && is_one(&literal_sum) && !lowered_terms.is_empty() {
         literal_sum = xlsynth::IrBits::zero(literal_sum.get_bit_count());
         Some(gb.get_true())
     } else {
@@ -422,17 +434,15 @@ pub(super) fn gatify_add_binop(
     g8_builder: &mut GateBuilder,
 ) -> AigBitVector {
     if let Some((lhs, rhs_bits)) = normalize_add_literal_rhs(f, a, b) {
-        if let Some(k) = get_pow2_minus1_k(&rhs_bits) {
-            let lhs_gate_refs = env
-                .get_bit_vector(lhs)
-                .expect("add lhs should be present for literal-rhs rewrite");
-            assert_eq!(lhs_gate_refs.get_bit_count(), rhs_bits.get_bit_count());
-            return if k == 0 {
-                lhs_gate_refs
-            } else {
-                gatify_add_const_pow2_minus1(g8_builder, &lhs_gate_refs, k)
-            };
-        }
+        let lhs_gate_refs = env
+            .get_bit_vector(lhs)
+            .expect("add lhs should be present for literal-rhs rewrite");
+        return gatify_add_literal_to_dynamic_sum(
+            g8_builder,
+            &lhs_gate_refs,
+            &rhs_bits,
+            adder_mapping,
+        );
     }
 
     let a_gate_refs = env.get_bit_vector(a).expect("add lhs should be present");

--- a/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
@@ -114,14 +114,69 @@ fn gatify_add_const_pow2_minus1(
     lhs_bits: &AigBitVector,
     k: usize,
 ) -> AigBitVector {
+    assert!(k > 0 && k <= lhs_bits.get_bit_count());
+    gatify_add_const_single_ones_run(gb, lhs_bits, 0..k, gb.get_false())
+}
+
+/// Recognizes literals with one contiguous run of 1s and zeros elsewhere.
+fn get_single_ones_run(bits: &xlsynth::IrBits) -> Option<Range<usize>> {
+    let bit_count = bits.get_bit_count();
+    let mut run_start = 0usize;
+    while run_start < bit_count
+        && !bits
+            .get_bit(run_start)
+            .expect("literal bit index should be in bounds during run detection")
+    {
+        run_start += 1;
+    }
+
+    let mut run_end = run_start;
+    while run_end < bit_count
+        && bits
+            .get_bit(run_end)
+            .expect("literal bit index should be in bounds during run detection")
+    {
+        run_end += 1;
+    }
+
+    for i in run_end..bit_count {
+        if bits
+            .get_bit(i)
+            .expect("literal bit index should be in bounds during run detection")
+        {
+            return None;
+        }
+    }
+
+    Some(run_start..run_end)
+}
+
+/// Lowers `lhs_bits + literal_run + carry_in` where `literal_run` has one
+/// contiguous run of 1s and zeros elsewhere.
+fn gatify_add_const_single_ones_run(
+    gb: &mut GateBuilder,
+    lhs_bits: &AigBitVector,
+    ones_run: Range<usize>,
+    carry_in: AigOperand,
+) -> AigBitVector {
     let bit_count = lhs_bits.get_bit_count();
-    assert!(k > 0 && k <= bit_count);
+    assert!(ones_run.start <= ones_run.end && ones_run.end <= bit_count);
 
     let mut sum = Vec::with_capacity(bit_count);
-    // For low bits where rhs_i=1, carry recurrence is c_{i+1} = lhs_i | c_i,
-    // and sum_i = !(lhs_i ^ c_i).
-    let mut carry = gb.get_false();
-    for i in 0..k {
+    let mut carry = carry_in;
+
+    // For rhs_i=0, this is an increment-by-carry chain:
+    // sum_i = lhs_i ^ carry and c_{i+1} = lhs_i & carry.
+    for i in 0..ones_run.start {
+        let lhs_i = *lhs_bits.get_lsb(i);
+        let sum_i = gb.add_xor_binary(lhs_i, carry);
+        sum.push(sum_i);
+        carry = gb.add_and_binary(lhs_i, carry);
+    }
+
+    // For rhs_i=1, carry recurrence is c_{i+1} = lhs_i | carry,
+    // and sum_i = !(lhs_i ^ carry).
+    for i in ones_run {
         let lhs_i = *lhs_bits.get_lsb(i);
         let lhs_xor_carry = gb.add_xor_binary(lhs_i, carry);
         let sum_i = gb.add_not(lhs_xor_carry);
@@ -129,9 +184,7 @@ fn gatify_add_const_pow2_minus1(
         carry = gb.add_or_binary(lhs_i, carry);
     }
 
-    // For upper bits where rhs_i=0, this is an increment-by-carry chain:
-    // sum_i = lhs_i ^ carry and c_{i+1} = lhs_i & carry.
-    for i in k..bit_count {
+    for i in sum.len()..bit_count {
         let lhs_i = *lhs_bits.get_lsb(i);
         let sum_i = gb.add_xor_binary(lhs_i, carry);
         sum.push(sum_i);
@@ -311,13 +364,23 @@ fn gatify_dense_ext_nary_add_terms(
         carry_in
     };
 
-    if lowered_terms.len() == 1 && carry_in.is_none() {
-        return gatify_add_literal_to_dynamic_sum(
-            gb,
-            &lowered_terms[0],
-            &literal_sum,
-            adder_mapping,
-        );
+    if lowered_terms.len() == 1 {
+        if let Some(ones_run) = get_single_ones_run(&literal_sum) {
+            return gatify_add_const_single_ones_run(
+                gb,
+                &lowered_terms[0],
+                ones_run,
+                carry_in.unwrap_or_else(|| gb.get_false()),
+            );
+        }
+        if carry_in.is_none() {
+            return gatify_add_literal_to_dynamic_sum(
+                gb,
+                &lowered_terms[0],
+                &literal_sum,
+                adder_mapping,
+            );
+        }
     }
 
     if carry_in.is_none() && get_pow2_minus1_k(&literal_sum).is_some() {

--- a/xlsynth-g8r/src/gatify/mod.rs
+++ b/xlsynth-g8r/src/gatify/mod.rs
@@ -3,5 +3,6 @@
 //! Gateification (PIR → `GateFn`) and associated pre-lowering rewrites.
 
 pub mod ir2gate;
+pub mod ir2gate_arithmetic;
 pub mod mul_by_const_csd;
 pub mod prep_for_gatify;

--- a/xlsynth-g8r/src/gatify/prep_for_gatify.rs
+++ b/xlsynth-g8r/src/gatify/prep_for_gatify.rs
@@ -399,6 +399,7 @@ fn absorb_nary_add_term_wrappers(f: &ir::Fn, out_w: usize, term: &mut ExtNaryAdd
 /// Applies one greedy scan over each nary-add node's term list.
 fn grow_ext_nary_add_terms_once(
     f: &ir::Fn,
+    use_counts: &[usize],
     out_w: usize,
     terms: &mut Vec<ExtNaryAddTerm>,
 ) -> usize {
@@ -411,8 +412,11 @@ fn grow_ext_nary_add_terms_once(
         }
 
         let term = terms[term_index];
+        let operand_use_count = use_counts[term.operand.index];
         if let Some((lhs, rhs)) = term_payload_matches_add(f, &term) {
-            if absorb_binop_candidate_is_always_equivalent(f, &term, out_w) {
+            if operand_use_count == 1
+                && absorb_binop_candidate_is_always_equivalent(f, &term, out_w)
+            {
                 terms.splice(
                     term_index..term_index + 1,
                     [
@@ -434,7 +438,9 @@ fn grow_ext_nary_add_terms_once(
         }
 
         if let Some((lhs, rhs)) = term_payload_matches_sub(f, &term) {
-            if absorb_binop_candidate_is_always_equivalent(f, &term, out_w) {
+            if operand_use_count == 1
+                && absorb_binop_candidate_is_always_equivalent(f, &term, out_w)
+            {
                 terms.splice(
                     term_index..term_index + 1,
                     [
@@ -456,7 +462,9 @@ fn grow_ext_nary_add_terms_once(
         }
 
         if let Some(nested_terms) = term_payload_matches_nested_ext_nary_add(f, &term) {
-            if combine_nary_add_candidate_is_always_equivalent(f, &term, out_w) {
+            if operand_use_count == 1
+                && combine_nary_add_candidate_is_always_equivalent(f, &term, out_w)
+            {
                 let replacement_terms =
                     nested_terms.into_iter().map(|nested_term| ExtNaryAddTerm {
                         operand: nested_term.operand,
@@ -476,6 +484,7 @@ fn grow_ext_nary_add_terms_once(
 
 /// Greedily absorbs wrappers and nested add/sub trees into `ext_nary_add`.
 fn grow_ext_nary_adds(f: &mut ir::Fn) -> usize {
+    let use_counts = get_use_counts(f);
     let mut rewrites = 0usize;
     for node_index in 0..f.nodes.len() {
         let NodePayload::ExtNaryAdd { terms, arch } = f.nodes[node_index].payload.clone() else {
@@ -486,7 +495,7 @@ fn grow_ext_nary_adds(f: &mut ir::Fn) -> usize {
         };
 
         let mut terms = terms;
-        let node_rewrites = grow_ext_nary_add_terms_once(f, out_w, &mut terms);
+        let node_rewrites = grow_ext_nary_add_terms_once(f, &use_counts, out_w, &mut terms);
         if node_rewrites == 0 {
             continue;
         }
@@ -1568,6 +1577,41 @@ top fn f(a: bits[4] id=1, b: bits[4] id=2, c: bits[8] id=3) -> bits[8] {
                     "ret outer: bits[8] = ext_nary_add(inner, c, signed=[false, false], negated=[false, false], id=5)",
                 ),
             "expected narrow inner ext_nary_add to remain nested; got:\n{}",
+            optimized_text
+        );
+    }
+
+    #[test]
+    fn nary_add_rewrite_does_not_absorb_shared_nested_add_terms() {
+        let ir_text = r#"package sample
+
+top fn f(a: bits[8] id=1, b: bits[8] id=2, c: bits[8] id=3) -> (bits[8], bits[8]) {
+  inner: bits[8] = add(a, b, id=4)
+  outer: bits[8] = add(inner, c, id=5)
+  ret pair: (bits[8], bits[8]) = tuple(inner, outer, id=6)
+}
+"#;
+        let mut parser = Parser::new(ir_text);
+        let pkg = parser.parse_and_validate_package().unwrap();
+        let f = pkg.get_top_fn().unwrap();
+
+        let optimized = prep_for_gatify(
+            f,
+            None,
+            PrepForGatifyOptions {
+                enable_rewrite_nary_add: true,
+                ..PrepForGatifyOptions::default()
+            },
+        );
+        let optimized_text = optimized.to_string();
+        assert!(
+            optimized_text.contains(
+                "inner: bits[8] = ext_nary_add(a, b, signed=[false, false], negated=[false, false], id=4)",
+            )
+                && optimized_text.contains(
+                    "outer: bits[8] = ext_nary_add(inner, c, signed=[false, false], negated=[false, false], id=5)",
+                ),
+            "expected shared inner add to remain a nested operand instead of being duplicated; got:\n{}",
             optimized_text
         );
     }

--- a/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
+++ b/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
@@ -18,6 +18,13 @@ struct ExtNaryAddPow2Minus1Row {
     deepest_path: usize,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ExtNaryAddCorrectionCountRow {
+    correction_count: usize,
+    live_nodes: usize,
+    deepest_path: usize,
+}
+
 fn build_sub_ir_text(bit_count: usize) -> String {
     format!(
         r#"package test
@@ -61,6 +68,137 @@ top fn f(p0: bits[{bit_count}] id=1) -> bits[{bit_count}] {{
   ret r: bits[{bit_count}] = ext_nary_add(p0, lit, signed=[false, false], negated=[false, false], arch=ripple_carry, id=3)
 }}
 "#
+    )
+}
+
+fn format_bool_attrs(values: &[bool]) -> String {
+    values
+        .iter()
+        .map(|value| value.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn build_nary_add_unit_inc_ir_text(bit_count: usize, correction_count: usize) -> String {
+    let mut params = vec![format!("x: bits[{bit_count}] id=1")];
+    let mut operands = vec!["x".to_string()];
+    let mut signed = vec![false];
+    let mut negated = vec![false];
+    for i in 0..correction_count {
+        let id = 2 + i;
+        let name = format!("b{i}");
+        params.push(format!("{name}: bits[1] id={id}"));
+        operands.push(name);
+        signed.push(false);
+        negated.push(false);
+    }
+    let ret_id = 2 + correction_count;
+    format!(
+        r#"package test
+
+top fn f({params}) -> bits[{bit_count}] {{
+  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=ripple_carry, id={ret_id})
+}}
+"#,
+        params = params.join(", "),
+        operands = operands.join(", "),
+        signed = format_bool_attrs(&signed),
+        negated = format_bool_attrs(&negated),
+    )
+}
+
+fn build_nary_add_unit_dec_ir_text(bit_count: usize, correction_count: usize) -> String {
+    let mut params = vec![format!("x: bits[{bit_count}] id=1")];
+    let mut operands = vec!["x".to_string()];
+    let mut signed = vec![false];
+    let mut negated = vec![false];
+    for i in 0..correction_count {
+        let id = 2 + i;
+        let name = format!("b{i}");
+        params.push(format!("{name}: bits[1] id={id}"));
+        operands.push(name);
+        signed.push(false);
+        negated.push(true);
+    }
+    let ret_id = 2 + correction_count;
+    format!(
+        r#"package test
+
+top fn f({params}) -> bits[{bit_count}] {{
+  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=ripple_carry, id={ret_id})
+}}
+"#,
+        params = params.join(", "),
+        operands = operands.join(", "),
+        signed = format_bool_attrs(&signed),
+        negated = format_bool_attrs(&negated),
+    )
+}
+
+fn build_nary_sub_plus_signext_ir_text(bit_count: usize, correction_count: usize) -> String {
+    let mut params = vec![
+        format!("lhs: bits[{bit_count}] id=1"),
+        format!("rhs: bits[{bit_count}] id=2"),
+    ];
+    let mut operands = vec!["lhs".to_string(), "rhs".to_string()];
+    let mut signed = vec![false, false];
+    let mut negated = vec![false, true];
+    for i in 0..correction_count {
+        let id = 3 + i;
+        let name = format!("b{i}");
+        params.push(format!("{name}: bits[1] id={id}"));
+        operands.push(name);
+        signed.push(true);
+        negated.push(false);
+    }
+    let ret_id = 3 + correction_count;
+    format!(
+        r#"package test
+
+top fn f({params}) -> bits[{bit_count}] {{
+  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=ripple_carry, id={ret_id})
+}}
+"#,
+        params = params.join(", "),
+        operands = operands.join(", "),
+        signed = format_bool_attrs(&signed),
+        negated = format_bool_attrs(&negated),
+    )
+}
+
+fn build_nary_counter_inc_dec_ir_text(bit_count: usize, correction_count: usize) -> String {
+    let mut params = vec![format!("counter: bits[{bit_count}] id=1")];
+    let mut operands = vec!["counter".to_string()];
+    let mut signed = vec![false];
+    let mut negated = vec![false];
+    for i in 0..correction_count {
+        let id = 2 + i;
+        let name = format!("inc{i}");
+        params.push(format!("{name}: bits[1] id={id}"));
+        operands.push(name);
+        signed.push(false);
+        negated.push(false);
+    }
+    for i in 0..correction_count {
+        let id = 2 + correction_count + i;
+        let name = format!("dec{i}");
+        params.push(format!("{name}: bits[1] id={id}"));
+        operands.push(name);
+        signed.push(false);
+        negated.push(true);
+    }
+    let ret_id = 2 + 2 * correction_count;
+    format!(
+        r#"package test
+
+top fn f({params}) -> bits[{bit_count}] {{
+  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=ripple_carry, id={ret_id})
+}}
+"#,
+        params = params.join(", "),
+        operands = operands.join(", "),
+        signed = format_bool_attrs(&signed),
+        negated = format_bool_attrs(&negated),
     )
 }
 
@@ -122,6 +260,21 @@ fn gather_ext_nary_add_pow2_minus1_rows() -> Vec<ExtNaryAddPow2Minus1Row> {
     got
 }
 
+fn gather_ext_nary_add_correction_count_rows(
+    build_ir_text: impl Fn(usize) -> String,
+) -> Vec<ExtNaryAddCorrectionCountRow> {
+    let mut got = Vec::new();
+    for correction_count in 0..=4 {
+        let stats = get_ir_gate_stats(&build_ir_text(correction_count));
+        got.push(ExtNaryAddCorrectionCountRow {
+            correction_count,
+            live_nodes: stats.0,
+            deepest_path: stats.1,
+        });
+    }
+    got
+}
+
 #[test]
 fn test_ext_nary_add_sub_gate_stats_sweep_1_to_16() {
     let got = gather_ext_nary_add_sub_rows();
@@ -170,6 +323,91 @@ fn test_ext_nary_add_pow2_minus1_gate_stats_sweep_w8() {
         ExtNaryAddPow2Minus1Row { literal_value:  63, live_nodes: 35, deepest_path:  9 },
         ExtNaryAddPow2Minus1Row { literal_value: 127, live_nodes: 35, deepest_path:  9 },
         ExtNaryAddPow2Minus1Row { literal_value: 255, live_nodes: 35, deepest_path:  9 },
+    ];
+
+    assert_eq!(got.as_slice(), want);
+}
+
+#[test]
+fn test_ext_nary_add_unit_inc_gate_stats_sweep_w16_corrections_0_to_4() {
+    let got = gather_ext_nary_add_correction_count_rows(|correction_count| {
+        build_nary_add_unit_inc_ir_text(16, correction_count)
+    });
+
+    // This locks in the non-stacked `+bits[1]` lowering shape, where at most
+    // one unit increment becomes a carry-in and the rest join the dense add.
+    // eprintln!("{got:#?}");
+    #[rustfmt::skip]
+    let want: &[ExtNaryAddCorrectionCountRow] = &[
+        ExtNaryAddCorrectionCountRow { correction_count: 0, live_nodes:  16, deepest_path:  1 },
+        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes:  80, deepest_path: 18 },
+        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes:  88, deepest_path: 20 },
+        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 100, deepest_path: 24 },
+        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 116, deepest_path: 28 },
+    ];
+
+    assert_eq!(got.as_slice(), want);
+}
+
+#[test]
+fn test_ext_nary_add_unit_dec_gate_stats_sweep_w16_corrections_0_to_4() {
+    let got = gather_ext_nary_add_correction_count_rows(|correction_count| {
+        build_nary_add_unit_dec_ir_text(16, correction_count)
+    });
+
+    // This locks in the non-stacked `-bits[1]` lowering shape, where only one
+    // decrement can use carry-in fusion and the rest join the dense add.
+    // eprintln!("{got:#?}");
+    #[rustfmt::skip]
+    let want: &[ExtNaryAddCorrectionCountRow] = &[
+        ExtNaryAddCorrectionCountRow { correction_count: 0, live_nodes:  16, deepest_path:  1 },
+        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes:  80, deepest_path: 33 },
+        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes:  88, deepest_path: 34 },
+        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 198, deepest_path: 50 },
+        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 204, deepest_path: 50 },
+    ];
+
+    assert_eq!(got.as_slice(), want);
+}
+
+#[test]
+fn test_ext_nary_add_sub_plus_signext_gate_stats_sweep_w16_corrections_0_to_4() {
+    let got = gather_ext_nary_add_correction_count_rows(|correction_count| {
+        build_nary_sub_plus_signext_ir_text(16, correction_count)
+    });
+
+    // This captures `lhs - rhs + sign_ext(b*)`, where one sign-extended
+    // correction can fuse into the subtract carry-in and the rest fall back to
+    // dense terms.
+    // eprintln!("{got:#?}");
+    #[rustfmt::skip]
+    let want: &[ExtNaryAddCorrectionCountRow] = &[
+        ExtNaryAddCorrectionCountRow { correction_count: 0, live_nodes: 196, deepest_path: 46 },
+        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes: 204, deepest_path: 48 },
+        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes: 327, deepest_path: 50 },
+        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 384, deepest_path: 50 },
+        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 396, deepest_path: 52 },
+    ];
+
+    assert_eq!(got.as_slice(), want);
+}
+
+#[test]
+fn test_ext_nary_add_counter_inc_dec_gate_stats_sweep_w16_corrections_0_to_4() {
+    let got = gather_ext_nary_add_correction_count_rows(|correction_count| {
+        build_nary_counter_inc_dec_ir_text(16, correction_count)
+    });
+
+    // This captures `counter + inc* - dec*`, where one bit-0 correction may be
+    // carried in directly and the rest fall back to dense terms.
+    // eprintln!("{got:#?}");
+    #[rustfmt::skip]
+    let want: &[ExtNaryAddCorrectionCountRow] = &[
+        ExtNaryAddCorrectionCountRow { correction_count: 0, live_nodes:  16, deepest_path:  1 },
+        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes: 186, deepest_path: 48 },
+        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes: 310, deepest_path: 50 },
+        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 337, deepest_path: 54 },
+        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 257, deepest_path: 54 },
     ];
 
     assert_eq!(got.as_slice(), want);

--- a/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
+++ b/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
@@ -384,9 +384,9 @@ fn test_ext_nary_add_pow2_gate_stats_sweep_w8() {
     #[rustfmt::skip]
     let want: &[ExtNaryAddPow2Row] = &[
         ExtNaryAddPow2Row { literal_value:   1, live_nodes: 37, deepest_path: 7 },
-        ExtNaryAddPow2Row { literal_value:   2, live_nodes: 33, deepest_path: 7 },
+        ExtNaryAddPow2Row { literal_value:   2, live_nodes: 33, deepest_path: 6 },
         ExtNaryAddPow2Row { literal_value:   4, live_nodes: 28, deepest_path: 6 },
-        ExtNaryAddPow2Row { literal_value:   8, live_nodes: 24, deepest_path: 6 },
+        ExtNaryAddPow2Row { literal_value:   8, live_nodes: 24, deepest_path: 5 },
         ExtNaryAddPow2Row { literal_value:  16, live_nodes: 19, deepest_path: 5 },
         ExtNaryAddPow2Row { literal_value:  32, live_nodes: 15, deepest_path: 4 },
         ExtNaryAddPow2Row { literal_value:  64, live_nodes: 11, deepest_path: 3 },

--- a/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
+++ b/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use xlsynth_g8r::aig::get_summary_stats::get_summary_stats;
+use xlsynth_g8r::ir2gate_utils::AdderMapping;
+use xlsynth_g8r::ir2gates;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ExtNaryAddSubRow {
+    bit_count: usize,
+    live_nodes: usize,
+    deepest_path: usize,
+}
+
+fn build_sub_ir_text(bit_count: usize) -> String {
+    format!(
+        r#"package test
+
+top fn f(lhs: bits[{bit_count}] id=1, rhs: bits[{bit_count}] id=2) -> bits[{bit_count}] {{
+  ret sub.3: bits[{bit_count}] = sub(lhs, rhs, id=3)
+}}
+"#
+    )
+}
+
+fn build_nary_sub_ir_text(bit_count: usize) -> String {
+    format!(
+        r#"package test
+
+top fn f(lhs: bits[{bit_count}] id=1, rhs: bits[{bit_count}] id=2) -> bits[{bit_count}] {{
+  ret ext_nary_add.3: bits[{bit_count}] = ext_nary_add(lhs, rhs, signed=[false, false], negated=[false, true], arch=ripple_carry, id=3)
+}}
+"#
+    )
+}
+
+fn get_ir_gate_stats(ir_text: &str) -> (usize, usize) {
+    let out = ir2gates::ir2gates_from_ir_text(
+        ir_text,
+        None,
+        ir2gates::Ir2GatesOptions {
+            fold: true,
+            hash: true,
+            check_equivalence: false,
+            enable_rewrite_carry_out: false,
+            enable_rewrite_prio_encode: false,
+            enable_rewrite_nary_add: false,
+            adder_mapping: AdderMapping::RippleCarry,
+            mul_adder_mapping: None,
+            aug_opt: Default::default(),
+        },
+    )
+    .expect("ir2gates");
+    let stats = get_summary_stats(&out.gatify_output.gate_fn);
+    (stats.live_nodes, stats.deepest_path)
+}
+
+fn gather_ext_nary_add_sub_rows() -> Vec<ExtNaryAddSubRow> {
+    let mut got = Vec::new();
+    for bit_count in 1..=16 {
+        let sub_stats = get_ir_gate_stats(&build_sub_ir_text(bit_count));
+        let nary_sub_stats = get_ir_gate_stats(&build_nary_sub_ir_text(bit_count));
+        assert_eq!(
+            sub_stats, nary_sub_stats,
+            "expected explicit ext_nary_add(lhs, -rhs) to match dedicated sub lowering for {bit_count}-bit operands"
+        );
+        got.push(ExtNaryAddSubRow {
+            bit_count,
+            live_nodes: sub_stats.0,
+            deepest_path: sub_stats.1,
+        });
+    }
+    got
+}
+
+#[test]
+fn test_ext_nary_add_sub_gate_stats_sweep_1_to_16() {
+    let got = gather_ext_nary_add_sub_rows();
+
+    // This is a "microbenchmark sweep" style test: lock in the expected gate
+    // count + depth for `sub` / `ext_nary_add(lhs, -rhs)`, so we can notice
+    // regressions and improvements.
+    // eprintln!("{got:#?}");
+    #[rustfmt::skip]
+    let want: &[ExtNaryAddSubRow] = &[
+        ExtNaryAddSubRow { bit_count: 1, live_nodes: 5, deepest_path: 3 },
+        ExtNaryAddSubRow { bit_count: 2, live_nodes: 14, deepest_path: 5 },
+        ExtNaryAddSubRow { bit_count: 3, live_nodes: 27, deepest_path: 7 },
+        ExtNaryAddSubRow { bit_count: 4, live_nodes: 40, deepest_path: 10 },
+        ExtNaryAddSubRow { bit_count: 5, live_nodes: 53, deepest_path: 13 },
+        ExtNaryAddSubRow { bit_count: 6, live_nodes: 66, deepest_path: 16 },
+        ExtNaryAddSubRow { bit_count: 7, live_nodes: 79, deepest_path: 19 },
+        ExtNaryAddSubRow { bit_count: 8, live_nodes: 92, deepest_path: 22 },
+        ExtNaryAddSubRow { bit_count: 9, live_nodes: 105, deepest_path: 25 },
+        ExtNaryAddSubRow { bit_count: 10, live_nodes: 118, deepest_path: 28 },
+        ExtNaryAddSubRow { bit_count: 11, live_nodes: 131, deepest_path: 31 },
+        ExtNaryAddSubRow { bit_count: 12, live_nodes: 144, deepest_path: 34 },
+        ExtNaryAddSubRow { bit_count: 13, live_nodes: 157, deepest_path: 37 },
+        ExtNaryAddSubRow { bit_count: 14, live_nodes: 170, deepest_path: 40 },
+        ExtNaryAddSubRow { bit_count: 15, live_nodes: 183, deepest_path: 43 },
+        ExtNaryAddSubRow { bit_count: 16, live_nodes: 196, deepest_path: 46 },
+    ];
+
+    assert_eq!(got.as_slice(), want);
+}

--- a/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
+++ b/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
@@ -11,6 +11,13 @@ struct ExtNaryAddSubRow {
     deepest_path: usize,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ExtNaryAddPow2Minus1Row {
+    literal_value: u64,
+    live_nodes: usize,
+    deepest_path: usize,
+}
+
 fn build_sub_ir_text(bit_count: usize) -> String {
     format!(
         r#"package test
@@ -28,6 +35,30 @@ fn build_nary_sub_ir_text(bit_count: usize) -> String {
 
 top fn f(lhs: bits[{bit_count}] id=1, rhs: bits[{bit_count}] id=2) -> bits[{bit_count}] {{
   ret ext_nary_add.3: bits[{bit_count}] = ext_nary_add(lhs, rhs, signed=[false, false], negated=[false, true], arch=ripple_carry, id=3)
+}}
+"#
+    )
+}
+
+fn build_add_const_ir_text(bit_count: usize, literal_value: u64) -> String {
+    format!(
+        r#"package test
+
+top fn f(p0: bits[{bit_count}] id=1) -> bits[{bit_count}] {{
+  lit: bits[{bit_count}] = literal(value={literal_value}, id=2)
+  ret r: bits[{bit_count}] = add(p0, lit, id=3)
+}}
+"#
+    )
+}
+
+fn build_nary_add_const_ir_text(bit_count: usize, literal_value: u64) -> String {
+    format!(
+        r#"package test
+
+top fn f(p0: bits[{bit_count}] id=1) -> bits[{bit_count}] {{
+  lit: bits[{bit_count}] = literal(value={literal_value}, id=2)
+  ret r: bits[{bit_count}] = ext_nary_add(p0, lit, signed=[false, false], negated=[false, false], arch=ripple_carry, id=3)
 }}
 "#
     )
@@ -72,6 +103,25 @@ fn gather_ext_nary_add_sub_rows() -> Vec<ExtNaryAddSubRow> {
     got
 }
 
+fn gather_ext_nary_add_pow2_minus1_rows() -> Vec<ExtNaryAddPow2Minus1Row> {
+    let mut got = Vec::new();
+    for k in 1..=8 {
+        let literal_value = (1u64 << k) - 1;
+        let add_stats = get_ir_gate_stats(&build_add_const_ir_text(8, literal_value));
+        let nary_add_stats = get_ir_gate_stats(&build_nary_add_const_ir_text(8, literal_value));
+        assert_eq!(
+            add_stats, nary_add_stats,
+            "expected explicit ext_nary_add(p0, {literal_value}) to match dedicated add lowering"
+        );
+        got.push(ExtNaryAddPow2Minus1Row {
+            literal_value,
+            live_nodes: add_stats.0,
+            deepest_path: add_stats.1,
+        });
+    }
+    got
+}
+
 #[test]
 fn test_ext_nary_add_sub_gate_stats_sweep_1_to_16() {
     let got = gather_ext_nary_add_sub_rows();
@@ -98,6 +148,28 @@ fn test_ext_nary_add_sub_gate_stats_sweep_1_to_16() {
         ExtNaryAddSubRow { bit_count: 14, live_nodes: 170, deepest_path: 40 },
         ExtNaryAddSubRow { bit_count: 15, live_nodes: 183, deepest_path: 43 },
         ExtNaryAddSubRow { bit_count: 16, live_nodes: 196, deepest_path: 46 },
+    ];
+
+    assert_eq!(got.as_slice(), want);
+}
+
+#[test]
+fn test_ext_nary_add_pow2_minus1_gate_stats_sweep_w8() {
+    let got = gather_ext_nary_add_pow2_minus1_rows();
+
+    // This locks in the shared `add(p0, 2^k-1)` / `ext_nary_add(p0, 2^k-1)`
+    // gate stats for width 8.
+    // eprintln!("{got:#?}");
+    #[rustfmt::skip]
+    let want: &[ExtNaryAddPow2Minus1Row] = &[
+        ExtNaryAddPow2Minus1Row { literal_value:   1, live_nodes: 35, deepest_path:  9 },
+        ExtNaryAddPow2Minus1Row { literal_value:   3, live_nodes: 35, deepest_path:  9 },
+        ExtNaryAddPow2Minus1Row { literal_value:   7, live_nodes: 35, deepest_path:  9 },
+        ExtNaryAddPow2Minus1Row { literal_value:  15, live_nodes: 35, deepest_path:  9 },
+        ExtNaryAddPow2Minus1Row { literal_value:  31, live_nodes: 35, deepest_path:  9 },
+        ExtNaryAddPow2Minus1Row { literal_value:  63, live_nodes: 35, deepest_path:  9 },
+        ExtNaryAddPow2Minus1Row { literal_value: 127, live_nodes: 35, deepest_path:  9 },
+        ExtNaryAddPow2Minus1Row { literal_value: 255, live_nodes: 35, deepest_path:  9 },
     ];
 
     assert_eq!(got.as_slice(), want);

--- a/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
+++ b/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
@@ -19,6 +19,13 @@ struct ExtNaryAddPow2Minus1Row {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+struct ExtNaryAddPow2Row {
+    literal_value: u64,
+    live_nodes: usize,
+    deepest_path: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct ExtNaryAddSingleOnesRunRow {
     literal_value: u64,
     live_nodes: usize,
@@ -48,7 +55,7 @@ fn build_nary_sub_ir_text(bit_count: usize) -> String {
         r#"package test
 
 top fn f(lhs: bits[{bit_count}] id=1, rhs: bits[{bit_count}] id=2) -> bits[{bit_count}] {{
-  ret ext_nary_add.3: bits[{bit_count}] = ext_nary_add(lhs, rhs, signed=[false, false], negated=[false, true], arch=ripple_carry, id=3)
+  ret ext_nary_add.3: bits[{bit_count}] = ext_nary_add(lhs, rhs, signed=[false, false], negated=[false, true], arch=brent_kung, id=3)
 }}
 "#
     )
@@ -72,7 +79,7 @@ fn build_nary_add_const_ir_text(bit_count: usize, literal_value: u64) -> String 
 
 top fn f(p0: bits[{bit_count}] id=1) -> bits[{bit_count}] {{
   lit: bits[{bit_count}] = literal(value={literal_value}, id=2)
-  ret r: bits[{bit_count}] = ext_nary_add(p0, lit, signed=[false, false], negated=[false, false], arch=ripple_carry, id=3)
+  ret r: bits[{bit_count}] = ext_nary_add(p0, lit, signed=[false, false], negated=[false, false], arch=brent_kung, id=3)
 }}
 "#
     )
@@ -104,7 +111,7 @@ fn build_nary_add_unit_inc_ir_text(bit_count: usize, correction_count: usize) ->
         r#"package test
 
 top fn f({params}) -> bits[{bit_count}] {{
-  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=ripple_carry, id={ret_id})
+  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=brent_kung, id={ret_id})
 }}
 "#,
         params = params.join(", "),
@@ -132,7 +139,7 @@ fn build_nary_add_unit_dec_ir_text(bit_count: usize, correction_count: usize) ->
         r#"package test
 
 top fn f({params}) -> bits[{bit_count}] {{
-  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=ripple_carry, id={ret_id})
+  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=brent_kung, id={ret_id})
 }}
 "#,
         params = params.join(", "),
@@ -163,7 +170,7 @@ fn build_nary_sub_plus_signext_ir_text(bit_count: usize, correction_count: usize
         r#"package test
 
 top fn f({params}) -> bits[{bit_count}] {{
-  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=ripple_carry, id={ret_id})
+  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=brent_kung, id={ret_id})
 }}
 "#,
         params = params.join(", "),
@@ -199,7 +206,7 @@ fn build_nary_counter_inc_dec_ir_text(bit_count: usize, correction_count: usize)
         r#"package test
 
 top fn f({params}) -> bits[{bit_count}] {{
-  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=ripple_carry, id={ret_id})
+  ret ext_nary_add.{ret_id}: bits[{bit_count}] = ext_nary_add({operands}, signed=[{signed}], negated=[{negated}], arch=brent_kung, id={ret_id})
 }}
 "#,
         params = params.join(", "),
@@ -220,7 +227,7 @@ fn get_ir_gate_stats(ir_text: &str) -> (usize, usize) {
             enable_rewrite_carry_out: false,
             enable_rewrite_prio_encode: false,
             enable_rewrite_nary_add: false,
-            adder_mapping: AdderMapping::RippleCarry,
+            adder_mapping: AdderMapping::BrentKung,
             mul_adder_mapping: None,
             aug_opt: Default::default(),
         },
@@ -259,6 +266,25 @@ fn gather_ext_nary_add_pow2_minus1_rows() -> Vec<ExtNaryAddPow2Minus1Row> {
             "expected explicit ext_nary_add(p0, {literal_value}) to match dedicated add lowering"
         );
         got.push(ExtNaryAddPow2Minus1Row {
+            literal_value,
+            live_nodes: add_stats.0,
+            deepest_path: add_stats.1,
+        });
+    }
+    got
+}
+
+fn gather_ext_nary_add_pow2_rows() -> Vec<ExtNaryAddPow2Row> {
+    let mut got = Vec::new();
+    for k in 0..8 {
+        let literal_value = 1u64 << k;
+        let add_stats = get_ir_gate_stats(&build_add_const_ir_text(8, literal_value));
+        let nary_add_stats = get_ir_gate_stats(&build_nary_add_const_ir_text(8, literal_value));
+        assert_eq!(
+            add_stats, nary_add_stats,
+            "expected explicit ext_nary_add(p0, {literal_value}) to match dedicated add lowering"
+        );
+        got.push(ExtNaryAddPow2Row {
             literal_value,
             live_nodes: add_stats.0,
             deepest_path: add_stats.1,
@@ -306,21 +332,21 @@ fn test_ext_nary_add_sub_gate_stats_sweep_1_to_16() {
     #[rustfmt::skip]
     let want: &[ExtNaryAddSubRow] = &[
         ExtNaryAddSubRow { bit_count: 1, live_nodes: 5, deepest_path: 3 },
-        ExtNaryAddSubRow { bit_count: 2, live_nodes: 14, deepest_path: 5 },
-        ExtNaryAddSubRow { bit_count: 3, live_nodes: 27, deepest_path: 7 },
-        ExtNaryAddSubRow { bit_count: 4, live_nodes: 40, deepest_path: 10 },
-        ExtNaryAddSubRow { bit_count: 5, live_nodes: 53, deepest_path: 13 },
-        ExtNaryAddSubRow { bit_count: 6, live_nodes: 66, deepest_path: 16 },
-        ExtNaryAddSubRow { bit_count: 7, live_nodes: 79, deepest_path: 19 },
-        ExtNaryAddSubRow { bit_count: 8, live_nodes: 92, deepest_path: 22 },
-        ExtNaryAddSubRow { bit_count: 9, live_nodes: 105, deepest_path: 25 },
-        ExtNaryAddSubRow { bit_count: 10, live_nodes: 118, deepest_path: 28 },
-        ExtNaryAddSubRow { bit_count: 11, live_nodes: 131, deepest_path: 31 },
-        ExtNaryAddSubRow { bit_count: 12, live_nodes: 144, deepest_path: 34 },
-        ExtNaryAddSubRow { bit_count: 13, live_nodes: 157, deepest_path: 37 },
-        ExtNaryAddSubRow { bit_count: 14, live_nodes: 170, deepest_path: 40 },
-        ExtNaryAddSubRow { bit_count: 15, live_nodes: 183, deepest_path: 43 },
-        ExtNaryAddSubRow { bit_count: 16, live_nodes: 196, deepest_path: 46 },
+        ExtNaryAddSubRow { bit_count: 2, live_nodes: 15, deepest_path: 6 },
+        ExtNaryAddSubRow { bit_count: 3, live_nodes: 28, deepest_path: 8 },
+        ExtNaryAddSubRow { bit_count: 4, live_nodes: 41, deepest_path: 10 },
+        ExtNaryAddSubRow { bit_count: 5, live_nodes: 57, deepest_path: 10 },
+        ExtNaryAddSubRow { bit_count: 6, live_nodes: 70, deepest_path: 12 },
+        ExtNaryAddSubRow { bit_count: 7, live_nodes: 86, deepest_path: 12 },
+        ExtNaryAddSubRow { bit_count: 8, live_nodes: 99, deepest_path: 14 },
+        ExtNaryAddSubRow { bit_count: 9, live_nodes: 118, deepest_path: 14 },
+        ExtNaryAddSubRow { bit_count: 10, live_nodes: 131, deepest_path: 14 },
+        ExtNaryAddSubRow { bit_count: 11, live_nodes: 147, deepest_path: 14 },
+        ExtNaryAddSubRow { bit_count: 12, live_nodes: 160, deepest_path: 16 },
+        ExtNaryAddSubRow { bit_count: 13, live_nodes: 179, deepest_path: 16 },
+        ExtNaryAddSubRow { bit_count: 14, live_nodes: 192, deepest_path: 16 },
+        ExtNaryAddSubRow { bit_count: 15, live_nodes: 208, deepest_path: 16 },
+        ExtNaryAddSubRow { bit_count: 16, live_nodes: 221, deepest_path: 18 },
     ];
 
     assert_eq!(got.as_slice(), want);
@@ -343,6 +369,28 @@ fn test_ext_nary_add_pow2_minus1_gate_stats_sweep_w8() {
         ExtNaryAddPow2Minus1Row { literal_value:  63, live_nodes: 35, deepest_path:  9 },
         ExtNaryAddPow2Minus1Row { literal_value: 127, live_nodes: 35, deepest_path:  9 },
         ExtNaryAddPow2Minus1Row { literal_value: 255, live_nodes: 35, deepest_path:  9 },
+    ];
+
+    assert_eq!(got.as_slice(), want);
+}
+
+#[test]
+fn test_ext_nary_add_pow2_gate_stats_sweep_w8() {
+    let got = gather_ext_nary_add_pow2_rows();
+
+    // This locks in the shared `add(p0, 2^k)` / `ext_nary_add(p0, 2^k)`
+    // gate stats for width 8.
+    // eprintln!("{got:#?}");
+    #[rustfmt::skip]
+    let want: &[ExtNaryAddPow2Row] = &[
+        ExtNaryAddPow2Row { literal_value:   1, live_nodes: 35, deepest_path: 9 },
+        ExtNaryAddPow2Row { literal_value:   2, live_nodes: 33, deepest_path: 7 },
+        ExtNaryAddPow2Row { literal_value:   4, live_nodes: 28, deepest_path: 6 },
+        ExtNaryAddPow2Row { literal_value:   8, live_nodes: 24, deepest_path: 6 },
+        ExtNaryAddPow2Row { literal_value:  16, live_nodes: 19, deepest_path: 5 },
+        ExtNaryAddPow2Row { literal_value:  32, live_nodes: 15, deepest_path: 4 },
+        ExtNaryAddPow2Row { literal_value:  64, live_nodes: 11, deepest_path: 3 },
+        ExtNaryAddPow2Row { literal_value: 128, live_nodes:  8, deepest_path: 1 },
     ];
 
     assert_eq!(got.as_slice(), want);
@@ -379,10 +427,10 @@ fn test_ext_nary_add_unit_inc_gate_stats_sweep_w16_corrections_0_to_4() {
     #[rustfmt::skip]
     let want: &[ExtNaryAddCorrectionCountRow] = &[
         ExtNaryAddCorrectionCountRow { correction_count: 0, live_nodes:  16, deepest_path:  1 },
-        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes:  80, deepest_path: 18 },
-        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes:  88, deepest_path: 20 },
-        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 100, deepest_path: 24 },
-        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 116, deepest_path: 28 },
+        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes: 102, deepest_path: 10 },
+        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes: 136, deepest_path: 13 },
+        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 146, deepest_path: 16 },
+        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 162, deepest_path: 18 },
     ];
 
     assert_eq!(got.as_slice(), want);
@@ -401,9 +449,9 @@ fn test_ext_nary_add_unit_dec_gate_stats_sweep_w16_corrections_0_to_4() {
     let want: &[ExtNaryAddCorrectionCountRow] = &[
         ExtNaryAddCorrectionCountRow { correction_count: 0, live_nodes:  16, deepest_path:  1 },
         ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes:  80, deepest_path: 18 },
-        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes:  88, deepest_path: 34 },
-        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 198, deepest_path: 50 },
-        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 204, deepest_path: 50 },
+        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes: 166, deepest_path: 17 },
+        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 234, deepest_path: 21 },
+        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 238, deepest_path: 21 },
     ];
 
     assert_eq!(got.as_slice(), want);
@@ -421,11 +469,11 @@ fn test_ext_nary_add_sub_plus_signext_gate_stats_sweep_w16_corrections_0_to_4() 
     // eprintln!("{got:#?}");
     #[rustfmt::skip]
     let want: &[ExtNaryAddCorrectionCountRow] = &[
-        ExtNaryAddCorrectionCountRow { correction_count: 0, live_nodes: 196, deepest_path: 46 },
-        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes: 204, deepest_path: 48 },
-        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes: 327, deepest_path: 50 },
-        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 384, deepest_path: 50 },
-        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 396, deepest_path: 52 },
+        ExtNaryAddCorrectionCountRow { correction_count: 0, live_nodes: 221, deepest_path: 18 },
+        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes: 240, deepest_path: 18 },
+        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes: 363, deepest_path: 21 },
+        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 418, deepest_path: 23 },
+        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 430, deepest_path: 23 },
     ];
 
     assert_eq!(got.as_slice(), want);
@@ -443,10 +491,10 @@ fn test_ext_nary_add_counter_inc_dec_gate_stats_sweep_w16_corrections_0_to_4() {
     #[rustfmt::skip]
     let want: &[ExtNaryAddCorrectionCountRow] = &[
         ExtNaryAddCorrectionCountRow { correction_count: 0, live_nodes:  16, deepest_path:  1 },
-        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes: 186, deepest_path: 48 },
-        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes: 310, deepest_path: 50 },
-        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 337, deepest_path: 54 },
-        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 257, deepest_path: 54 },
+        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes: 222, deepest_path: 17 },
+        ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes: 344, deepest_path: 21 },
+        ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 373, deepest_path: 27 },
+        ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 291, deepest_path: 27 },
     ];
 
     assert_eq!(got.as_slice(), want);

--- a/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
+++ b/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
@@ -19,6 +19,13 @@ struct ExtNaryAddPow2Minus1Row {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+struct ExtNaryAddSingleOnesRunRow {
+    literal_value: u64,
+    live_nodes: usize,
+    deepest_path: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct ExtNaryAddCorrectionCountRow {
     correction_count: usize,
     live_nodes: usize,
@@ -260,6 +267,19 @@ fn gather_ext_nary_add_pow2_minus1_rows() -> Vec<ExtNaryAddPow2Minus1Row> {
     got
 }
 
+fn gather_ext_nary_add_single_ones_run_rows() -> Vec<ExtNaryAddSingleOnesRunRow> {
+    let mut got = Vec::new();
+    for literal_value in [0u64, 0b0001_0000, 0b0001_1100, 0b0011_1100, 0b1111_0000] {
+        let nary_add_stats = get_ir_gate_stats(&build_nary_add_const_ir_text(8, literal_value));
+        got.push(ExtNaryAddSingleOnesRunRow {
+            literal_value,
+            live_nodes: nary_add_stats.0,
+            deepest_path: nary_add_stats.1,
+        });
+    }
+    got
+}
+
 fn gather_ext_nary_add_correction_count_rows(
     build_ir_text: impl Fn(usize) -> String,
 ) -> Vec<ExtNaryAddCorrectionCountRow> {
@@ -329,6 +349,25 @@ fn test_ext_nary_add_pow2_minus1_gate_stats_sweep_w8() {
 }
 
 #[test]
+fn test_ext_nary_add_single_ones_run_gate_stats_w8() {
+    let got = gather_ext_nary_add_single_ones_run_rows();
+
+    // This locks in the one-dense-term shifted-ones-run finalizer for explicit
+    // `ext_nary_add(p0, literal)` with no dynamic carry-in.
+    // eprintln!("{got:#?}");
+    #[rustfmt::skip]
+    let want: &[ExtNaryAddSingleOnesRunRow] = &[
+        ExtNaryAddSingleOnesRunRow { literal_value:   0, live_nodes:  8, deepest_path:  1 },
+        ExtNaryAddSingleOnesRunRow { literal_value:  16, live_nodes: 19, deepest_path:  5 },
+        ExtNaryAddSingleOnesRunRow { literal_value:  28, live_nodes: 27, deepest_path:  7 },
+        ExtNaryAddSingleOnesRunRow { literal_value:  60, live_nodes: 27, deepest_path:  7 },
+        ExtNaryAddSingleOnesRunRow { literal_value: 240, live_nodes: 19, deepest_path:  5 },
+    ];
+
+    assert_eq!(got.as_slice(), want);
+}
+
+#[test]
 fn test_ext_nary_add_unit_inc_gate_stats_sweep_w16_corrections_0_to_4() {
     let got = gather_ext_nary_add_correction_count_rows(|correction_count| {
         build_nary_add_unit_inc_ir_text(16, correction_count)
@@ -361,7 +400,7 @@ fn test_ext_nary_add_unit_dec_gate_stats_sweep_w16_corrections_0_to_4() {
     #[rustfmt::skip]
     let want: &[ExtNaryAddCorrectionCountRow] = &[
         ExtNaryAddCorrectionCountRow { correction_count: 0, live_nodes:  16, deepest_path:  1 },
-        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes:  80, deepest_path: 33 },
+        ExtNaryAddCorrectionCountRow { correction_count: 1, live_nodes:  80, deepest_path: 18 },
         ExtNaryAddCorrectionCountRow { correction_count: 2, live_nodes:  88, deepest_path: 34 },
         ExtNaryAddCorrectionCountRow { correction_count: 3, live_nodes: 198, deepest_path: 50 },
         ExtNaryAddCorrectionCountRow { correction_count: 4, live_nodes: 204, deepest_path: 50 },

--- a/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
+++ b/xlsynth-g8r/tests/ext_nary_add_gate_stats_sweep_test.rs
@@ -361,7 +361,7 @@ fn test_ext_nary_add_pow2_minus1_gate_stats_sweep_w8() {
     // eprintln!("{got:#?}");
     #[rustfmt::skip]
     let want: &[ExtNaryAddPow2Minus1Row] = &[
-        ExtNaryAddPow2Minus1Row { literal_value:   1, live_nodes: 35, deepest_path:  9 },
+        ExtNaryAddPow2Minus1Row { literal_value:   1, live_nodes: 37, deepest_path:  7 },
         ExtNaryAddPow2Minus1Row { literal_value:   3, live_nodes: 35, deepest_path:  9 },
         ExtNaryAddPow2Minus1Row { literal_value:   7, live_nodes: 35, deepest_path:  9 },
         ExtNaryAddPow2Minus1Row { literal_value:  15, live_nodes: 35, deepest_path:  9 },
@@ -383,7 +383,7 @@ fn test_ext_nary_add_pow2_gate_stats_sweep_w8() {
     // eprintln!("{got:#?}");
     #[rustfmt::skip]
     let want: &[ExtNaryAddPow2Row] = &[
-        ExtNaryAddPow2Row { literal_value:   1, live_nodes: 35, deepest_path: 9 },
+        ExtNaryAddPow2Row { literal_value:   1, live_nodes: 37, deepest_path: 7 },
         ExtNaryAddPow2Row { literal_value:   2, live_nodes: 33, deepest_path: 7 },
         ExtNaryAddPow2Row { literal_value:   4, live_nodes: 28, deepest_path: 6 },
         ExtNaryAddPow2Row { literal_value:   8, live_nodes: 24, deepest_path: 6 },

--- a/xlsynth-g8r/tests/ext_nary_add_ir2gates_test.rs
+++ b/xlsynth-g8r/tests/ext_nary_add_ir2gates_test.rs
@@ -463,7 +463,7 @@ fn constant_operand_reduces_gate_count() {
 }
 
 #[test]
-fn negated_operand_increases_gate_count() {
+fn one_negated_operand_uses_same_gate_count_as_non_negated_terms() {
     let non_negated = build_single_stage_ext_nary_add_ir_text(
         16,
         &[
@@ -516,11 +516,10 @@ fn negated_operand_increases_gate_count() {
     let (negated_gates, _) =
         get_ir_gate_stats(&one_negated, /* fold= */ false, /* hash= */ false);
 
-    assert!(
-        negated_gates > non_negated_gates,
-        "expected a negated operand to increase And2 gate count; non_negated={} negated={}",
-        non_negated_gates,
-        negated_gates
+    assert_eq!(
+        non_negated_gates, negated_gates,
+        "expected a single negated operand's +1 contribution to be lowered via carry_in, not an extra CSA operand; non_negated={} negated={}",
+        non_negated_gates, negated_gates
     );
 }
 


### PR DESCRIPTION
Refactors gatify arithmetic lowering and adds targeted ext_nary_add specializations for common sparse literal/carry shapes. The goal is to improve QoR for simple constant-add forms while preserving the existing dense fallback path for general n-ary adds.

  - Move add/sub/ext_nary_add gatification into ir2gate_arithmetic.rs.
  - Add ext_nary_add operand classification by term width, shift, active range, and fill kind.
  - Fuse simple unit corrections into the final carry-in when possible, with dense fallback otherwise.
  - Specialize literal additions for 2^k - 1, single runs of ones, x + 1, and x + 2^k.
  - Add gate-stats sweep coverage for n-ary subtraction, pow2/pow2-minus-one literals, single-runs-of-ones literals, and correction-count cases.
 
Results on some designs from DSLX stdlib plus a dual path adder I had codex build. Summary: small gate count increase, significant depth reduction:

 | design | live_nodes baselib/change | deepest_path baselib/change |
  | --- | --- | --- |
  | bf16_add | 1090 / +9 (+0.83%) | 85 / -2 (-2.35%) |
  | bf16_add_dual_path | 1259 / +9 (+0.71%) | 75 / +0 (+0.00%) |
  | bf16_add_with_clz | 1081 / +15 (+1.39%) | 84 / -1 (-1.19%) |
  | bf16_fma | 3628 / +22 (+0.61%) | 164 / -16 (-9.76%) |
  | bf16_mul | 1148 / +18 (+1.57%) | 73 / -7 (-9.59%) |
  | fp32_add | 2523 / +16 (+0.63%) | 100 / -1 (-1.00%) |
  | fp32_add_dual_path | 2889 / +21 (+0.73%) | 91 / -3 (-3.30%) |
  | fp32_add_with_clz | 2503 / +25 (+1.00%) | 101 / +0 (+0.00%) |