### PR TITLE
Improve fraig performance and optimization results

### DIFF
--- a/xlsynth-g8r/src/aig_sim/gate_simd.rs
+++ b/xlsynth-g8r/src/aig_sim/gate_simd.rs
@@ -28,6 +28,11 @@ impl Vec256 {
     }
 
     #[inline]
+    pub const fn from_words(words: [u64; 4]) -> Self {
+        Self(u64x4::from_array(words))
+    }
+
+    #[inline]
     pub const fn splat(bit: bool) -> Self {
         Self(u64x4::from_array(if bit { [u64::MAX; 4] } else { [0; 4] }))
     }
@@ -79,16 +84,12 @@ pub struct GateSimdResult {
     pub outputs: Vec<Vec256>,
 }
 
-/// Evaluates `gate_fn` on a *batch* of 256 input samples supplied in SIMD
-/// form.
+/// Evaluates `gate_fn` and returns every node's 256-wide value.
 ///
-/// The caller must flatten all input bits (across all declared inputs and their
-/// constituent bit-vectors) into the `inputs` slice in the same order that
-/// `gate_fn.inputs` enumerates them **from LSb→MSb**.
-///
-/// Panics if the batch size is not exactly 256 or if the number of supplied
-/// input vectors does not match the total input bit-count.
-pub fn eval(gate_fn: &GateFn, inputs: &[Vec256]) -> GateSimdResult {
+/// The returned vector is indexed by `AigRef::id`. Nodes outside the output
+/// cone are left at zero, matching the scalar simulator's `Collect::All`
+/// behavior for unvisited nodes.
+pub fn eval_all_node_values(gate_fn: &GateFn, inputs: &[Vec256]) -> Vec<Vec256> {
     // Sanity-check that the batch size is 256 – this is a *fixed* requirement
     // for this interpreter variant.
     debug_assert_eq!(core::mem::size_of::<Vec256>(), 32);
@@ -127,6 +128,21 @@ pub fn eval(gate_fn: &GateFn, inputs: &[Vec256]) -> GateSimdResult {
             }
         }
     }
+
+    env
+}
+
+/// Evaluates `gate_fn` on a *batch* of 256 input samples supplied in SIMD
+/// form.
+///
+/// The caller must flatten all input bits (across all declared inputs and their
+/// constituent bit-vectors) into the `inputs` slice in the same order that
+/// `gate_fn.inputs` enumerates them **from LSb→MSb**.
+///
+/// Panics if the batch size is not exactly 256 or if the number of supplied
+/// input vectors does not match the total input bit-count.
+pub fn eval(gate_fn: &GateFn, inputs: &[Vec256]) -> GateSimdResult {
+    let env = eval_all_node_values(gate_fn, inputs);
 
     // Collect outputs.
     let mut outputs: Vec<Vec256> = Vec::new();

--- a/xlsynth-g8r/src/propose_equiv.rs
+++ b/xlsynth-g8r/src/propose_equiv.rs
@@ -3,14 +3,63 @@
 //! Functionality for proposing equivalence classes via concrete simulation.
 
 use crate::aig::{AigNode, AigRef, GateFn};
-use crate::aig_sim::gate_sim::{self, Collect, GateSimResult};
-use bitvec::vec::BitVec;
+use crate::aig_sim::gate_simd::{self, Vec256};
 use xlsynth::IrBits;
 use xlsynth_pir::fuzz_utils::arbitrary_irbits;
 
 use rand::Rng;
+use std::cmp::min;
 use std::collections::{HashMap, HashSet};
-use std::hash::{DefaultHasher, Hash, Hasher};
+
+const SIMD_LANES: usize = 256;
+// Domain-separation labels for the BLAKE3 simulation signature hash chain.
+const SIGNATURE_INIT_DOMAIN: &[u8] = b"xlsynth-g8r/fraig/simulation-signature/v1/init";
+const SIGNATURE_UPDATE_DOMAIN: &[u8] = b"xlsynth-g8r/fraig/simulation-signature/v1/update";
+const SIGNATURE_FINAL_DOMAIN: &[u8] = b"xlsynth-g8r/fraig/simulation-signature/v1/final";
+
+/// A streaming 256-bit simulation signature for one node.
+///
+/// SAT validation is still the authority, so a hash collision can only create
+/// extra candidates that are later rejected. Keeping only the BLAKE3 digest
+/// avoids materializing the old samples-by-nodes history matrix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SimulationSignature([u8; 32]);
+
+impl SimulationSignature {
+    #[inline]
+    fn new() -> Self {
+        Self(*blake3::hash(SIGNATURE_INIT_DOMAIN).as_bytes())
+    }
+
+    #[inline]
+    fn words_to_le_bytes(words: [u64; 4]) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        for (i, word) in words.into_iter().enumerate() {
+            bytes[i * 8..(i + 1) * 8].copy_from_slice(&word.to_le_bytes());
+        }
+        bytes
+    }
+
+    #[inline]
+    fn update_words(&mut self, words: [u64; 4], batch_index: u64) {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(SIGNATURE_UPDATE_DOMAIN);
+        hasher.update(&self.0);
+        hasher.update(&batch_index.to_le_bytes());
+        hasher.update(&Self::words_to_le_bytes(words));
+        self.0 = *hasher.finalize().as_bytes();
+    }
+
+    #[inline]
+    fn finalize(mut self, total_samples: usize) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(SIGNATURE_FINAL_DOMAIN);
+        hasher.update(&self.0);
+        hasher.update(&total_samples.to_le_bytes());
+        self.0 = *hasher.finalize().as_bytes();
+        self
+    }
+}
 
 /// Represents a node within a proposed equivalence class, indicating whether
 /// its simulation history matches the class directly (Normal) or inversely
