### PR TITLE
Fix Default traits for wide types in generated AOT Rust wrappers

### DIFF
--- a/xlsynth/src/aot_builder.rs
+++ b/xlsynth/src/aot_builder.rs
@@ -416,6 +416,25 @@ fn is_named_tuple(ty: &ResolvedType, name: &str) -> bool {
     matches!(ty, ResolvedType::Tuple { name: ty_name, .. } if ty_name == name)
 }
 
+fn render_default_expr(ty: &ResolvedType) -> String {
+    match ty {
+        ResolvedType::Bits { bit_count } => {
+            if *bit_count <= 64 {
+                "Default::default()".to_string()
+            } else {
+                let byte_count = bit_count.div_ceil(8);
+                format!("[0; {byte_count}]")
+            }
+        }
+        ResolvedType::Tuple { name, .. } => format!("{name}::default()"),
+        ResolvedType::Array { element, .. } => {
+            let element_default = render_default_expr(element);
+            format!("std::array::from_fn(|_| {element_default})")
+        }
+        ResolvedType::Token => "Token::default()".to_string(),
+    }
+}
+
 fn render_type_declarations(
     resolver: &TypeResolver,
     input_types: &[ResolvedType],
@@ -441,9 +460,13 @@ fn render_type_declarations(
     }
 
     for tuple in &resolver.tuple_defs {
-        out.push_str("#[derive(Debug, Clone, PartialEq, Eq, Default)]\n");
+        out.push_str("#[derive(Debug, Clone, PartialEq, Eq)]\n");
         if tuple.field_types.is_empty() {
             out.push_str(&format!("pub struct {} {{}}\n\n", tuple.name));
+            out.push_str(&format!(
+                "impl Default for {} {{\n    fn default() -> Self {{\n        Self {{}}\n    }}\n}}\n\n",
+                tuple.name
+            ));
             continue;
         }
         out.push_str(&format!("pub struct {} {{\n", tuple.name));
@@ -453,6 +476,18 @@ fn render_type_declarations(
                 rust_type_name(field_ty)
             ));
         }
+        out.push_str("}\n\n");
+        out.push_str(&format!("impl Default for {} {{\n", tuple.name));
+        out.push_str("    fn default() -> Self {\n");
+        out.push_str("        Self {\n");
+        for (index, field_ty) in tuple.field_types.iter().enumerate() {
+            out.push_str(&format!(
+                "            field{index}: {},\n",
+                render_default_expr(field_ty)
+            ));
+        }
+        out.push_str("        }\n");
+        out.push_str("    }\n");
         out.push_str("}\n\n");
     }
 
