### PR TITLE
Change compute_uses to return vec<vec<>> instead of hashmap<hashset<>>

### DIFF
--- a/xlsynth-mcmc-pir/src/lib.rs
+++ b/xlsynth-mcmc-pir/src/lib.rs
@@ -49,6 +49,7 @@ use xlsynth_pir::ir::FileTable as PirFileTable;
 use xlsynth_pir::ir::Fn as IrFn;
 use xlsynth_pir::ir::Package as PirPackage;
 use xlsynth_pir::ir::PackageMember as PirPackageMember;
+use xlsynth_pir::ir::Param as PirParam;
 use xlsynth_pir::ir::Type as PirType;
 use xlsynth_pir::ir_eval::{FnEvalResult, eval_fn};
 use xlsynth_pir::ir_parser;
@@ -1329,83 +1330,111 @@ pub fn mcmc_iteration(
     }
 }
 
-fn make_all_zeros_value(ty: &PirType) -> IrValue {
+fn make_all_zeros_value(ty: &PirType) -> Result<IrValue> {
     match ty {
-        PirType::Token => IrValue::make_token(),
+        PirType::Token => Ok(IrValue::make_token()),
         PirType::Bits(width) => {
             if *width == 0 {
-                IrValue::from_bits(&IrBits::make_ubits(0, 0).unwrap())
+                Ok(IrValue::from_bits(&IrBits::make_ubits(0, 0).unwrap()))
             } else {
-                IrValue::from_bits(&IrBits::make_ubits(*width, 0).unwrap())
+                Ok(IrValue::from_bits(&IrBits::make_ubits(*width, 0).unwrap()))
             }
         }
         PirType::Tuple(elem_types) => {
-            let elems: Vec<IrValue> = elem_types.iter().map(|t| make_all_zeros_value(t)).collect();
-            IrValue::make_tuple(&elems)
+            let elems: Result<Vec<IrValue>> =
+                elem_types.iter().map(|t| make_all_zeros_value(t)).collect();
+            Ok(IrValue::make_tuple(&elems?))
         }
         PirType::Array(arr) => {
+            if arr.element_count == 0 {
+                return Err(anyhow::anyhow!(
+                    "cannot construct all-zeros oracle sample for zero-length array type {}",
+                    ty
+                ));
+            }
             let mut elems: Vec<IrValue> = Vec::with_capacity(arr.element_count);
             for _ in 0..arr.element_count {
-                elems.push(make_all_zeros_value(&arr.element_type));
+                elems.push(make_all_zeros_value(&arr.element_type)?);
             }
-            IrValue::make_array(&elems).expect("array elements must be same-typed")
+            IrValue::make_array(&elems).map_err(|e| {
+                anyhow::anyhow!("failed to construct all-zeros array oracle sample: {}", e)
+            })
         }
     }
 }
 
-fn make_all_ones_value(ty: &PirType) -> IrValue {
+fn make_all_ones_value(ty: &PirType) -> Result<IrValue> {
     match ty {
-        PirType::Token => IrValue::make_token(),
+        PirType::Token => Ok(IrValue::make_token()),
         PirType::Bits(width) => {
             if *width == 0 {
-                IrValue::from_bits(&IrBits::make_ubits(0, 0).unwrap())
+                Ok(IrValue::from_bits(&IrBits::make_ubits(0, 0).unwrap()))
             } else if *width <= 64 {
                 let mask = if *width == 64 {
                     u64::MAX
                 } else {
                     (1u64 << *width) - 1
                 };
-                IrValue::from_bits(&IrBits::make_ubits(*width, mask).unwrap())
+                Ok(IrValue::from_bits(
+                    &IrBits::make_ubits(*width, mask).unwrap(),
+                ))
             } else {
-                // Build bits by parsing a typed value string via IrBits helper.
+                // Build the bit vector directly to avoid fixed-width integer limits.
                 let ones: Vec<bool> = vec![true; *width];
-                IrValue::from_bits(&IrBits::from_lsb_is_0(&ones))
+                Ok(IrValue::from_bits(&IrBits::from_lsb_is_0(&ones)))
             }
         }
         PirType::Tuple(elem_types) => {
-            let elems: Vec<IrValue> = elem_types.iter().map(|t| make_all_ones_value(t)).collect();
-            IrValue::make_tuple(&elems)
+            let elems: Result<Vec<IrValue>> =
+                elem_types.iter().map(|t| make_all_ones_value(t)).collect();
+            Ok(IrValue::make_tuple(&elems?))
         }
         PirType::Array(arr) => {
+            if arr.element_count == 0 {
+                return Err(anyhow::anyhow!(
+                    "cannot construct all-ones oracle sample for zero-length array type {}",
+                    ty
+                ));
+            }
             let mut elems: Vec<IrValue> = Vec::with_capacity(arr.element_count);
             for _ in 0..arr.element_count {
-                elems.push(make_all_ones_value(&arr.element_type));
+                elems.push(make_all_ones_value(&arr.element_type)?);
             }
-            IrValue::make_array(&elems).expect("array elements must be same-typed")
+            IrValue::make_array(&elems).map_err(|e| {
+                anyhow::anyhow!("failed to construct all-ones array oracle sample: {}", e)
+            })
         }
     }
 }
 
-fn arbitrary_value_for_type<R: Rng>(rng: &mut R, ty: &PirType) -> IrValue {
+fn arbitrary_value_for_type<R: Rng>(rng: &mut R, ty: &PirType) -> Result<IrValue> {
     match ty {
-        PirType::Token => IrValue::make_token(),
+        PirType::Token => Ok(IrValue::make_token()),
         PirType::Bits(width) => {
             let bits = arbitrary_irbits(rng, *width);
-            IrValue::from_bits(&bits)
+            Ok(IrValue::from_bits(&bits))
         }
         PirType::Tuple(elem_types) => {
-            let elems: Vec<IrValue> = elem_types
+            let elems: Result<Vec<IrValue>> = elem_types
                 .iter()
                 .map(|t| arbitrary_value_for_type(rng, t))
                 .collect();
-            IrValue::make_tuple(&elems)
+            Ok(IrValue::make_tuple(&elems?))
         }
         PirType::Array(arr) => {
+            if arr.element_count == 0 {
+                return Err(anyhow::anyhow!(
+                    "cannot construct random oracle sample for zero-length array type {}",
+                    ty
+                ));
+            }
             let mut elems: Vec<IrValue> = Vec::with_capacity(arr.element_count);
             for _ in 0..arr.element_count {
-                elems.push(arbitrary_value_for_type(rng, &arr.element_type));
+                elems.push(arbitrary_value_for_type(rng, &arr.element_type)?);
             }
-            IrValue::make_array(&elems).expect("array elements must be same-typed")
+            IrValue::make_array(&elems).map_err(|e| {
+                anyhow::anyhow!("failed to construct random array oracle sample: {}", e)
+            })
         }
     }
 }
@@ -1420,6 +1449,23 @@ fn eval_fn_safe(f: &IrFn, args: &[IrValue]) -> Result<IrValue, ()> {
         Ok(FnEvalResult::Success(s)) => Ok(s.value),
         Ok(FnEvalResult::Failure(_f)) => Err(()),
         Err(_panic) => Err(()),
+    }
+}
+
+fn make_oracle_args<F>(params: &[PirParam], label: &str, mut make_value: F) -> Option<Vec<IrValue>>
+where
+    F: FnMut(&PirType) -> Result<IrValue>,
+{
+    match params.iter().map(|p| make_value(&p.ty)).collect() {
+        Ok(args) => Some(args),
+        Err(e) => {
+            log::debug!(
+                "[pir-mcmc] failed to construct {} oracle sample args: {}; rejecting candidate",
+                label,
+                e
+            );
+            None
+        }
     }
 }
 
@@ -1440,16 +1486,14 @@ fn pir_equiv_oracle<R: Rng>(
     }
 
     // Deterministic corner cases first: all-zeros and all-ones.
-    let zeros_args: Vec<IrValue> = lhs
-        .params
-        .iter()
-        .map(|p| make_all_zeros_value(&p.ty))
-        .collect();
-    let ones_args: Vec<IrValue> = lhs
-        .params
-        .iter()
-        .map(|p| make_all_ones_value(&p.ty))
-        .collect();
+    let zeros_args = match make_oracle_args(&lhs.params, "all-zeros", make_all_zeros_value) {
+        Some(args) => args,
+        None => return false,
+    };
+    let ones_args = match make_oracle_args(&lhs.params, "all-ones", make_all_ones_value) {
+        Some(args) => args,
+        None => return false,
+    };
     for args in [&zeros_args, &ones_args] {
         let l = eval_fn_safe(lhs, args);
         let r = eval_fn_safe(rhs, args);
@@ -1465,11 +1509,12 @@ fn pir_equiv_oracle<R: Rng>(
 
     // Randomized sampling.
     for _ in 0..random_samples {
-        let args: Vec<IrValue> = lhs
-            .params
-            .iter()
-            .map(|p| arbitrary_value_for_type(rng, &p.ty))
-            .collect();
+        let args = match make_oracle_args(&lhs.params, "random", |ty| {
+            arbitrary_value_for_type(rng, ty)
+        }) {
+            Some(args) => args,
+            None => return false,
+        };
         let l = eval_fn_safe(lhs, &args);
         let r = eval_fn_safe(rhs, &args);
         match (l, r) {
@@ -2006,6 +2051,27 @@ mod tests {
             4,
             /* enable_formal_oracle= */ false,
         ));
+    }
+
+    #[test]
+    fn pir_equiv_oracle_rejects_zero_length_array_params_without_panic() {
+        let ir_text = r#"fn zero_len(a: bits[8][0] id=10) -> bits[1] {
+  ret literal.20: bits[1] = literal(value=0, id=20)
+}"#;
+        let mut parser1 = ir_parser::Parser::new(ir_text);
+        let lhs = parser1.parse_fn().unwrap();
+        let mut parser2 = ir_parser::Parser::new(ir_text);
+        let rhs = parser2.parse_fn().unwrap();
+
+        let mut rng = Pcg64Mcg::seed_from_u64(1);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            pir_equiv_oracle(
+                &lhs, &rhs, &mut rng, 4, /* enable_formal_oracle= */ false,
+            )
+        }));
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
     }
 
     #[test]