@@ -63,6 +112,98 @@ fn gen_random_inputs(gate_fn: &GateFn, rng: &mut impl Rng) -> Vec<IrBits> {
         .collect()
 }
 
+fn total_input_bits(gate_fn: &GateFn) -> usize {
+    gate_fn.inputs.iter().map(|i| i.get_bit_count()).sum()
+}
+
+fn set_lane_inputs(
+    gate_fn: &GateFn,
+    lane: usize,
+    inputs: &[IrBits],
+    words_per_input_bit: &mut [[u64; 4]],
+) {
+    assert!(lane < SIMD_LANES);
+    assert_eq!(inputs.len(), gate_fn.inputs.len());
+    let limb = lane / 64;
+    let bit_mask = 1u64 << (lane % 64);
+    let mut bit_cursor = 0;
+    for (input_value, input) in inputs.iter().zip(gate_fn.inputs.iter()) {
+        for bit_idx in 0..input.bit_vector.get_bit_count() {
+            if input_value.get_bit(bit_idx).unwrap() {
+                words_per_input_bit[bit_cursor + bit_idx][limb] |= bit_mask;
+            }
+        }
+        bit_cursor += input.bit_vector.get_bit_count();
+    }
+}
+
+fn random_simd_inputs(gate_fn: &GateFn, lane_count: usize, rng: &mut impl Rng) -> Vec<Vec256> {
+    assert!(lane_count <= SIMD_LANES);
+    let mut words_per_input_bit = vec![[0u64; 4]; total_input_bits(gate_fn)];
+    for lane in 0..lane_count {
+        let inputs = gen_random_inputs(gate_fn, rng);
+        set_lane_inputs(gate_fn, lane, &inputs, &mut words_per_input_bit);
+    }
+    words_per_input_bit
+        .into_iter()
+        .map(Vec256::from_words)
+        .collect()
+}
+
+fn counterexample_simd_inputs(gate_fn: &GateFn, counterexamples: &[&Vec<IrBits>]) -> Vec<Vec256> {
+    assert!(counterexamples.len() <= SIMD_LANES);
+    let mut words_per_input_bit = vec![[0u64; 4]; total_input_bits(gate_fn)];
+    for (lane, inputs) in counterexamples.iter().enumerate() {
+        set_lane_inputs(gate_fn, lane, inputs, &mut words_per_input_bit);
+    }
+    words_per_input_bit
+        .into_iter()
+        .map(Vec256::from_words)
+        .collect()
+}
+
+fn lane_mask(valid_lanes: usize) -> [u64; 4] {
+    assert!(valid_lanes <= SIMD_LANES);
+    let mut mask = [0u64; 4];
+    let full_limbs = valid_lanes / 64;
+    let remainder = valid_lanes % 64;
+    for word in mask.iter_mut().take(full_limbs) {
+        *word = u64::MAX;
+    }
+    if remainder > 0 {
+        mask[full_limbs] = (1u64 << remainder) - 1;
+    }
+    mask
+}
+
+fn masked_words(value: Vec256, mask: [u64; 4], inverted: bool) -> [u64; 4] {
+    let words = value.to_array();
+    [
+        (if inverted { !words[0] } else { words[0] }) & mask[0],
+        (if inverted { !words[1] } else { words[1] }) & mask[1],
+        (if inverted { !words[2] } else { words[2] }) & mask[2],
+        (if inverted { !words[3] } else { words[3] }) & mask[3],
+    ]
+}
+
+fn update_signatures(
+    gate_fn: &GateFn,
+    candidate_node_indices: &[usize],
+    normal_signatures: &mut [SimulationSignature],
+    inverse_signatures: &mut [SimulationSignature],
+    inputs: &[Vec256],
+    valid_lanes: usize,
+    batch_index: u64,
+) {
+    let node_values = gate_simd::eval_all_node_values(gate_fn, inputs);
+    let mask = lane_mask(valid_lanes);
+    for &node_index in candidate_node_indices {
+        let value = node_values[node_index];
+        normal_signatures[node_index].update_words(masked_words(value, mask, false), batch_index);
+        inverse_signatures[node_index].update_words(masked_words(value, mask, true), batch_index);
+    }
+}
+
 /// Returns a mapping from hash value (a hash over the history for a given gate
 /// as it's fed random samples) to a sequence of the nodes that had the same
 /// history.
