### PR TITLE
[g8r] ripple carry emission had room to improve (surprisingly)

### DIFF
--- a/xlsynth-g8r/src/ir2gate_utils.rs
+++ b/xlsynth-g8r/src/ir2gate_utils.rs
@@ -118,28 +118,23 @@ pub fn gatify_add_ripple_carry(
     assert_eq!(lhs.get_bit_count(), rhs.get_bit_count());
     let mut gates = Vec::new();
     for i in 0..lhs.get_bit_count() {
-        // The truth table for a adder bit is:
-        //
-        //  a b c | sum cout
-        // --------
-        //  0 0 0 | 0   0
-        //  0 0 1 | 1   0
-        //  0 1 0 | 1   0
-        //  0 1 1 | 0   1
-        //  1 0 0 | 1   0
-        //  1 0 1 | 0   1
-        //  1 1 0 | 0   1
-        //  1 1 1 | 1   1
-        //
-        // sum = a ^ b ^ c_in
-        // cout = (a & b) | (b & c_in) | (a & c_in)
         let lhs_i = lhs.get_lsb(i);
         let rhs_i = rhs.get_lsb(i);
-        let sum = g8_builder.add_xor_nary(&[*lhs_i, *rhs_i, c_in], ReductionKind::Linear);
-        let c_out_0 = g8_builder.add_and_binary(*lhs_i, *rhs_i);
-        let c_out_1 = g8_builder.add_and_binary(*rhs_i, c_in);
-        let c_out_2 = g8_builder.add_and_binary(*lhs_i, c_in);
-        let cout = g8_builder.add_or_nary(&[c_out_0, c_out_1, c_out_2], ReductionKind::Linear);
+        let propagate = g8_builder.add_xor_binary(*lhs_i, *rhs_i);
+        let (sum, cout) = if g8_builder.options.fold && g8_builder.is_known_false(c_in) {
+            let carry = g8_builder.add_and_binary(*lhs_i, *rhs_i);
+            (propagate, carry)
+        } else if g8_builder.options.fold && g8_builder.is_known_true(c_in) {
+            let sum = g8_builder.add_not(propagate);
+            let carry = g8_builder.add_or_binary(*lhs_i, *rhs_i);
+            (sum, carry)
+        } else {
+            let generate = g8_builder.add_and_binary(*lhs_i, *rhs_i);
+            let sum = g8_builder.add_xor_binary(propagate, c_in);
+            let propagated_carry = g8_builder.add_and_binary(propagate, c_in);
+            let carry = g8_builder.add_or_binary(generate, propagated_carry);
+            (sum, carry)
+        };
         if let Some(tag_prefix) = tag_prefix {
             g8_builder.add_tag(
                 cout.node,

--- a/xlsynth-g8r/tests/add_const_pow2m1_gate_stats_sweep_test.rs
+++ b/xlsynth-g8r/tests/add_const_pow2m1_gate_stats_sweep_test.rs
@@ -111,12 +111,12 @@ fn test_add_const_pow2m1_gate_stats_sweep_1_to_8() {
     let want: &[AddPow2Minus1Row] = &[
         AddPow2Minus1Row { bit_count: 1, live_nodes_baseline: 5, deepest_path_baseline: 3, live_nodes_pow2m1: 1, deepest_path_pow2m1: 1 },
         AddPow2Minus1Row { bit_count: 2, live_nodes_baseline: 14, deepest_path_baseline: 5, live_nodes_pow2m1: 5, deepest_path_pow2m1: 3 },
-        AddPow2Minus1Row { bit_count: 3, live_nodes_baseline: 27, deepest_path_baseline: 7, live_nodes_pow2m1: 10, deepest_path_pow2m1: 4 },
-        AddPow2Minus1Row { bit_count: 4, live_nodes_baseline: 40, deepest_path_baseline: 10, live_nodes_pow2m1: 15, deepest_path_pow2m1: 5 },
-        AddPow2Minus1Row { bit_count: 5, live_nodes_baseline: 53, deepest_path_baseline: 13, live_nodes_pow2m1: 20, deepest_path_pow2m1: 6 },
-        AddPow2Minus1Row { bit_count: 6, live_nodes_baseline: 66, deepest_path_baseline: 16, live_nodes_pow2m1: 25, deepest_path_pow2m1: 7 },
-        AddPow2Minus1Row { bit_count: 7, live_nodes_baseline: 79, deepest_path_baseline: 19, live_nodes_pow2m1: 30, deepest_path_pow2m1: 8 },
-        AddPow2Minus1Row { bit_count: 8, live_nodes_baseline: 92, deepest_path_baseline: 22, live_nodes_pow2m1: 35, deepest_path_pow2m1: 9 },
+        AddPow2Minus1Row { bit_count: 3, live_nodes_baseline: 25, deepest_path_baseline: 7, live_nodes_pow2m1: 10, deepest_path_pow2m1: 4 },
+        AddPow2Minus1Row { bit_count: 4, live_nodes_baseline: 36, deepest_path_baseline: 9, live_nodes_pow2m1: 15, deepest_path_pow2m1: 5 },
+        AddPow2Minus1Row { bit_count: 5, live_nodes_baseline: 47, deepest_path_baseline: 11, live_nodes_pow2m1: 20, deepest_path_pow2m1: 6 },
+        AddPow2Minus1Row { bit_count: 6, live_nodes_baseline: 58, deepest_path_baseline: 13, live_nodes_pow2m1: 25, deepest_path_pow2m1: 7 },
+        AddPow2Minus1Row { bit_count: 7, live_nodes_baseline: 69, deepest_path_baseline: 15, live_nodes_pow2m1: 30, deepest_path_pow2m1: 8 },
+        AddPow2Minus1Row { bit_count: 8, live_nodes_baseline: 80, deepest_path_baseline: 17, live_nodes_pow2m1: 35, deepest_path_pow2m1: 9 },
     ];
 
     assert_eq!(got.as_slice(), want);

--- a/xlsynth-g8r/tests/gate_sim_vs_ir_interp.rs
+++ b/xlsynth-g8r/tests/gate_sim_vs_ir_interp.rs
@@ -104,7 +104,7 @@ fn test_bf16_mul_g8r_stats() {
     log::info!("getting id to use count");
     let id_to_use_count: HashMap<AigRef, usize> = get_id_to_use_count(gate_fn);
     let live_node_count = id_to_use_count.len();
-    assert_within!(live_node_count as isize, 1153 as isize, 20 as isize);
+    assert_within!(live_node_count as isize, 1125 as isize, 20 as isize);
 
     log::info!("getting gate depth");
     let live_nodes: Vec<AigRef> = id_to_use_count.keys().cloned().collect();

--- a/xlsynth-g8r/tests/ir2gates_with_analysis_test.rs
+++ b/xlsynth-g8r/tests/ir2gates_with_analysis_test.rs
@@ -35,7 +35,7 @@ top fn main(a0: bits[8] id=1, a1: bits[8] id=2, a2: bits[8] id=3, a3: bits[8] id
     )
     .unwrap();
     let got = get_summary_stats(&out.gatify_output.gate_fn);
-    assert_eq!(got.live_nodes, 1292);
+    assert_eq!(got.live_nodes, 1204);
 
     // Compare against a baseline that explicitly disables range_info.
     let mut pir_parser = ir_parser::Parser::new(ir_text);
@@ -58,7 +58,7 @@ top fn main(a0: bits[8] id=1, a1: bits[8] id=2, a2: bits[8] id=3, a3: bits[8] id
     )
     .unwrap();
     let base_stats = get_summary_stats(&base.gate_fn);
-    assert_eq!(base_stats.live_nodes, 1397);
+    assert_eq!(base_stats.live_nodes, 1299);
 }
 
 #[test]

--- a/xlsynth-g8r/tests/range_specialization_tests.rs
+++ b/xlsynth-g8r/tests/range_specialization_tests.rs
@@ -74,12 +74,12 @@ top fn main(a0: bits[8] id=1, a1: bits[8] id=2, a2: bits[8] id=3, a3: bits[8] id
     let spec_stats = get_summary_stats(&spec.gate_fn);
 
     assert_eq!(
-        base_stats.live_nodes, 1397,
+        base_stats.live_nodes, 1299,
         "baseline live_nodes={}",
         base_stats.live_nodes
     );
     assert_eq!(
-        spec_stats.live_nodes, 1292,
+        spec_stats.live_nodes, 1204,
         "specialized live_nodes={}",
         spec_stats.live_nodes
     );

--- a/xlsynth-g8r/tests/ripple_carry_qor_sweep_test.rs
+++ b/xlsynth-g8r/tests/ripple_carry_qor_sweep_test.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use xlsynth_g8r::aig::get_summary_stats::{AigStats, get_aig_stats};
+use xlsynth_g8r::aig::{AigBitVector, GateFn};
+use xlsynth_g8r::check_equivalence;
+use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions, ReductionKind};
+use xlsynth_g8r::ir2gate_utils::gatify_add_ripple_carry;
+
+#[derive(Debug, PartialEq, Eq)]
+struct RippleCarryQorRow {
+    bit_count: usize,
+    old_and_nodes: usize,
+    old_depth: usize,
+    public_and_nodes: usize,
+    public_depth: usize,
+}
+
+fn gatify_add_ripple_carry_old_maj3(
+    gb: &mut GateBuilder,
+    lhs: &AigBitVector,
+    rhs: &AigBitVector,
+    mut c_in: xlsynth_g8r::aig::AigOperand,
+) -> (xlsynth_g8r::aig::AigOperand, AigBitVector) {
+    assert_eq!(lhs.get_bit_count(), rhs.get_bit_count());
+    let mut sum_bits = Vec::new();
+    for i in 0..lhs.get_bit_count() {
+        let lhs_i = lhs.get_lsb(i);
+        let rhs_i = rhs.get_lsb(i);
+        let sum = gb.add_xor_nary(&[*lhs_i, *rhs_i, c_in], ReductionKind::Linear);
+        let c_out_0 = gb.add_and_binary(*lhs_i, *rhs_i);
+        let c_out_1 = gb.add_and_binary(*rhs_i, c_in);
+        let c_out_2 = gb.add_and_binary(*lhs_i, c_in);
+        c_in = gb.add_or_nary(&[c_out_0, c_out_1, c_out_2], ReductionKind::Linear);
+        sum_bits.push(sum);
+    }
+    (c_in, AigBitVector::from_lsb_is_index_0(&sum_bits))
+}
+
+fn make_ripple_carry_old(bit_count: usize) -> GateFn {
+    let mut gb = GateBuilder::new(
+        format!("ripple_carry_old_{bit_count}b"),
+        GateBuilderOptions::opt(),
+    );
+    let lhs = gb.add_input("lhs".to_string(), bit_count);
+    let rhs = gb.add_input("rhs".to_string(), bit_count);
+    let c_in = *gb.add_input("c_in".to_string(), 1).get_lsb(0);
+    let (c_out, sum) = gatify_add_ripple_carry_old_maj3(&mut gb, &lhs, &rhs, c_in);
+    gb.add_output("c_out".to_string(), AigBitVector::from_bit(c_out));
+    gb.add_output("sum".to_string(), sum);
+    gb.build()
+}
+
+fn make_ripple_carry_public(bit_count: usize) -> GateFn {
+    let mut gb = GateBuilder::new(
+        format!("ripple_carry_public_{bit_count}b"),
+        GateBuilderOptions::opt(),
+    );
+    let lhs = gb.add_input("lhs".to_string(), bit_count);
+    let rhs = gb.add_input("rhs".to_string(), bit_count);
+    let c_in = *gb.add_input("c_in".to_string(), 1).get_lsb(0);
+    let (c_out, sum) = gatify_add_ripple_carry(&lhs, &rhs, c_in, Some("ripple_carry"), &mut gb);
+    gb.add_output("c_out".to_string(), AigBitVector::from_bit(c_out));
+    gb.add_output("sum".to_string(), sum);
+    gb.build()
+}
+
+fn stats_for_gate_fn(gate_fn: &GateFn) -> AigStats {
+    get_aig_stats(gate_fn)
+}
+
+fn gather_ripple_carry_qor_rows() -> Vec<RippleCarryQorRow> {
+    let mut got = Vec::new();
+    for bit_count in [1usize, 2, 3, 4, 5, 8, 16, 32, 64] {
+        let old = make_ripple_carry_old(bit_count);
+        let public = make_ripple_carry_public(bit_count);
+        check_equivalence::prove_same_gate_fn_via_ir(&old, &public)
+            .expect("old and public ripple-carry lowerings should be equivalent");
+        let old_stats = stats_for_gate_fn(&old);
+        let public_stats = stats_for_gate_fn(&public);
+        got.push(RippleCarryQorRow {
+            bit_count,
+            old_and_nodes: old_stats.and_nodes,
+            old_depth: old_stats.max_depth,
+            public_and_nodes: public_stats.and_nodes,
+            public_depth: public_stats.max_depth,
+        });
+    }
+    got
+}
+
+#[test]
+fn test_ripple_carry_propagate_generate_qor_and_equivalence_sweep() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let got = gather_ripple_carry_qor_rows();
+
+    for row in &got {
+        assert!(
+            row.public_and_nodes < row.old_and_nodes,
+            "expected propagate/generate ripple carry to reduce AND nodes: {:?}",
+            row
+        );
+        assert!(
+            row.public_depth <= row.old_depth,
+            "expected propagate/generate ripple carry not to increase depth: {:?}",
+            row
+        );
+    }
+
+    #[rustfmt::skip]
+    let want: &[RippleCarryQorRow] = &[
+        RippleCarryQorRow { bit_count: 1, old_and_nodes: 11, old_depth: 4, public_and_nodes: 9, public_depth: 4 },
+        RippleCarryQorRow { bit_count: 2, old_and_nodes: 22, old_depth: 6, public_and_nodes: 18, public_depth: 6 },
+        RippleCarryQorRow { bit_count: 3, old_and_nodes: 33, old_depth: 9, public_and_nodes: 27, public_depth: 8 },
+        RippleCarryQorRow { bit_count: 4, old_and_nodes: 44, old_depth: 12, public_and_nodes: 36, public_depth: 10 },
+        RippleCarryQorRow { bit_count: 5, old_and_nodes: 55, old_depth: 15, public_and_nodes: 45, public_depth: 12 },
+        RippleCarryQorRow { bit_count: 8, old_and_nodes: 88, old_depth: 24, public_and_nodes: 72, public_depth: 18 },
+        RippleCarryQorRow { bit_count: 16, old_and_nodes: 176, old_depth: 48, public_and_nodes: 144, public_depth: 34 },
+        RippleCarryQorRow { bit_count: 32, old_and_nodes: 352, old_depth: 96, public_and_nodes: 288, public_depth: 66 },
+        RippleCarryQorRow { bit_count: 64, old_and_nodes: 704, old_depth: 192, public_and_nodes: 576, public_depth: 130 },
+    ];
+    assert_eq!(got, want);
+}

--- a/xlsynth-g8r/tests/test_adder_depths.rs
+++ b/xlsynth-g8r/tests/test_adder_depths.rs
@@ -90,7 +90,7 @@ fn depth(g: &GateFn) -> usize {
 #[test]
 fn adder_depths() {
     let _ = env_logger::builder().is_test(true).try_init();
-    const RIPPLE: [usize; 8] = [5, 7, 10, 13, 16, 19, 22, 25];
+    const RIPPLE: [usize; 8] = [5, 7, 9, 11, 13, 15, 17, 19];
     const CARRY_SELECT: [usize; 8] = [5, 7, 9, 9, 11, 11, 13, 13];
     const KOGGE: [usize; 8] = [5, 7, 8, 9, 10, 11, 11, 11];
     const BRENT: [usize; 8] = [5, 7, 8, 10, 10, 12, 12, 14];


### PR DESCRIPTION
Before: ripple-carry add used the generic full-adder shape per bit, effectively sum = a ^ b ^ cin and cout = (a & b) | (b & cin) | (a & cin), so each carry stage rebuilt three pairwise terms instead of carrying a shared propagate signal forward.

After: ripple-carry add uses the canonical generate/propagate recurrence, p = a ^ b, g = a & b, sum = p ^ cin, cout = g | (p & cin)