@@ -1068,6 +1103,7 @@ fn emit_link_archive(base_name: &str, object_file: &Path) -> AotResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::aot_entrypoint_metadata::AotType;
 
     #[test]
     fn sanitize_identifier_rewrites_non_ident_chars() {
@@ -1079,5 +1115,47 @@ mod tests {
     #[test]
     fn sanitize_value_identifier_handles_keywords() {
         assert_eq!(sanitize_value_identifier("type", "arg"), "type_");
+    }
+
+    #[test]
+    fn render_type_declarations_emits_manual_default_impls() {
+        let mut resolver = TypeResolver::default();
+        let input_ty = resolver.lower_type(
+            &AotType::Tuple {
+                elements: vec![
+                    AotType::Bits { bit_count: 8 },
+                    AotType::Array {
+                        size: 128,
+                        element: Box::new(AotType::Bits { bit_count: 16 }),
+                    },
+                    AotType::Bits { bit_count: 257 },
+                ],
+            },
+            "Input0",
+        );
+        let output_ty = resolver.lower_type(&AotType::Tuple { elements: vec![] }, "Output");
+
+        let declarations = render_type_declarations(&resolver, &[input_ty], &output_ty);
+
+        assert!(
+            declarations.contains("#[derive(Debug, Clone, PartialEq, Eq)]\npub struct Input0 {")
+        );
+        assert!(
+            declarations.contains("field1: std::array::from_fn(|_| Default::default()),"),
+            "declarations should use from_fn for large arrays: {}",
+            declarations
+        );
+        assert!(
+            declarations.contains("field2: [0; 33],"),
+            "declarations should zero-initialize wide bits arrays: {}",
+            declarations
+        );
+        assert!(
+            declarations.contains(
+                "impl Default for Output {\n    fn default() -> Self {\n        Self {}\n    }\n}"
+            ),
+            "declarations should emit a manual Default impl for empty structs: {}",
+            declarations
+        );
     }
 }

--- a/xlsynth/tests/aot-test-crate/build.rs
+++ b/xlsynth/tests/aot-test-crate/build.rs
@@ -80,6 +80,20 @@ top fn wide_sizes(input: (bits[1], bits[7], bits[8], bits[16], bits[32], bits[64
 }
 "#;
 
+    let large_array_tuple_ir = r#"package aot_tests
+
+top fn large_array_tuple(input: (bits[8], bits[16][128])) -> (bits[8], bits[16][128]) {
+  ret out: (bits[8], bits[16][128]) = identity(input)
+}
+"#;
+
+    let wide_bits_tuple_ir = r#"package aot_tests
+
+top fn wide_bits_tuple(input: (bits[8], bits[257])) -> (bits[8], bits[257]) {
+  ret out: (bits[8], bits[257]) = identity(input)
+}
+"#;
+
     let trace_assert_ir = r#"package aot_tests
 
 top fn trace_assert_pair(tok: token, pair: (bits[8], bits[8])) -> (bits[8], bits[8]) {
@@ -125,6 +139,18 @@ top fn trace_assert_pair(tok: token, pair: (bits[8], bits[8])) -> (bits[8], bits
             top: "wide_sizes",
             env_var: "XLSYNTH_AOT_WIDE_SIZES_RS",
             ir_text: wide_sizes_ir,
+        },
+        AotCase {
+            name: "large_array_tuple",
+            top: "large_array_tuple",
+            env_var: "XLSYNTH_AOT_LARGE_ARRAY_TUPLE_RS",
+            ir_text: large_array_tuple_ir,
+        },
+        AotCase {
+            name: "wide_bits_tuple",
+            top: "wide_bits_tuple",
+            env_var: "XLSYNTH_AOT_WIDE_BITS_TUPLE_RS",
+            ir_text: wide_bits_tuple_ir,
         },
         AotCase {
             name: "trace_assert",

--- a/xlsynth/tests/aot-test-crate/src/lib.rs
+++ b/xlsynth/tests/aot-test-crate/src/lib.rs
@@ -20,6 +20,14 @@ pub mod wide_sizes_aot {
     include!(env!("XLSYNTH_AOT_WIDE_SIZES_RS"));
 }
 
+pub mod large_array_tuple_aot {
+    include!(env!("XLSYNTH_AOT_LARGE_ARRAY_TUPLE_RS"));
+}
+
+pub mod wide_bits_tuple_aot {
+    include!(env!("XLSYNTH_AOT_WIDE_BITS_TUPLE_RS"));
+}
+
 pub mod trace_assert_aot {
     include!(env!("XLSYNTH_AOT_TRACE_ASSERT_RS"));
 }

--- a/xlsynth/tests/aot-test-crate/tests/aot_test.rs
+++ b/xlsynth/tests/aot-test-crate/tests/aot_test.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use xlsynth_aot_test_crate::{
-    add_inputs_aot, add_one_aot, compound_shapes_aot, empty_tuple_aot, trace_assert_aot,
-    wide_sizes_aot,
+    add_inputs_aot, add_one_aot, compound_shapes_aot, empty_tuple_aot, large_array_tuple_aot,
+    trace_assert_aot, wide_bits_tuple_aot, wide_sizes_aot,
 };
 
 #[test]
@@ -96,6 +96,38 @@ fn generated_runner_supports_varied_bit_widths_including_wide_values() {
             [0x78, 0x56, 0x34, 0x12, 0xEF, 0xCD, 0xAB, 0x90, 0x00]
         ]
     );
+}
+
+#[test]
+fn generated_runner_supports_manual_default_for_large_array_tuple_structs() {
+    let mut runner = large_array_tuple_aot::new_runner().expect("runner creation should succeed");
+    let mut input = large_array_tuple_aot::Input0::default();
+    input.field0 = 0x5A;
+    input.field1[0] = 0x1234;
+    input.field1[127] = 0xABCD;
+
+    let output = runner.run(&input).expect("run should succeed");
+    assert_eq!(output.field0, 0x5A);
+    assert_eq!(output.field1[0], 0x1234);
+    assert_eq!(output.field1[127], 0xABCD);
+    assert!(output.field1[1..127].iter().all(|value| *value == 0));
+}
+
+#[test]
+fn generated_runner_supports_manual_default_for_wide_bits_tuple_structs() {
+    let mut runner = wide_bits_tuple_aot::new_runner().expect("runner creation should succeed");
+    let mut input = wide_bits_tuple_aot::Input0::default();
+    let mut expected_wide_bits = [0u8; 33];
+    expected_wide_bits[0] = 0x5A;
+    expected_wide_bits[32] = 0x01;
+
+    input.field0 = 0xC3;
+    input.field1 = expected_wide_bits;
+
+    let output = runner.run(&input).expect("run should succeed");
+    assert_eq!(output.field0, 0xC3);
+    assert_eq!(output.field1, expected_wide_bits);
+    assert!(output.field1[1..32].iter().all(|value| *value == 0));
 }
 
 #[test]


### PR DESCRIPTION
AOT compilation of DSLX/XLS generates Rust wrapper code for running the compiled code. These generated wrappers were broken for arrays with more than 32 elements because the trait derivation for arrays is based on a macro which maxes out at 32 elements. This affected explicit DSLX array types with more than 32 elements and wide bits types which are represented as byte arrays. This change fixes the problem by explicitly providing a Default impl for any type with an array.