@@ -71,89 +212,134 @@ pub fn propose_equivalence_classes(
     input_sample_count: usize,
     rng: &mut impl Rng,
     counterexamples: &HashSet<Vec<IrBits>>,
-) -> HashMap<u64, Vec<EquivNode>> {
-    // samples x gate values -- would be nicer to have a BitMatrix
+) -> HashMap<SimulationSignature, Vec<EquivNode>> {
     let gate_count = gate_fn.gates.len();
-    let mut history: Vec<BitVec> = Vec::with_capacity(input_sample_count);
+    let candidate_node_indices: Vec<usize> = gate_fn
+        .gates
+        .iter()
+        .enumerate()
+        .filter_map(|(node_index, node)| {
+            if matches!(node, AigNode::Input { .. } | AigNode::Literal { .. }) {
+                None
+            } else {
+                Some(node_index)
+            }
+        })
+        .collect();
+    let mut normal_signatures = vec![SimulationSignature::new(); gate_count];
+    let mut inverse_signatures = vec![SimulationSignature::new(); gate_count];
+    let mut batch_index = 0u64;
 
-    // Push `input_sample_count` random samples through the gate function and
-    // collect the history of all the nodes.
-    for _ in 0..input_sample_count {
-        let inputs: Vec<IrBits> = gen_random_inputs(gate_fn, rng);
-        let result: GateSimResult = gate_sim::eval(gate_fn, &inputs, Collect::All);
-        history.push(result.all_values.unwrap());
+    // Push `input_sample_count` random samples through the gate function in
+    // 256-wide batches and stream each node's sampled value into a signature.
+    let mut remaining_random_samples = input_sample_count;
+    while remaining_random_samples > 0 {
+        let lane_count = min(remaining_random_samples, SIMD_LANES);
+        let inputs = random_simd_inputs(gate_fn, lane_count, rng);
+        update_signatures(
+            gate_fn,
+            &candidate_node_indices,
+            &mut normal_signatures,
+            &mut inverse_signatures,
+            &inputs,
+            lane_count,
+            batch_index,
+        );
+        batch_index += 1;
+        remaining_random_samples -= lane_count;
     }
 
     // Now do it for all explicitly-provided counterexamples.
-    for counterexample in counterexamples {
-        let result: GateSimResult = gate_sim::eval(gate_fn, counterexample, Collect::All);
+    let counterexample_refs: Vec<&Vec<IrBits>> = counterexamples.iter().collect();
+    for batch in counterexample_refs.chunks(SIMD_LANES) {
+        let inputs = counterexample_simd_inputs(gate_fn, batch);
+        update_signatures(
+            gate_fn,
+            &candidate_node_indices,
+            &mut normal_signatures,
+            &mut inverse_signatures,
+            &inputs,
+            batch.len(),
+            batch_index,
+        );
+        batch_index += 1;
+    }
+
+    // Group by hash
+    let total_samples = input_sample_count + counterexamples.len();
+    let mut grouped_classes: HashMap<SimulationSignature, Vec<EquivNode>> = HashMap::new();
+    for node_index in candidate_node_indices {
+        let node_ref = AigRef { id: node_index };
+        let entries = [
+            (
+                normal_signatures[node_index].finalize(total_samples),
+                EquivNode::Normal(node_ref),
+            ),
+            (
+                inverse_signatures[node_index].finalize(total_samples),
+                EquivNode::Inverted(node_ref),
+            ),
+        ];
+        for (hash, equiv_node) in entries {
+            grouped_classes
+                .entry(hash)
+                .or_insert_with(Vec::new)
+                .push(equiv_node);
+        }
+    }
+
+    for nodes in grouped_classes.values_mut() {
+        nodes.sort_unstable();
+    }
+
+    grouped_classes.retain(|_, nodes| nodes.len() > 1);
+    grouped_classes
+}
+
+#[cfg(test)]
+fn propose_equivalence_classes_scalar_for_test(
+    gate_fn: &GateFn,
+    input_samples: &[Vec<IrBits>],
+    counterexamples: &[Vec<IrBits>],
+) -> HashMap<Vec<bool>, Vec<EquivNode>> {
+    use crate::aig_sim::gate_sim::{self, Collect, GateSimResult};
+
+    let gate_count = gate_fn.gates.len();
+    let mut history = Vec::with_capacity(input_samples.len() + counterexamples.len());
+    for sample in input_samples {
+        let result: GateSimResult = gate_sim::eval(gate_fn, sample, Collect::All);
+        history.push(result.all_values.unwrap());
+    }
+    for sample in counterexamples {
+        let result: GateSimResult = gate_sim::eval(gate_fn, sample, Collect::All);
         history.push(result.all_values.unwrap());
     }
 
-    // Collects the history for the given `gate_index` across all samples.
-    let collect_across_samples = |gate_index: usize| -> BitVec {
-        history.iter().map(|h| -> bool { h[gate_index] }).collect()
-    };
-
-    // Calculate normal and inverse hashes in a single pass.
-    let node_hashes: Vec<(u64, u64)> = (0..gate_count)
-        .map(|i| {
-            let mut gate_history = collect_across_samples(i);
-
-            // Calculate normal hash
-            let mut normal_hasher = DefaultHasher::new();
-            gate_history.hash(&mut normal_hasher);
-            let normal_hash = normal_hasher.finish();
-
-            // Calculate inverse hash
-            gate_history.iter_mut().for_each(|mut bit| *bit = !*bit);
-            let mut inverse_hasher = DefaultHasher::new();
-            gate_history.hash(&mut inverse_hasher);
-            let inverse_hash = inverse_hasher.finish();
-
-            (normal_hash, inverse_hash)
-        })
-        .collect();
-
-    // Collect all potential hash entries (normal and inverted) for
-    // non-input/literal nodes.
-    let all_potential_equivs: Vec<(u64, EquivNode)> = (0..gate_count)
-        .filter_map(|node_index| {
-            let node = &gate_fn.gates[node_index];
-            if matches!(node, AigNode::Input { .. } | AigNode::Literal { .. }) {
-                None // Skip inputs and literals
-            } else {
-                let (normal_hash, inverse_hash) = node_hashes[node_index];
-                let node_ref = AigRef { id: node_index };
-                Some(vec![
-                    (normal_hash, EquivNode::Normal(node_ref)),
-                    (inverse_hash, EquivNode::Inverted(node_ref)),
-                ])
-            }
-        })
-        .flatten()
-        .collect();
-
-    // Group by hash
-    let mut grouped_classes: HashMap<u64, Vec<EquivNode>> = HashMap::new();
-    for (hash, equiv_node) in all_potential_equivs {
+    let mut grouped_classes = HashMap::new();
+    for node_index in 0..gate_count {
+        let node = &gate_fn.gates[node_index];
+        if matches!(node, AigNode::Input { .. } | AigNode::Literal { .. }) {
+            continue;
+        }
+        let normal_history: Vec<bool> = history.iter().map(|h| h[node_index]).collect();
+        let inverse_history: Vec<bool> = normal_history.iter().map(|bit| !*bit).collect();
+        let node_ref = AigRef { id: node_index };
         grouped_classes
-            .entry(hash)
+            .entry(normal_history)
             .or_insert_with(Vec::new)
-            .push(equiv_node);
+            .push(EquivNode::Normal(node_ref));
+        grouped_classes
+            .entry(inverse_history)
+            .or_insert_with(Vec::new)
+            .push(EquivNode::Inverted(node_ref));
     }
 
-    // Filter out singleton classes and sort remaining classes.
-    let equiv_classes: HashMap<u64, Vec<EquivNode>> = grouped_classes
-        .into_iter()
-        .filter(|(_, nodes)| nodes.len() > 1)
-        .map(|(hash, mut nodes)| {
-            nodes.sort_unstable(); // Sort for deterministic output within the class list
-            (hash, nodes)
-        })
-        .collect();
+    for nodes in grouped_classes.values_mut() {
+        nodes.sort_unstable();
+    }
 
-    equiv_classes
+    grouped_classes.retain(|_, nodes| nodes.len() > 1);
+    grouped_classes
 }
 
 #[cfg(test)]
@@ -161,6 +347,18 @@ mod tests {
     use super::*;
     use crate::test_utils::{setup_graph_with_redundancies, setup_simple_graph};
     use rand::SeedableRng;
+
+    fn sorted_classes<K>(classes: &HashMap<K, Vec<EquivNode>>) -> Vec<Vec<EquivNode>>
+    where
+        K: Eq + std::hash::Hash,
+    {
+        let mut values = classes.values().cloned().collect::<Vec<_>>();
+        for value in values.iter_mut() {
+            value.sort_unstable();
+        }
+        values.sort();
+        values
+    }
 
     #[test]
     fn test_propose_equiv_simple_graph() {
@@ -220,6 +418,44 @@ mod tests {
                 })
                 .collect::<Vec<_>>(),
             want
+        );
+    }
+
+    #[test]
+    fn test_propose_equiv_simd_hash_matches_scalar_multiple_batches() {
+        let graph = setup_graph_with_redundancies();
+        let input_sample_count = 513;
+        let mut seeded_rng = rand::rngs::StdRng::seed_from_u64(7);
+        let input_samples = (0..input_sample_count)
+            .map(|_| gen_random_inputs(&graph.g, &mut seeded_rng))
+            .collect::<Vec<_>>();
+        let counterexample_samples = vec![
+            vec![
+                IrBits::bool(false),
+                IrBits::bool(false),
+                IrBits::bool(false),
+            ],
+            vec![IrBits::bool(true), IrBits::bool(false), IrBits::bool(true)],
+            vec![IrBits::bool(true), IrBits::bool(true), IrBits::bool(false)],
+        ];
+        let scalar_classes = propose_equivalence_classes_scalar_for_test(
+            &graph.g,
+            &input_samples,
+            &counterexample_samples,
+        );
+
+        let counterexamples = counterexample_samples.into_iter().collect::<HashSet<_>>();
+        let mut simd_rng = rand::rngs::StdRng::seed_from_u64(7);
+        let simd_classes = propose_equivalence_classes(
+            &graph.g,
+            input_sample_count,
+            &mut simd_rng,
+            &counterexamples,
+        );
+
+        assert_eq!(
+            sorted_classes(&simd_classes),
+            sorted_classes(&scalar_classes)
         );
     }
 }

--- a/xlsynth-g8r/src/prove_gate_fn_equiv_varisat.rs
+++ b/xlsynth-g8r/src/prove_gate_fn_equiv_varisat.rs
@@ -12,6 +12,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::aig::gate::{AigNode, AigRef, GateFn};
+use crate::aig::get_summary_stats::get_gate_depth;
 use crate::aig::topo::extract_cone;
 use crate::propose_equiv::EquivNode;
 pub use crate::prove_gate_fn_equiv_common::EquivResult;
@@ -175,6 +176,80 @@ fn add_miters(
         miters.push(xor_miter);
     }
     miters
+}
+
+fn model_value_for_equiv_node(
+    model_set: &HashSet<varisat::Lit>,
+    aig_ref_to_lit: &HashMap<AigRef, varisat::Lit>,
+    equiv_node: EquivNode,
+) -> bool {
+    let base_value = model_set.contains(&aig_ref_to_lit[&equiv_node.aig_ref()]);
+    if equiv_node.is_inverted() {
+        !base_value
+    } else {
+        base_value
+    }
+}
+
+fn split_bucket_by_model_set(
+    nodes: &[EquivNode],
+    model_set: &HashSet<varisat::Lit>,
+    aig_ref_to_lit: &HashMap<AigRef, varisat::Lit>,
+) -> Vec<Vec<EquivNode>> {
+    let mut false_values = Vec::new();
+    let mut true_values = Vec::new();
+
+    for &node in nodes {
+        if model_value_for_equiv_node(model_set, aig_ref_to_lit, node) {
+            true_values.push(node);
+        } else {
+            false_values.push(node);
+        }
+    }
+
+    if false_values.is_empty() || true_values.is_empty() {
+        return vec![nodes.to_vec()];
+    }
+
+    [false_values, true_values]
+        .into_iter()
+        .filter(|bucket| bucket.len() > 1)
+        .collect()
+}
+
+fn presplit_by_counterexample_models(
+    nodes: Vec<EquivNode>,
+    counterexample_models: &[HashSet<varisat::Lit>],
+    aig_ref_to_lit: &HashMap<AigRef, varisat::Lit>,
+) -> Vec<Vec<EquivNode>> {
+    let mut buckets = vec![nodes];
+    for model_set in counterexample_models {
+        buckets = buckets
+            .into_iter()
+            .flat_map(|bucket| split_bucket_by_model_set(&bucket, model_set, aig_ref_to_lit))
+            .collect();
+        if buckets.is_empty() {
+            break;
+        }
+    }
+    buckets
+}
+
+fn equiv_node_depth_key(
+    ref_to_depth: &HashMap<AigRef, usize>,
+    equiv_node: EquivNode,
+) -> (usize, bool, usize) {
+    let aig_ref = equiv_node.aig_ref();
+    (ref_to_depth[&aig_ref], equiv_node.is_inverted(), aig_ref.id)
+}
+
+fn sorted_equiv_class(
+    equiv_class: &[EquivNode],
+    ref_to_depth: &HashMap<AigRef, usize>,
+) -> Vec<EquivNode> {
+    let mut nodes = equiv_class.to_vec();
+    nodes.sort_unstable_by_key(|node| equiv_node_depth_key(ref_to_depth, *node));
+    nodes
 }
 
 fn solver_model_to_cex(
@@ -365,53 +440,86 @@ pub fn validate_equivalence_classes(
         proven_equiv_sets: Vec::new(),
         cex_inputs: Vec::new(),
     };
+    let all_nodes: Vec<AigRef> = gate_fn
+        .gates
+        .iter()
+        .enumerate()
+        .map(|(id, _)| AigRef { id })
+        .collect();
+    let depth_stats = get_gate_depth(gate_fn, &all_nodes);
+    let mut sorted_equiv_classes: Vec<Vec<EquivNode>> = equiv_classes
+        .iter()
+        .map(|equiv_class| sorted_equiv_class(equiv_class, &depth_stats.ref_to_depth))
+        .collect();
+    sorted_equiv_classes.sort_unstable_by_key(|equiv_class| {
+        let representative = equiv_class[0];
+        (
+            equiv_node_depth_key(&depth_stats.ref_to_depth, representative),
+            equiv_class.len(),
+        )
+    });
+    let mut counterexample_models: Vec<HashSet<varisat::Lit>> = Vec::new();
 
     // Now iterate through the equivalence classes -- for each equivalence class
     // we'll advance a miter that checks whether the next value in the
     // equivalence class is equivalent to the previous value(s) which are
     // determined to be equivalent. By using multiple miters I'm suspecting we can
-    // potentially find counterexamples faster.
-    for equiv_class in equiv_classes {
-        let mut known_equiv = vec![equiv_class[0]];
-        for &candidate in &equiv_class[1..] {
-            // Create a miter between this candidate and all known equivalent values.
-            let miters = add_miters(&mut solver, &aig_ref_to_lit, &known_equiv, candidate);
+    // potentially find counterexamples faster. Before spending SAT work on a
+    // class, split it by counterexamples found in earlier classes. A new
+    // counterexample still stops the current original class, preserving the old
+    // per-class proof budget.
+    for equiv_class in sorted_equiv_classes {
+        let buckets =
+            presplit_by_counterexample_models(equiv_class, &counterexample_models, &aig_ref_to_lit);
+        let mut stop_class_after_new_counterexample = false;
+        for bucket in buckets {
+            let mut known_equiv = vec![bucket[0]];
+            for &candidate in &bucket[1..] {
+                // Create a miter between this candidate and all known equivalent values.
+                let miters = add_miters(&mut solver, &aig_ref_to_lit, &known_equiv, candidate);
 
-            // Assume the miters outputs are true, which is stating "the candidate is
-            // unequal to the known_equiv values".
-            solver.assume(&miters);
-            let solve_result = solver.solve();
-            match solve_result {
-                Ok(false) => {
-                    // No counterexample found, expand the known equivalent set.
-                    known_equiv.push(candidate);
-                }
-                Ok(true) => {
-                    // Counterexample found, extract it from the model.
-                    let model = solver.model();
-                    assert!(
-                        model.is_some(),
-                        "counterexample found, should be able to extract model"
-                    );
-                    let model_unwrapped = model.unwrap();
-                    let cex = solver_model_to_cex(
-                        &model_unwrapped,
-                        &all_primary_inputs,
-                        &aig_ref_to_lit,
-                        gate_fn,
-                    );
-                    validation_result.cex_inputs.push(cex);
-                    break;
-                }
-                Err(e) => {
-                    return Err(ValidationError::SolverError(e));
+                // Assume the miters outputs are true, which is stating "the candidate is
+                // unequal to the known_equiv values".
+                solver.assume(&miters);
+                let solve_result = solver.solve();
+                match solve_result {
+                    Ok(false) => {
+                        // No counterexample found, expand the known equivalent set.
+                        known_equiv.push(candidate);
+                    }
+                    Ok(true) => {
+                        // Counterexample found, extract it from the model.
+                        let model = solver.model();
+                        assert!(
+                            model.is_some(),
+                            "counterexample found, should be able to extract model"
+                        );
+                        let model_unwrapped = model.unwrap();
+                        let model_set: HashSet<varisat::Lit> =
+                            model_unwrapped.iter().cloned().collect();
+                        let cex = solver_model_to_cex(
+                            &model_unwrapped,
+                            &all_primary_inputs,
+                            &aig_ref_to_lit,
+                            gate_fn,
+                        );
+                        validation_result.cex_inputs.push(cex);
+                        counterexample_models.push(model_set);
+                        stop_class_after_new_counterexample = true;
+                        break;
+                    }
+                    Err(e) => {
+                        return Err(ValidationError::SolverError(e));
+                    }
                 }
             }
-        }
-        if known_equiv.len() > 1 {
-            validation_result
-                .proven_equiv_sets
-                .push(known_equiv.to_vec());
+
+            if known_equiv.len() > 1 {
+                validation_result.proven_equiv_sets.push(known_equiv);
+            }
+            if stop_class_after_new_counterexample {
+                break;
+            }
         }
     }
 
@@ -492,6 +600,31 @@ mod tests {
             validation_result.cex_inputs.len(),
             1,
             "Should find exactly one counterexample"
+        );
+    }
+
+    #[test]
+    fn test_validate_reuses_counterexample_for_later_class() {
+        let setup = setup_partially_equiv_graph();
+
+        let proposed_class = &[
+            EquivNode::Normal(setup.c.node),
+            EquivNode::Normal(setup.a.node),
+            EquivNode::Normal(setup.b.node),
+        ];
+
+        let validation_result =
+            validate_equivalence_classes(&setup.g, &[proposed_class, proposed_class]).unwrap();
+
+        assert_eq!(
+            validation_result.proven_equiv_sets.len(),
+            2,
+            "Both duplicate classes should still prove the a == b pair"
+        );
+        assert_eq!(
+            validation_result.cex_inputs.len(),
+            1,
+            "The second class should be split by the first class's counterexample"
         );
     }
 }


### PR DESCRIPTION
Vectorize evaluation and fix latent bug related to inversion. Also, only store hash of node results rather than vector of bit results. Improves ir2g8r run time by 7x, delay by 4%, node count by 2% across a large corpus.