--- a/xlsynth-mcmc-pir/src/transforms/clone_multi_user_node.rs
+++ b/xlsynth-mcmc-pir/src/transforms/clone_multi_user_node.rs
@@ -24,12 +24,12 @@ impl PirTransform for CloneMultiUserNodeTransform {
                 // Do not clone parameter nodes; they are expected to always
                 // have names, and cloning them can violate invariants used by
                 // pretty-printing and other utilities.
-                let node = f.get_node(*nr);
+                let node = f.get_node(nr);
                 match &node.payload {
                     NodePayload::GetParam(_) => None,
                     NodePayload::Nil => None,
                     _ if users.len() > 1 => Some(TransformCandidate {
-                        location: TransformLocation::Node(*nr),
+                        location: TransformLocation::Node(nr),
                         always_equivalent,
                     }),
                     _ => None,

--- a/xlsynth-mcmc-pir/src/transforms/guarded_predicate_rewire.rs
+++ b/xlsynth-mcmc-pir/src/transforms/guarded_predicate_rewire.rs
@@ -22,10 +22,7 @@ impl GuardedPredicateRewireTransform {
         pairs
     }
 
-    fn compute_fanout_cone(
-        users_map: &std::collections::HashMap<NodeRef, HashSet<NodeRef>>,
-        root: NodeRef,
-    ) -> HashSet<NodeRef> {
+    fn compute_fanout_cone(users_map: &Users, root: NodeRef) -> HashSet<NodeRef> {
         let mut visited = HashSet::new();
         let mut work = VecDeque::new();
         visited.insert(root);
@@ -189,7 +186,7 @@ impl GuardedPredicateRewireTransform {
 
     fn append_arm_candidates(
         f: &IrFn,
-        users_map: &std::collections::HashMap<NodeRef, HashSet<NodeRef>>,
+        users_map: &Users,
         arm_root: NodeRef,
         arm_guard: Option<NodeRef>,
         guard_base: NodeRef,

--- a/xlsynth-mcmc-pir/src/transforms/mod.rs
+++ b/xlsynth-mcmc-pir/src/transforms/mod.rs
@@ -11,7 +11,7 @@ use xlsynth::{IrBits, IrValue};
 #[allow(unused_imports)]
 use xlsynth_pir::ir::{Binop, Fn as IrFn, NaryOp, Node, NodePayload, NodeRef, Type, Unop};
 #[allow(unused_imports)]
-use xlsynth_pir::ir_utils::{compute_users, remap_payload_with};
+use xlsynth_pir::ir_utils::{Users, compute_users, remap_payload_with};
 
 mod add_fission;
 mod add_sign_ext_u1_to_sub_zero_ext_u1;

--- a/xlsynth-mcmc-pir/src/transforms/rewire_operand_to_same_type.rs
+++ b/xlsynth-mcmc-pir/src/transforms/rewire_operand_to_same_type.rs
@@ -26,10 +26,7 @@ impl RewireOperandToSameTypeTransform {
         f.get_node(nr).ty.clone()
     }
 
-    fn compute_fanout_cone(
-        users_map: &std::collections::HashMap<NodeRef, HashSet<NodeRef>>,
-        root: NodeRef,
-    ) -> HashSet<NodeRef> {
+    fn compute_fanout_cone(users_map: &Users, root: NodeRef) -> HashSet<NodeRef> {
         let mut visited: HashSet<NodeRef> = HashSet::new();
         let mut work: VecDeque<NodeRef> = VecDeque::new();
         visited.insert(root);

--- a/xlsynth-mcmc-pir/src/transforms/sel_same_arms_fold.rs
+++ b/xlsynth-mcmc-pir/src/transforms/sel_same_arms_fold.rs
@@ -32,8 +32,7 @@ impl SelSameArmsFoldTransform {
         }
     }
 
-    fn compute_fanout_cone(f: &IrFn, root: NodeRef) -> HashSet<NodeRef> {
-        let users_map = compute_users(f);
+    fn compute_fanout_cone(users_map: &Users, root: NodeRef) -> HashSet<NodeRef> {
         let mut visited: HashSet<NodeRef> = HashSet::new();
         let mut work: VecDeque<NodeRef> = VecDeque::new();
         visited.insert(root);
@@ -59,6 +58,7 @@ impl PirTransform for SelSameArmsFoldTransform {
     fn find_candidates(&mut self, f: &IrFn) -> Vec<TransformCandidate> {
         let always_equivalent = true;
         let mut out = Vec::<TransformCandidate>::new();
+        let users_map = compute_users(f);
 
         for nr in f.node_refs() {
             let node = f.get_node(nr);
@@ -98,7 +98,7 @@ impl PirTransform for SelSameArmsFoldTransform {
                         continue;
                     };
 
-                    let fanout_cone = Self::compute_fanout_cone(f, nr);
+                    let fanout_cone = Self::compute_fanout_cone(&users_map, nr);
                     let mut chosen_p: Option<NodeRef> = None;
                     for cand in f.node_refs() {
                         if cand == nr {
@@ -178,7 +178,8 @@ impl PirTransform for SelSameArmsFoldTransform {
                     return Err("SelSameArmsFoldTransform: only supports bits[w] nodes".to_string());
                 };
 
-                let fanout_cone = Self::compute_fanout_cone(f, target_ref);
+                let users_map = compute_users(f);
+                let fanout_cone = Self::compute_fanout_cone(&users_map, target_ref);
                 let mut chosen_p: Option<NodeRef> = None;
                 for cand in f.node_refs() {
                     if cand == target_ref {

--- a/xlsynth-pir/Cargo.toml
+++ b/xlsynth-pir/Cargo.toml
@@ -24,6 +24,7 @@ rand_pcg = "0.3.1"
 tempfile = "3.20"
 bitvec = "1.0.1"
 sha2 = "0.10"
+smallvec = "1.13.2"
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/xlsynth-pir/src/ir_query.rs
+++ b/xlsynth-pir/src/ir_query.rs
@@ -4,8 +4,8 @@
 
 use crate::ir;
 use crate::ir_utils;
+use crate::ir_utils::Users;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use xlsynth::IrBits;
 use xlsynth::IrValue;
 
@@ -342,7 +342,7 @@ pub(crate) type QueryBindings = HashMap<String, Binding>;
 pub(crate) fn find_root_query_bindings(
     query: &QueryExpr,
     f: &ir::Fn,
-    users: &HashMap<ir::NodeRef, HashSet<ir::NodeRef>>,
+    users: &Users,
     node_ref: ir::NodeRef,
 ) -> Vec<QueryBindings> {
     let bindings = HashMap::new();
@@ -354,7 +354,7 @@ pub(crate) fn find_root_query_bindings(
 fn match_solutions(
     expr: &QueryExpr,
     f: &ir::Fn,
-    users: &HashMap<ir::NodeRef, HashSet<ir::NodeRef>>,
+    users: &Users,
     node_ref: ir::NodeRef,
     bindings: &Bindings,
 ) -> Vec<Bindings> {
@@ -753,7 +753,7 @@ fn match_args_solutions(
     args: &[QueryExpr],
     operands: &[ir::NodeRef],
     f: &ir::Fn,
-    users: &HashMap<ir::NodeRef, HashSet<ir::NodeRef>>,
+    users: &Users,
     bindings: &Bindings,
 ) -> Vec<Bindings> {
     if args.is_empty() {
@@ -790,7 +790,7 @@ fn match_args_with_ellipsis_solutions(
     pattern: &[QueryExpr],
     operands: &[ir::NodeRef],
     f: &ir::Fn,
-    users: &HashMap<ir::NodeRef, HashSet<ir::NodeRef>>,
+    users: &Users,
     bindings: &Bindings,
 ) -> Vec<Bindings> {
     fn non_ellipsis_count(p: &[QueryExpr]) -> usize {
@@ -803,7 +803,7 @@ fn match_args_with_ellipsis_solutions(
         pattern: &[QueryExpr],
         operands: &[ir::NodeRef],
         f: &ir::Fn,
-        users: &HashMap<ir::NodeRef, HashSet<ir::NodeRef>>,
+        users: &Users,
         pi: usize,
         oi: usize,
         bindings: &Bindings,
@@ -906,7 +906,7 @@ fn match_named_args_solutions(
     named_args: &[NamedArg],
     payload: &ir::NodePayload,
     f: &ir::Fn,
-    users: &HashMap<ir::NodeRef, HashSet<ir::NodeRef>>,
+    users: &Users,
     node_ref: ir::NodeRef,
     bindings: &Bindings,
 ) -> Vec<Bindings> {
@@ -1022,7 +1022,7 @@ fn match_select_named_arg(
     cases: &[ir::NodeRef],
     default: &Option<ir::NodeRef>,
     f: &ir::Fn,
-    users: &HashMap<ir::NodeRef, HashSet<ir::NodeRef>>,
+    users: &Users,
     bindings: &Bindings,
 ) -> Vec<Bindings> {
     match arg.name.as_str() {

--- a/xlsynth-pir/src/ir_rewrite.rs
+++ b/xlsynth-pir/src/ir_rewrite.rs
@@ -7,7 +7,8 @@ use crate::ir::{self, MemberType, NodePayload, NodeRef, Type};
 use crate::ir_deduce;
 use crate::ir_query;
 use crate::ir_utils;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use crate::ir_utils::Users;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::str::FromStr;
 use xlsynth::IrValue;
@@ -743,7 +744,7 @@ fn is_rewriteable_root(f: &ir::Fn, node_ref: NodeRef, ret_reachable: &[bool]) ->
 fn unique_bindings_at_root(
     query: &ir_query::QueryExpr,
     f: &ir::Fn,
-    users: &HashMap<NodeRef, HashSet<NodeRef>>,
+    users: &Users,
     node_ref: NodeRef,
 ) -> Result<Option<ir_query::QueryBindings>, MatchRewriteRuleApplyError> {
     let raw_bindings = ir_query::find_root_query_bindings(query, f, users, node_ref);

--- a/xlsynth-pir/src/ir_utils.rs
+++ b/xlsynth-pir/src/ir_utils.rs
@@ -3,7 +3,8 @@
 //! Utility functions for working with / on XLS IR.
 
 use crate::ir::{self, Fn, Node, NodePayload, NodeRef, Package, PackageMember, Type};
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use smallvec::SmallVec;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TrivialFnBody {
@@ -685,31 +686,66 @@ pub fn compact_and_toposort_with_mapping_in_place(
     Ok(old_to_new_refs)
 }
 
+pub type UserList = SmallVec<[NodeRef; 2]>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Users {
+    users: Vec<UserList>,
+}
+
+impl Users {
+    /// Returns the user list for `nr`, or `None` when `nr` is out of bounds.
+    pub fn get(&self, nr: &NodeRef) -> Option<&[NodeRef]> {
+        self.users.get(nr.index).map(|v| v.as_slice())
+    }
+
+    /// Returns the number of node entries in this users map.
+    pub fn len(&self) -> usize {
+        self.users.len()
+    }
+
+    /// Returns true when there are no node entries.
+    pub fn is_empty(&self) -> bool {
+        self.users.is_empty()
+    }
+
+    /// Iterates over all node refs and their direct users in node-index order.
+    pub fn iter(&self) -> impl Iterator<Item = (NodeRef, &[NodeRef])> {
+        self.users
+            .iter()
+            .enumerate()
+            .map(|(index, users)| (NodeRef { index }, users.as_slice()))
+    }
+}
+
 /// Computes the immediate users of each node in the function.
 ///
-/// Returns a mapping from each `NodeRef` to the set of `NodeRef`s that
-/// directly use it as an operand. Nodes with no users will map to an empty set.
-pub fn compute_users(f: &Fn) -> HashMap<NodeRef, HashSet<NodeRef>> {
+/// Returns dense indexed user lists for each `NodeRef`.
+///
+/// Each list is sorted and deduplicated, so a node that references the same
+/// operand multiple times is still recorded as one direct user of that operand.
+/// Nodes with no users map to an empty list.
+pub fn compute_users(f: &Fn) -> Users {
     let n = f.nodes.len();
-    let mut users: HashMap<NodeRef, HashSet<NodeRef>> = HashMap::with_capacity(n);
-
-    // Initialize all keys so even unreachable / sink nodes appear with empty sets.
-    for i in 0..n {
-        users.insert(NodeRef { index: i }, HashSet::new());
-    }
+    let mut users: Vec<UserList> = (0..n).map(|_| UserList::new()).collect();
 
     // For each node, add it as a user of each of its operands.
     for (i, node) in f.nodes.iter().enumerate() {
         let this_ref = NodeRef { index: i };
         for dep in operands(&node.payload) {
             users
-                .get_mut(&dep)
+                .get_mut(dep.index)
                 .expect("operand NodeRef must exist in users map")
-                .insert(this_ref);
+                .push(this_ref);
         }
     }
 
-    users
+    for user_list in &mut users {
+        user_list.sort_by_key(|nr| nr.index);
+        user_list.dedup();
+    }
+
+    Users { users }
 }
 
 /// Replaces the payload (and optionally the type) of `target` in `f`.
@@ -1885,5 +1921,31 @@ mod users_tests {
         assert!(users.get(&b).unwrap().contains(&and));
         assert!(users.get(&and).unwrap().contains(&ret));
         assert!(users.get(&ret).unwrap().is_empty());
+    }
+
+    #[test]
+    fn users_deduplicates_repeated_operand_uses() {
+        let f = parse_fn(
+            r#"fn f(x: bits[1] id=1) -> bits[1] {
+  ret add.2: bits[1] = add(x, x, id=2)
+}"#,
+        );
+        let users = compute_users(&f);
+
+        let mut x_ref: Option<NodeRef> = None;
+        let mut add_ref: Option<NodeRef> = None;
+        for (i, node) in f.nodes.iter().enumerate() {
+            match &node.payload {
+                NodePayload::GetParam(_) => x_ref = Some(NodeRef { index: i }),
+                NodePayload::Binop(_, lhs, rhs) if lhs == rhs => {
+                    add_ref = Some(NodeRef { index: i })
+                }
+                _ => {}
+            }
+        }
+
+        let x = x_ref.expect("expected param node");
+        let add = add_ref.expect("expected repeated-operand add");
+        assert_eq!(users.get(&x).unwrap(), &[add]);
     }
 }

--- a/xlsynth-pir/src/structural_similarity.rs
+++ b/xlsynth-pir/src/structural_similarity.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 
 use crate::ir::{Fn, Node, NodePayload, NodeRef, Param, ParamId, Type, node_textual_id};
 use crate::ir_utils::{
-    compute_users, get_topological, is_valid_identifier_name, operands, remap_payload_with,
+    Users, compute_users, get_topological, is_valid_identifier_name, operands, remap_payload_with,
     sanitize_text_id_to_identifier_name,
 };
 use crate::node_hashing::{
@@ -847,7 +847,7 @@ pub fn compute_dual_difference_regions(lhs: &Fn, rhs: &Fn) -> (HashSet<NodeRef>,
 fn compute_region_boundary_nodes(
     f: &Fn,
     region: &HashSet<NodeRef>,
-    users_map: &HashMap<NodeRef, HashSet<NodeRef>>,
+    users_map: &Users,
 ) -> Vec<NodeRef> {
     let mut boundary: Vec<NodeRef> = Vec::new();
     for nr in region.iter() {


### PR DESCRIPTION
The new form is much faster to compute, and user membership testing is not done frequently so the O(log n) vs O(1) membership testing is a better tradeoff.