### PR TITLE
Unify gate-level formal backend selection.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Reduce the size of Cargo artifacts while preserving debug_asserts, etc, that
+  # would not be included in a release build.
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
+
 jobs:
   # -----------------------------------------------------------
   # 1) Lint-check / pre-commit gate on Ubuntu

--- a/scripts/run_valgrind_on_tests.py
+++ b/scripts/run_valgrind_on_tests.py
@@ -139,8 +139,8 @@ TEST_BINARY_CONFIGS: Dict[str, TestBinaryConfig] = {
             # Newly observed >300s cases
             "ir2gate_utils::tests::test_gatify_add_kogge_stone_1_to_16",
             "ir2gate_utils::tests::test_gatify_add_brent_kung_1_to_16",
-            "prove_gate_fn_equiv_varisat::tests::test_validate_equiv_bf16_mul",
-            "prove_gate_fn_equiv_varisat::tests::test_validate_equiv_bf16_add",
+            "prove_gate_fn_equiv_sat::tests::test_validate_equiv_bf16_mul",
+            "prove_gate_fn_equiv_sat::tests::test_validate_equiv_bf16_add",
         ],
         "shard_test_cases": True,
     },

--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -1323,8 +1323,9 @@ Supported flags include the common gate-optimization controls:
 - `--max-fraig-sim-samples=<N>` – maximum number of random simulation samples
   used for FRAIG candidate discovery. The uncapped count is scaled from the
   live node count and rounded to a SIMD batch boundary; default `8192`.
-- `--fraig-validation-backend=<cadical|varisat>` – SAT backend for validating
-  FRAIG equivalence classes (default `cadical`).
+- `--gate-formal-backend=<cadical|varisat|z3|ir>` – formal backend for
+  gate-level proof steps (default `cadical`). For FRAIG validation, `z3` and
+  `ir` use a slower pairwise validation path.
 - `--toggle-sample-count=<N>` – if non-zero, generate `N` random samples and
   report toggle statistics.
 - `--toggle-seed=<SEED>` – seed for toggle sampling (default `0`).
@@ -1682,12 +1683,14 @@ an existing internal AIG node, so downstream passes can potentially reuse logic.
 The flow is:
 
 - Simulate PIR and AIG over random inputs to propose candidate correspondences.
-- Use Varisat to prove or refute each candidate in bulk (incremental SAT).
+- Use the selected gate formal backend to prove or refute each candidate.
+  `cadical` and `varisat` use the bulk incremental SAT path; `z3` and `ir` use
+  a pairwise proof path.
 
 Example:
 
 ```shell
-xlsynth-driver ir-aig-sharing my_design.ir my_design.aig --samples 256 --seed 0 --max-proofs 200 --print-mappings 0 --output-json report.json
+xlsynth-driver ir-aig-sharing my_design.ir my_design.aig --samples 256 --seed 0 --max-proofs 200 --gate-formal-backend cadical --print-mappings 0 --output-json report.json
 ```
 
 ### `dslx-equiv`

--- a/xlsynth-driver/src/g8r_cli.rs
+++ b/xlsynth-driver/src/g8r_cli.rs
@@ -10,7 +10,7 @@ use xlsynth_g8r::gatify::prep_for_gatify::PrepForGatifyOptions;
 use xlsynth_g8r::ir2gate_utils::AdderMapping;
 use xlsynth_g8r::process_ir_path;
 use xlsynth_g8r::process_ir_path::DEFAULT_MAX_FRAIG_SIM_SAMPLES;
-use xlsynth_g8r::prove_gate_fn_equiv_varisat::ValidationBackend;
+use xlsynth_g8r::prove_gate_fn_equiv_common::GateFormalBackend;
 
 fn parse_adder_mapping(value: Option<&str>) -> AdderMapping {
     match value {
@@ -106,15 +106,15 @@ fn parse_optional_usize_or_exit(
     }
 }
 
-fn parse_validation_backend_or_exit(matches: &ArgMatches) -> ValidationBackend {
+fn parse_gate_formal_backend_or_exit(matches: &ArgMatches) -> GateFormalBackend {
     let value = matches
-        .get_one::<String>("fraig_validation_backend")
+        .get_one::<String>("gate_formal_backend")
         .map(|s| s.as_str())
-        .unwrap_or(ValidationBackend::default().as_str());
-    match ValidationBackend::parse(value) {
+        .unwrap_or(GateFormalBackend::default().as_str());
+    match GateFormalBackend::parse(value) {
         Ok(backend) => backend,
         Err(_) => {
-            eprintln!("Invalid --fraig-validation-backend: {:?}", value);
+            eprintln!("Invalid --gate-formal-backend: {:?}", value);
             std::process::exit(1);
         }
     }
@@ -137,7 +137,7 @@ pub(crate) struct G8rCliOptions {
     pub(crate) graph_logical_effort_beta2: f64,
     pub(crate) fraig_max_iterations: Option<usize>,
     pub(crate) max_fraig_sim_samples: usize,
-    pub(crate) fraig_validation_backend: ValidationBackend,
+    pub(crate) gate_formal_backend: GateFormalBackend,
 }
 
 pub(crate) fn parse_g8r_cli_options(matches: &ArgMatches) -> G8rCliOptions {
@@ -193,7 +193,7 @@ pub(crate) fn parse_g8r_cli_options(matches: &ArgMatches) -> G8rCliOptions {
         "--max-fraig-sim-samples",
         DEFAULT_MAX_FRAIG_SIM_SAMPLES,
     );
-    let fraig_validation_backend = parse_validation_backend_or_exit(matches);
+    let gate_formal_backend = parse_gate_formal_backend_or_exit(matches);
 
     G8rCliOptions {
         fold,
@@ -212,7 +212,7 @@ pub(crate) fn parse_g8r_cli_options(matches: &ArgMatches) -> G8rCliOptions {
         graph_logical_effort_beta2,
         fraig_max_iterations,
         max_fraig_sim_samples,
-        fraig_validation_backend,
+        gate_formal_backend,
     }
 }
 
@@ -240,7 +240,7 @@ pub(crate) fn build_process_ir_path_options_for_cli(
         ir_top: ir_top.map(|s| s.to_string()),
         fraig_max_iterations: cli.fraig_max_iterations,
         max_fraig_sim_samples: Some(cli.max_fraig_sim_samples),
-        fraig_validation_backend: cli.fraig_validation_backend,
+        gate_formal_backend: cli.gate_formal_backend,
         quiet,
         emit_netlist,
         toggle_sample_count: cli.toggle_sample_count,

--- a/xlsynth-driver/src/ir_aig_sharing.rs
+++ b/xlsynth-driver/src/ir_aig_sharing.rs
@@ -11,9 +11,10 @@ use xlsynth_g8r::gate_builder::GateBuilderOptions;
 use xlsynth_g8r::gatify::ir2gate::GatifyOptions;
 use xlsynth_g8r::ir2gate_utils::AdderMapping;
 use xlsynth_g8r::ir_aig_sharing::{
-    get_equivalences, prove_equivalence_candidates_varisat_streaming, CandidateProofResult,
+    get_equivalences, prove_equivalence_candidates_with_backend_streaming, CandidateProofResult,
     IrAigCandidateRhs, IrAigSharingOptions,
 };
+use xlsynth_g8r::prove_gate_fn_equiv_common::GateFormalBackend;
 use xlsynth_pir::ir;
 use xlsynth_pir::ir_parser;
 use xlsynth_pir::ir_utils::is_structural_payload;
@@ -54,6 +55,7 @@ struct JsonOptions {
     seed: u64,
     exclude_structural_pir_nodes: bool,
     max_proofs: usize,
+    gate_formal_backend: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -193,6 +195,10 @@ pub fn handle_ir_aig_sharing(matches: &ArgMatches, _config: &Option<ToolchainCon
         .get_one::<String>("max_proofs")
         .map(|s| s.parse::<usize>().unwrap_or(0))
         .unwrap_or(0);
+    let gate_formal_backend = matches
+        .get_one::<String>("gate_formal_backend")
+        .map(|s| GateFormalBackend::parse(s).expect("validated by clap value_parser"))
+        .unwrap_or_default();
     let print_limit = matches
         .get_one::<String>("print")
         .map(|s| s.parse::<usize>().unwrap_or(0))
@@ -361,11 +367,12 @@ pub fn handle_ir_aig_sharing(matches: &ArgMatches, _config: &Option<ToolchainCon
         *current_any_proved = false;
     };
 
-    let proofs = match prove_equivalence_candidates_varisat_streaming(
+    let proofs = match prove_equivalence_candidates_with_backend_streaming(
         &pir_fn,
         &gate_fn,
         &candidates,
         &gatify_opts,
+        gate_formal_backend,
         |p| {
             // Proof stats.
             match &p.result {
@@ -521,6 +528,7 @@ pub fn handle_ir_aig_sharing(matches: &ArgMatches, _config: &Option<ToolchainCon
                 seed: sample_seed,
                 exclude_structural_pir_nodes: exclude_structural,
                 max_proofs,
+                gate_formal_backend: gate_formal_backend.as_str().to_string(),
             },
             stats: JsonStats {
                 candidates: proofs.len(),

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -379,11 +379,11 @@ impl AppExt for clap::Command {
                     .action(clap::ArgAction::Set),
             )
             .arg(
-                clap::Arg::new("fraig_validation_backend")
-                    .long("fraig-validation-backend")
+                clap::Arg::new("gate_formal_backend")
+                    .long("gate-formal-backend")
                     .value_name("BACKEND")
-                    .help("SAT backend for validating FRAIG equivalence classes (default: cadical)")
-                    .value_parser(["cadical", "varisat"])
+                    .help("Formal backend for gate-level proof steps (default: cadical)")
+                    .value_parser(["cadical", "varisat", "z3", "ir"])
                     .default_value("cadical")
                     .action(clap::ArgAction::Set),
             )
@@ -2384,6 +2384,15 @@ interpreted before lift. See docs/bit_blasted_output_ordering.md, section
                         .long("max-proofs")
                         .value_name("N")
                         .help("Limit number of candidates to prove (0 = no limit)")
+                        .action(clap::ArgAction::Set),
+                )
+                .arg(
+                    clap::Arg::new("gate_formal_backend")
+                        .long("gate-formal-backend")
+                        .value_name("BACKEND")
+                        .help("Formal backend for gate-level proof steps (default: cadical)")
+                        .value_parser(["cadical", "varisat", "z3", "ir"])
+                        .default_value("cadical")
                         .action(clap::ArgAction::Set),
                 )
                 .arg(

--- a/xlsynth-g8r/benches/mcmc_benchmark.rs
+++ b/xlsynth-g8r/benches/mcmc_benchmark.rs
@@ -11,6 +11,7 @@ use xlsynth_g8r::mcmc_logic::{
     McmcContext, McmcIterationOutput, Objective, build_transform_weights, cost, load_start,
     mcmc_iteration,
 };
+use xlsynth_g8r::prove_gate_fn_equiv_common::GateFormalBackend;
 use xlsynth_g8r::transforms::get_all_transforms;
 use xlsynth_pir::fuzz_utils;
 
@@ -100,6 +101,7 @@ fn benchmark_mcmc_iteration(c: &mut Criterion) {
                     rng: &mut rng,
                     all_transforms,
                     weights,
+                    gate_formal_backend: GateFormalBackend::default(),
                 };
                 let _result: McmcIterationOutput = mcmc_iteration(
                     current_gfn,

--- a/xlsynth-g8r/benches/mcmc_benchmark.rs
+++ b/xlsynth-g8r/benches/mcmc_benchmark.rs
@@ -114,7 +114,8 @@ fn benchmark_mcmc_iteration(c: &mut Criterion) {
                     false,
                     &simd_inputs,
                     &baseline_outputs,
-                );
+                )
+                .expect("MCMC iteration should not hit a formal backend error");
             },
             criterion::BatchSize::SmallInput,
         );

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_cut_db_rewrite_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_cut_db_rewrite_equiv.rs
@@ -8,7 +8,7 @@ use std::sync::OnceLock;
 use xlsynth_g8r::aig::cut_db_rewrite::{RewriteOptions, rewrite_gatefn_with_cut_db};
 use xlsynth_g8r::cut_db::loader::CutDb;
 use xlsynth_g8r::prove_gate_fn_equiv_common::EquivResult;
-use xlsynth_g8r::prove_gate_fn_equiv_varisat::{Ctx as VarisatCtx, prove_gate_fn_equiv as prove_sat};
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{Ctx as VarisatCtx, prove_gate_fn_equiv as prove_sat};
 use xlsynth_g8r_fuzz::{FuzzGraph, build_graph};
 
 static CUT_DB_BYTES: &[u8] = include_bytes!("../../data/cut_db_v1.bin");

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_arbitrary.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_arbitrary.rs
@@ -9,7 +9,7 @@ use rand::seq::IteratorRandom;
 #[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
 use xlsynth_g8r::prove_gate_fn_equiv_common::EquivResult;
 #[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
-use xlsynth_g8r::prove_gate_fn_equiv_varisat::{
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{
     Ctx as VarisatCtx, prove_gate_fn_equiv as prove_sat,
 };
 #[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]

--- a/xlsynth-g8r/src/aig/fraig.rs
+++ b/xlsynth-g8r/src/aig/fraig.rs
@@ -22,12 +22,9 @@ use crate::aig::bulk_replace::{SubstitutionMap, bulk_replace};
 use crate::aig::get_summary_stats::{GateDepthStats, get_gate_depth};
 use crate::aig::{AigOperand, AigRef, GateFn};
 use crate::{
-    gate_builder::GateBuilderOptions,
-    propose_equiv::EquivNode,
-    propose_equiv::propose_equivalence_classes,
-    prove_gate_fn_equiv_varisat::{
-        ValidationBackend, validate_equivalence_classes_presorted_with_backend,
-    },
+    gate_builder::GateBuilderOptions, propose_equiv::EquivNode,
+    propose_equiv::propose_equivalence_classes, prove_gate_fn_equiv_common::GateFormalBackend,
+    prove_gate_fn_equiv_sat::validate_equivalence_classes_presorted_with_backend,
 };
 
 /// Number of proposed equivalence classes validated before applying
@@ -202,17 +199,17 @@ pub fn fraig_optimize(
         f,
         input_sample_count,
         iteration_bounds,
-        ValidationBackend::default(),
+        GateFormalBackend::Cadical,
         rng,
     )
 }
 
-/// Runs FRAIG using an explicit SAT backend for equivalence validation.
+/// Runs FRAIG using an explicit formal backend for equivalence validation.
 pub fn fraig_optimize_with_backend(
     f: &GateFn,
     input_sample_count: usize,
     iteration_bounds: IterationBounds,
-    validation_backend: ValidationBackend,
+    validation_backend: GateFormalBackend,
     rng: &mut impl Rng,
 ) -> Result<(GateFn, DidConverge, Vec<FraigIterationStat>), Box<dyn Error>> {
     let mut iteration_count = 0;

--- a/xlsynth-g8r/src/bin/g8r-equivalent.rs
+++ b/xlsynth-g8r/src/bin/g8r-equivalent.rs
@@ -16,7 +16,7 @@ use clap::Parser;
 
 use xlsynth_g8r::aig::GateFn;
 use xlsynth_g8r::mcmc_logic::oracle_equiv_sat;
-use xlsynth_g8r::prove_gate_fn_equiv_varisat::{self, EquivResult};
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{self, EquivResult};
 
 /// Simple CLI to compare two GateFns.
 #[derive(Parser, Debug)]
@@ -81,9 +81,9 @@ fn main() {
 
     // Checker 3: Varisat-based SAT prover (structural)
     let varisat_equiv = {
-        let mut ctx = prove_gate_fn_equiv_varisat::Ctx::new();
+        let mut ctx = prove_gate_fn_equiv_sat::Ctx::new();
         matches!(
-            prove_gate_fn_equiv_varisat::prove_gate_fn_equiv(&lhs, &rhs, &mut ctx),
+            prove_gate_fn_equiv_sat::prove_gate_fn_equiv(&lhs, &rhs, &mut ctx),
             EquivResult::Proved
         )
     };

--- a/xlsynth-g8r/src/bin/g8r-equivalent.rs
+++ b/xlsynth-g8r/src/bin/g8r-equivalent.rs
@@ -66,7 +66,13 @@ fn main() {
     };
 
     // Checker 1: SAT/Z3 oracle (fast path)
-    let sat_equiv = oracle_equiv_sat(&lhs, &rhs);
+    let sat_equiv = match oracle_equiv_sat(&lhs, &rhs) {
+        Ok(equiv) => equiv,
+        Err(e) => {
+            eprintln!("SAT/Z3 oracle error: {}", e);
+            exit(2);
+        }
+    };
     println!("SAT/Z3 oracle: {}", sat_equiv);
 
     // Checker 2: IR-based equivalence.

--- a/xlsynth-g8r/src/bin/mcmc-driver.rs
+++ b/xlsynth-g8r/src/bin/mcmc-driver.rs
@@ -16,9 +16,10 @@ use tempfile::Builder;
 use xlsynth_g8r::aig::GateFn;
 use xlsynth_g8r::aig::get_summary_stats::SummaryStats;
 
-use xlsynth_g8r::aig::fraig::{IterationBounds, fraig_optimize};
+use xlsynth_g8r::aig::fraig::{IterationBounds, fraig_optimize_with_backend};
 use xlsynth_g8r::aig::get_summary_stats;
 use xlsynth_g8r::mcmc_logic::{Best, McmcOptions, Objective, cost, load_start, mcmc};
+use xlsynth_g8r::prove_gate_fn_equiv_common::GateFormalBackend;
 
 use std::time::{Duration, Instant};
 
@@ -120,6 +121,10 @@ struct CliArgs {
     /// Strategy for running multiple MCMC chains
     #[clap(long, value_enum, default_value_t = ChainStrategy::Independent)]
     chain_strategy: ChainStrategy,
+
+    /// Formal backend for gate-level proof steps.
+    #[clap(long, default_value = GateFormalBackend::DEFAULT_CLI_VALUE, value_parser = GateFormalBackend::CLI_VALUES)]
+    gate_formal_backend: String,
 }
 
 fn run_chain_segment(
@@ -149,6 +154,7 @@ fn run_chain_segment(
         Some(best),
         Some(chain_no),
         options,
+        GateFormalBackend::parse(&cfg.gate_formal_backend).expect("validated by clap value_parser"),
     )
 }
 
@@ -186,10 +192,12 @@ fn run_chain(
     };
     let fraig_gfn = {
         let mut rng_f = Pcg64Mcg::seed_from_u64(seed);
-        match fraig_optimize(
+        match fraig_optimize_with_backend(
             &gfn,
             64, // sample count
             IterationBounds::MaxIterations(1),
+            GateFormalBackend::parse(&cfg.gate_formal_backend)
+                .expect("validated by clap value_parser"),
             &mut rng_f,
         ) {
             Ok((g, _conv, _stats)) => g,
@@ -280,10 +288,12 @@ fn run_explore_exploit(
                         };
                         let fraig_gfn = {
                             let mut rng_f = Pcg64Mcg::seed_from_u64(seed ^ iter_offset);
-                            match fraig_optimize(
+                            match fraig_optimize_with_backend(
                                 &local_gfn,
                                 64, // sample count
                                 IterationBounds::MaxIterations(1),
+                                GateFormalBackend::parse(&cfg_cl.gate_formal_backend)
+                                    .expect("validated by clap value_parser"),
                                 &mut rng_f,
                             ) {
                                 Ok((g, _conv, _stats)) => g,

--- a/xlsynth-g8r/src/gate_fn_equiv_report.rs
+++ b/xlsynth-g8r/src/gate_fn_equiv_report.rs
@@ -2,7 +2,7 @@
 
 use crate::aig::GateFn;
 use crate::check_equivalence::{self, IrCheckResult};
-use crate::prove_gate_fn_equiv_varisat::{self, EquivResult};
+use crate::prove_gate_fn_equiv_sat::{self, EquivResult};
 #[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
 use crate::prove_gate_fn_equiv_z3;
 use serde::{Deserialize, Serialize};
@@ -51,8 +51,8 @@ pub fn prove_gate_fn_equiv_report(lhs: &GateFn, rhs: &GateFn) -> EquivReport {
     results.insert("ir".to_string(), ir_checker);
 
     let varisat = {
-        let mut ctx = prove_gate_fn_equiv_varisat::Ctx::new();
-        match prove_gate_fn_equiv_varisat::prove_gate_fn_equiv(lhs, rhs, &mut ctx) {
+        let mut ctx = prove_gate_fn_equiv_sat::Ctx::new();
+        match prove_gate_fn_equiv_sat::prove_gate_fn_equiv(lhs, rhs, &mut ctx) {
             EquivResult::Proved => EngineResult::Equiv,
             EquivResult::Disproved(cex) => EngineResult::NotEquiv(Some(format!("{:?}", cex))),
         }

--- a/xlsynth-g8r/src/ir_aig_sharing.rs
+++ b/xlsynth-g8r/src/ir_aig_sharing.rs
@@ -13,6 +13,7 @@
 //! A later step can use a solver to confirm or refute each candidate.
 
 use std::collections::HashMap;
+use std::ops::Not;
 
 use rand_xoshiro::Xoshiro256PlusPlus;
 use rand_xoshiro::rand_core::RngCore;
@@ -26,11 +27,14 @@ use xlsynth_pir::ir_eval;
 use xlsynth_pir::ir_utils::is_structural_payload;
 use xlsynth_pir::ir_value_utils::flatten_ir_value_to_lsb0_bits_for_type;
 
-use crate::aig::gate::{AigNode, AigOperand, AigRef, GateFn};
+use crate::aig::gate::{AigBitVector, AigNode, AigOperand, AigRef, GateFn, Output, PirNodeIds};
 use crate::aig::topo::topo_sort_refs;
 use crate::gatify::ir2gate::{GatifyOptions, gatify};
 use crate::ir2gate_utils::AdderMapping;
-use varisat::ExtendFormula;
+use crate::prove_gate_fn_equiv_common::{EquivResult, GateFormalBackend};
+use crate::prove_gate_fn_equiv_sat::{
+    CadicalSat, IncrementalSat, SatModel, SatSolveResult, prove_gate_fn_equiv_with_backend,
+};
 use varisat::Solver;
 
 #[derive(Debug, Clone)]
@@ -379,26 +383,107 @@ pub fn prove_equivalence_candidates_varisat(
     )
 }
 
-/// Streaming variant of `prove_equivalence_candidates_varisat`.
-///
-/// Calls `on_proof` as each candidate is proved/disproved/skipped, in the same
-/// order as `candidates`.
-pub fn prove_equivalence_candidates_varisat_streaming<F>(
+/// Proves (or disproves) equivalence for all candidates using CaDiCaL.
+pub fn prove_equivalence_candidates_cadical(
     pir_fn: &ir::Fn,
     gate_fn: &GateFn,
     candidates: &[IrAigEquivalenceCandidate],
     gatify_options: &GatifyOptions,
+) -> Result<Vec<CandidateProof>, String> {
+    prove_equivalence_candidates_cadical_streaming(
+        pir_fn,
+        gate_fn,
+        candidates,
+        gatify_options,
+        |_p| {},
+    )
+}
+
+/// Proves candidates using the selected backend.
+pub fn prove_equivalence_candidates_with_backend_streaming<F>(
+    pir_fn: &ir::Fn,
+    gate_fn: &GateFn,
+    candidates: &[IrAigEquivalenceCandidate],
+    gatify_options: &GatifyOptions,
+    backend: GateFormalBackend,
+    on_proof: F,
+) -> Result<Vec<CandidateProof>, String>
+where
+    F: FnMut(&CandidateProof),
+{
+    match backend {
+        GateFormalBackend::Varisat => prove_equivalence_candidates_varisat_streaming(
+            pir_fn,
+            gate_fn,
+            candidates,
+            gatify_options,
+            on_proof,
+        ),
+        GateFormalBackend::Cadical => prove_equivalence_candidates_cadical_streaming(
+            pir_fn,
+            gate_fn,
+            candidates,
+            gatify_options,
+            on_proof,
+        ),
+        GateFormalBackend::Z3 | GateFormalBackend::Ir => {
+            prove_equivalence_candidates_pairwise_streaming(
+                pir_fn,
+                gate_fn,
+                candidates,
+                gatify_options,
+                backend,
+                on_proof,
+            )
+        }
+    }
+}
+
+fn gate_fn_with_single_output(gate_fn: &GateFn, operand: AigOperand, output_name: &str) -> GateFn {
+    let mut out = gate_fn.clone();
+    out.outputs = vec![Output {
+        name: output_name.to_string(),
+        bit_vector: AigBitVector::from_bit(operand),
+    }];
+    out
+}
+
+fn gate_fn_with_rhs_output(gate_fn: &GateFn, rhs: IrAigCandidateRhs) -> GateFn {
+    match rhs {
+        IrAigCandidateRhs::AigOperand(op) => gate_fn_with_single_output(gate_fn, op, "gate"),
+        IrAigCandidateRhs::Const(value) => {
+            let mut out = gate_fn.clone();
+            let literal_ref = AigRef {
+                id: out.gates.len(),
+            };
+            out.gates.push(AigNode::Literal {
+                value,
+                pir_node_ids: PirNodeIds::new(),
+            });
+            out.outputs = vec![Output {
+                name: "gate".to_string(),
+                bit_vector: AigBitVector::from_bit(AigOperand::from(literal_ref)),
+            }];
+            out
+        }
+    }
+}
+
+fn prove_equivalence_candidates_pairwise_streaming<F>(
+    pir_fn: &ir::Fn,
+    gate_fn: &GateFn,
+    candidates: &[IrAigEquivalenceCandidate],
+    gatify_options: &GatifyOptions,
+    backend: GateFormalBackend,
     mut on_proof: F,
 ) -> Result<Vec<CandidateProof>, String>
 where
     F: FnMut(&CandidateProof),
 {
-    // Gatify PIR once to get a GateFn and a per-node lowering map.
     let gatify_output = gatify(pir_fn, gatify_options.clone())?;
     let pir_gate_fn = gatify_output.gate_fn;
     let lowering_map = gatify_output.lowering_map;
 
-    // Ensure input shapes match so a single shared input vector drives both.
     if pir_gate_fn.inputs.len() != gate_fn.inputs.len() {
         return Err(format!(
             "gate input arity mismatch: pir_gate_fn has {} inputs but gate_fn has {}",
@@ -422,26 +507,168 @@ where
         }
     }
 
+    let mut results = Vec::with_capacity(candidates.len());
+    for cand in candidates {
+        let Some(pir_bv) = lowering_map.get(&cand.pir_node_ref) else {
+            let proof = CandidateProof {
+                candidate: cand.clone(),
+                result: CandidateProofResult::Skipped {
+                    reason: format!(
+                        "missing lowering_map entry for pir_node_text_id={}",
+                        cand.pir_node_text_id
+                    ),
+                },
+            };
+            on_proof(&proof);
+            results.push(proof);
+            continue;
+        };
+        if cand.bit_index >= pir_bv.get_bit_count() {
+            let proof = CandidateProof {
+                candidate: cand.clone(),
+                result: CandidateProofResult::Skipped {
+                    reason: format!(
+                        "bit_index {} out of range for pir node bits[{}] (node_text_id={})",
+                        cand.bit_index,
+                        pir_bv.get_bit_count(),
+                        cand.pir_node_text_id
+                    ),
+                },
+            };
+            on_proof(&proof);
+            results.push(proof);
+            continue;
+        }
+
+        let pir_op: AigOperand = *pir_bv.get_lsb(cand.bit_index);
+        let pir_single = gate_fn_with_single_output(&pir_gate_fn, pir_op, "pir");
+        let gate_single = gate_fn_with_rhs_output(gate_fn, cand.rhs);
+        let result = match prove_gate_fn_equiv_with_backend(&pir_single, &gate_single, backend)
+            .map_err(|e| format!("{} proof error: {}", backend.as_str(), e))?
+        {
+            EquivResult::Proved => CandidateProofResult::Proved,
+            EquivResult::Disproved(counterexample_inputs) => CandidateProofResult::Disproved {
+                counterexample_inputs,
+            },
+        };
+        let proof = CandidateProof {
+            candidate: cand.clone(),
+            result,
+        };
+        on_proof(&proof);
+        results.push(proof);
+    }
+
+    Ok(results)
+}
+
+/// Streaming variant of `prove_equivalence_candidates_varisat`.
+///
+/// Calls `on_proof` as each candidate is proved/disproved/skipped, in the same
+/// order as `candidates`.
+pub fn prove_equivalence_candidates_varisat_streaming<F>(
+    pir_fn: &ir::Fn,
+    gate_fn: &GateFn,
+    candidates: &[IrAigEquivalenceCandidate],
+    gatify_options: &GatifyOptions,
+    on_proof: F,
+) -> Result<Vec<CandidateProof>, String>
+where
+    F: FnMut(&CandidateProof),
+{
     let mut solver = Solver::new();
+    prove_equivalence_candidates_incremental_sat_streaming(
+        pir_fn,
+        gate_fn,
+        candidates,
+        gatify_options,
+        &mut solver,
+        "varisat",
+        on_proof,
+    )
+}
+
+/// Streaming variant of `prove_equivalence_candidates_cadical`.
+pub fn prove_equivalence_candidates_cadical_streaming<F>(
+    pir_fn: &ir::Fn,
+    gate_fn: &GateFn,
+    candidates: &[IrAigEquivalenceCandidate],
+    gatify_options: &GatifyOptions,
+    on_proof: F,
+) -> Result<Vec<CandidateProof>, String>
+where
+    F: FnMut(&CandidateProof),
+{
+    let mut solver = CadicalSat::new().map_err(|e| format!("cadical setup error: {e}"))?;
+    prove_equivalence_candidates_incremental_sat_streaming(
+        pir_fn,
+        gate_fn,
+        candidates,
+        gatify_options,
+        &mut solver,
+        "cadical",
+        on_proof,
+    )
+}
+
+fn prove_equivalence_candidates_incremental_sat_streaming<S, F>(
+    pir_fn: &ir::Fn,
+    gate_fn: &GateFn,
+    candidates: &[IrAigEquivalenceCandidate],
+    gatify_options: &GatifyOptions,
+    solver: &mut S,
+    solver_name: &'static str,
+    mut on_proof: F,
+) -> Result<Vec<CandidateProof>, String>
+where
+    S: IncrementalSat,
+    F: FnMut(&CandidateProof),
+{
+    let gatify_output = gatify(pir_fn, gatify_options.clone())?;
+    let pir_gate_fn = gatify_output.gate_fn;
+    let lowering_map = gatify_output.lowering_map;
+
+    if pir_gate_fn.inputs.len() != gate_fn.inputs.len() {
+        return Err(format!(
+            "gate input arity mismatch: pir_gate_fn has {} inputs but gate_fn has {}",
+            pir_gate_fn.inputs.len(),
+            gate_fn.inputs.len()
+        ));
+    }
+    for (i, (a, b)) in pir_gate_fn
+        .inputs
+        .iter()
+        .zip(gate_fn.inputs.iter())
+        .enumerate()
+    {
+        if a.get_bit_count() != b.get_bit_count() {
+            return Err(format!(
+                "gate input width mismatch at input {}: pir_gate_fn bits[{}] vs gate_fn bits[{}]",
+                i,
+                a.get_bit_count(),
+                b.get_bit_count()
+            ));
+        }
+    }
 
     // Dedicated constant literals (so we can prove "PIR bit is constant 0/1").
-    let const_true = solver.new_lit();
-    solver.add_clause(&[const_true]);
-    let const_false = solver.new_lit();
-    solver.add_clause(&[!const_false]);
+    let const_true = solver.sat_new_lit();
+    solver.sat_add_clause(&[const_true]);
+    let const_false = solver.sat_new_lit();
+    solver.sat_add_clause(&[!const_false]);
 
     // Shared input literals: [input_port][bit_index_lsb0]
-    let mut input_lits: Vec<Vec<varisat::Lit>> = Vec::with_capacity(gate_fn.inputs.len());
+    let mut input_lits: Vec<Vec<S::Lit>> = Vec::with_capacity(gate_fn.inputs.len());
     for inp in gate_fn.inputs.iter() {
-        let mut bits: Vec<varisat::Lit> = Vec::with_capacity(inp.get_bit_count());
+        let mut bits: Vec<S::Lit> = Vec::with_capacity(inp.get_bit_count());
         for _ in 0..inp.get_bit_count() {
-            bits.push(solver.new_lit());
+            bits.push(solver.sat_new_lit());
         }
         input_lits.push(bits);
     }
 
-    let pir_lits = encode_gate_fn_all_nodes(&mut solver, &pir_gate_fn, &input_lits)?;
-    let gate_lits = encode_gate_fn_all_nodes(&mut solver, gate_fn, &input_lits)?;
+    let pir_lits = encode_gate_fn_all_nodes(solver, &pir_gate_fn, &input_lits)?;
+    let gate_lits = encode_gate_fn_all_nodes(solver, gate_fn, &input_lits)?;
 
     // GateFn primary input refs for counterexample reconstruction.
     let gate_primary_inputs: Vec<AigRef> = gate_fn
@@ -493,41 +720,34 @@ where
         };
 
         // Ask the solver for a counterexample: (pir != gate).
-        let diff = solver.new_lit();
-        add_tseitsin_xor(&mut solver, pir_lit, gate_lit, diff);
-        solver.assume(&[diff]);
-        let sat = solver
-            .solve()
-            .map_err(|e| format!("varisat solve error: {e:?}"))?;
-        if !sat {
-            let proof = CandidateProof {
-                candidate: cand.clone(),
-                result: CandidateProofResult::Proved,
-            };
-            on_proof(&proof);
-            results.push(proof);
-            continue;
-        }
+        let diff = solver.sat_new_lit();
+        add_tseitsin_xor(solver, pir_lit, gate_lit, diff);
+        let result = match solver
+            .sat_solve_assuming(&[diff])
+            .map_err(|e| format!("{solver_name} solve error: {e}"))?
+        {
+            SatSolveResult::Unsat => CandidateProofResult::Proved,
+            SatSolveResult::Sat => {
+                let model = solver
+                    .sat_model()
+                    .map_err(|e| format!("{solver_name} model error: {e}"))?;
 
-        let model = solver
-            .model()
-            .ok_or_else(|| "expected model when SAT".to_string())?;
-        let model_set: std::collections::HashSet<varisat::Lit> = model.iter().cloned().collect();
+                let mut input_assignment: HashMap<AigRef, bool> = HashMap::new();
+                for aig_ref in &gate_primary_inputs {
+                    let lit = gate_lits.get(aig_ref).ok_or_else(|| {
+                        format!("missing lit for gate primary input {:?}", aig_ref)
+                    })?;
+                    input_assignment.insert(*aig_ref, model.lit_value(*lit));
+                }
 
-        let mut input_assignment: HashMap<AigRef, bool> = HashMap::new();
-        for aig_ref in &gate_primary_inputs {
-            let lit = gate_lits
-                .get(aig_ref)
-                .ok_or_else(|| format!("missing lit for gate primary input {:?}", aig_ref))?;
-            input_assignment.insert(*aig_ref, model_set.contains(lit));
-        }
-
-        let cex_inputs: Vec<IrBits> = gate_fn.map_to_inputs(input_assignment);
+                CandidateProofResult::Disproved {
+                    counterexample_inputs: gate_fn.map_to_inputs(input_assignment),
+                }
+            }
+        };
         let proof = CandidateProof {
             candidate: cand.clone(),
-            result: CandidateProofResult::Disproved {
-                counterexample_inputs: cex_inputs,
-            },
+            result,
         };
         on_proof(&proof);
         results.push(proof);
@@ -545,11 +765,11 @@ fn is_all_same_bool(bits: &[bool]) -> Option<bool> {
     }
 }
 
-fn encode_gate_fn_all_nodes(
-    solver: &mut Solver,
+fn encode_gate_fn_all_nodes<S: IncrementalSat>(
+    solver: &mut S,
     gate_fn: &GateFn,
-    input_lits: &[Vec<varisat::Lit>],
-) -> Result<HashMap<AigRef, varisat::Lit>, String> {
+    input_lits: &[Vec<S::Lit>],
+) -> Result<HashMap<AigRef, S::Lit>, String> {
     if gate_fn.inputs.len() != input_lits.len() {
         return Err(format!(
             "input_lits arity mismatch: got {} expected {}",
@@ -558,7 +778,7 @@ fn encode_gate_fn_all_nodes(
         ));
     }
 
-    let mut map: HashMap<AigRef, varisat::Lit> = HashMap::new();
+    let mut map: HashMap<AigRef, S::Lit> = HashMap::new();
 
     // Seed primary inputs using the shared literals (one per input bit).
     for (i, inp) in gate_fn.inputs.iter().enumerate() {
@@ -591,7 +811,10 @@ fn encode_gate_fn_all_nodes(
             }
             continue;
         }
-        map.entry(r).or_insert_with(|| solver.new_lit());
+        if !map.contains_key(&r) {
+            let lit = solver.sat_new_lit();
+            map.insert(r, lit);
+        }
     }
 
     // Add structural clauses for all nodes.
@@ -602,9 +825,9 @@ fn encode_gate_fn_all_nodes(
             AigNode::Input { .. } => {}
             AigNode::Literal { value: v, .. } => {
                 if *v {
-                    solver.add_clause(&[out]);
+                    solver.sat_add_clause(&[out]);
                 } else {
-                    solver.add_clause(&[!out]);
+                    solver.sat_add_clause(&[!out]);
                 }
             }
             AigNode::And2 { a, b, .. } => {
@@ -618,37 +841,27 @@ fn encode_gate_fn_all_nodes(
     Ok(map)
 }
 
-fn lit_for_operand(
-    map: &HashMap<AigRef, varisat::Lit>,
-    op: AigOperand,
-) -> Result<varisat::Lit, String> {
+fn lit_for_operand<Lit>(map: &HashMap<AigRef, Lit>, op: AigOperand) -> Result<Lit, String>
+where
+    Lit: Copy + Not<Output = Lit>,
+{
     let base = *map
         .get(&op.node)
         .ok_or_else(|| format!("missing lit for AigRef id={}", op.node.id))?;
     Ok(if op.negated { !base } else { base })
 }
 
-fn add_tseitsin_and(
-    solver: &mut impl ExtendFormula,
-    a: varisat::Lit,
-    b: varisat::Lit,
-    output: varisat::Lit,
-) {
-    solver.add_clause(&[!a, !b, output]);
-    solver.add_clause(&[a, !output]);
-    solver.add_clause(&[b, !output]);
+fn add_tseitsin_and<S: IncrementalSat>(solver: &mut S, a: S::Lit, b: S::Lit, output: S::Lit) {
+    solver.sat_add_clause(&[!a, !b, output]);
+    solver.sat_add_clause(&[a, !output]);
+    solver.sat_add_clause(&[b, !output]);
 }
 
-fn add_tseitsin_xor(
-    solver: &mut impl ExtendFormula,
-    a: varisat::Lit,
-    b: varisat::Lit,
-    output: varisat::Lit,
-) {
-    solver.add_clause(&[!a, !b, !output]);
-    solver.add_clause(&[a, b, !output]);
-    solver.add_clause(&[a, !b, output]);
-    solver.add_clause(&[!a, b, output]);
+fn add_tseitsin_xor<S: IncrementalSat>(solver: &mut S, a: S::Lit, b: S::Lit, output: S::Lit) {
+    solver.sat_add_clause(&[!a, !b, !output]);
+    solver.sat_add_clause(&[a, b, !output]);
+    solver.sat_add_clause(&[a, !b, output]);
+    solver.sat_add_clause(&[!a, b, output]);
 }
 
 fn eval_gate_fn_all_node_values_positive(

--- a/xlsynth-g8r/src/lib.rs
+++ b/xlsynth-g8r/src/lib.rs
@@ -31,7 +31,7 @@ pub mod netlist;
 pub mod process_ir_path;
 pub mod propose_equiv;
 pub mod prove_gate_fn_equiv_common;
-pub mod prove_gate_fn_equiv_varisat;
+pub mod prove_gate_fn_equiv_sat;
 #[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
 pub mod prove_gate_fn_equiv_z3;
 pub mod test_utils;

--- a/xlsynth-g8r/src/main.rs
+++ b/xlsynth-g8r/src/main.rs
@@ -12,7 +12,7 @@ use xlsynth_g8r::ir2gate_utils::AdderMapping;
 use xlsynth_g8r::process_ir_path::{
     DEFAULT_MAX_FRAIG_SIM_SAMPLES, Options, process_ir_path_for_cli,
 };
-use xlsynth_g8r::prove_gate_fn_equiv_varisat::ValidationBackend;
+use xlsynth_g8r::prove_gate_fn_equiv_common::GateFormalBackend;
 use xlsynth_g8r::result_proto;
 
 /// Simple program to parse an XLS IR file and emit a Verilog netlist.
@@ -43,9 +43,9 @@ struct Args {
     )]
     max_fraig_sim_samples: usize,
 
-    /// SAT backend for validating FRAIG equivalence classes.
-    #[arg(long, default_value = "cadical", value_parser = ["cadical", "varisat"])]
-    fraig_validation_backend: String,
+    /// Formal backend for gate-level proof steps.
+    #[arg(long, default_value = GateFormalBackend::DEFAULT_CLI_VALUE, value_parser = GateFormalBackend::CLI_VALUES)]
+    gate_formal_backend: String,
 
     /// Whether to check equivalence between the IR and the gate function.
     #[arg(long, default_value_t = true)]
@@ -91,7 +91,7 @@ struct Args {
 fn main() {
     let _ = env_logger::builder().try_init();
     let args = Args::parse();
-    let fraig_validation_backend = ValidationBackend::parse(&args.fraig_validation_backend)
+    let gate_formal_backend = GateFormalBackend::parse(&args.gate_formal_backend)
         .expect("validated by clap value_parser");
     let cut_db = Some(xlsynth_g8r::cut_db::loader::CutDb::load_default());
 
@@ -117,7 +117,7 @@ fn main() {
         graph_logical_effort_beta2: args.graph_logical_effort_beta2,
         fraig_max_iterations: args.fraig_max_iterations,
         max_fraig_sim_samples: Some(args.max_fraig_sim_samples),
-        fraig_validation_backend,
+        gate_formal_backend,
         cut_db,
         cut_db_rewrite_max_iterations: CUT_DB_REWRITE_MAX_ITERATIONS_CLI,
         cut_db_rewrite_max_candidate_evals_per_round:

--- a/xlsynth-g8r/src/mcmc_logic.rs
+++ b/xlsynth-g8r/src/mcmc_logic.rs
@@ -23,14 +23,8 @@ use crate::aig::gate::GateFn;
 use crate::aig::{dce, get_summary_stats};
 use crate::aig_sim::gate_simd::{self, Vec256};
 use crate::gatify::ir2gate::{self, GatifyOptions};
-
-#[cfg(not(any(feature = "with-z3-system", feature = "with-z3-built")))]
-use crate::check_equivalence::prove_same_gate_fn_via_ir;
-
-#[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
-use crate::prove_gate_fn_equiv_common::EquivResult;
-#[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
-use crate::prove_gate_fn_equiv_z3::{self, prove_gate_fn_equiv as prove_gate_fn_equiv_z3};
+use crate::prove_gate_fn_equiv_common::{EquivResult, GateFormalBackend};
+use crate::prove_gate_fn_equiv_sat::prove_gate_fn_equiv_with_backend;
 
 use crate::test_utils::{
     Opt as SampleOpt, load_bf16_add_sample, load_bf16_mul_sample, make_ripple_carry_adder,
@@ -64,22 +58,21 @@ pub fn cost(g: &GateFn) -> Cost {
     }
 }
 
-/// Checks equivalence of two `GateFn`s using the external IR-based checker.
-pub fn oracle_equiv_sat(lhs: &GateFn, rhs: &GateFn) -> bool {
-    #[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
-    {
-        let mut ctx = prove_gate_fn_equiv_z3::Ctx::new();
-        return matches!(
-            prove_gate_fn_equiv_z3(lhs, rhs, &mut ctx),
-            EquivResult::Proved
-        );
-    }
+/// Checks equivalence of two `GateFn`s using the selected formal backend.
+pub fn oracle_equiv_sat_with_backend(
+    lhs: &GateFn,
+    rhs: &GateFn,
+    backend: GateFormalBackend,
+) -> bool {
+    matches!(
+        prove_gate_fn_equiv_with_backend(lhs, rhs, backend),
+        Ok(EquivResult::Proved)
+    )
+}
 
-    // If we don't have Z3 we do via IR equivalence.
-    #[cfg(not(any(feature = "with-z3-system", feature = "with-z3-built")))]
-    {
-        return prove_same_gate_fn_via_ir(lhs, rhs).is_ok();
-    }
+/// Checks equivalence of two `GateFn`s using the default backend.
+pub fn oracle_equiv_sat(lhs: &GateFn, rhs: &GateFn) -> bool {
+    oracle_equiv_sat_with_backend(lhs, rhs, GateFormalBackend::Cadical)
 }
 
 /// Type aliases specializing the generic MCMC helpers from `xlsynth-mcmc` to
@@ -95,6 +88,7 @@ pub struct McmcContext<'a> {
     pub rng: &'a mut Pcg64Mcg,
     pub all_transforms: Vec<Box<dyn crate::transforms::transform_trait::Transform>>,
     pub weights: Vec<f64>,
+    pub gate_formal_backend: GateFormalBackend,
 }
 
 /// Objective used to evaluate cost improvements.
@@ -215,7 +209,11 @@ pub fn mcmc_iteration(
                     };
                 }
                 oracle_time_micros = sim_time_micros;
-                let sat_res = oracle_equiv_sat(&current_gfn, &candidate_gfn);
+                let sat_res = oracle_equiv_sat_with_backend(
+                    &current_gfn,
+                    &candidate_gfn,
+                    context.gate_formal_backend,
+                );
                 if paranoid {
                     let external_res = crate::check_equivalence::prove_same_gate_fn_via_ir(
                         &current_gfn,
@@ -318,6 +316,7 @@ pub fn mcmc(
     shared_best: Option<Arc<Best>>,
     chain_no: Option<usize>,
     options: McmcOptions,
+    gate_formal_backend: GateFormalBackend,
 ) -> Result<GateFn> {
     println!("Ticker Legend: F=ApplyFail, O=OracleFail, M=MetropolisReject, CF=CandidateFail");
     let mut iteration_rng = Pcg64Mcg::seed_from_u64(seed);
@@ -378,6 +377,7 @@ pub fn mcmc(
         rng: &mut iteration_rng,
         all_transforms: all_available_transforms,
         weights,
+        gate_formal_backend,
     };
 
     let start_time = Instant::now();
@@ -652,6 +652,7 @@ pub fn mcmc(
                         &best_gfn,
                         global_iter,
                         "Iter checkpoint",
+                        gate_formal_backend,
                     )?;
                 }
             }
@@ -674,6 +675,7 @@ pub fn mcmc(
             &best_gfn,
             options.start_iteration + iterations_count,
             "Final checkpoint",
+            gate_formal_backend,
         )?;
         if progress_interval > 0 {
             let elapsed_secs = start_time.elapsed().as_secs_f64();
@@ -845,9 +847,10 @@ fn write_checkpoint(
     best_gfn: &GateFn,
     iter: u64,
     context: &str,
+    gate_formal_backend: GateFormalBackend,
 ) -> Result<()> {
     // Cross-check equivalence
-    let equiv_ok_sat = oracle_equiv_sat(original_gfn, best_gfn);
+    let equiv_ok_sat = oracle_equiv_sat_with_backend(original_gfn, best_gfn, gate_formal_backend);
     use crate::check_equivalence::{IrCheckResult, prove_same_gate_fn_via_ir_status};
 
     let ir_status = prove_same_gate_fn_via_ir_status(original_gfn, best_gfn);

--- a/xlsynth-g8r/src/mcmc_logic.rs
+++ b/xlsynth-g8r/src/mcmc_logic.rs
@@ -24,7 +24,7 @@ use crate::aig::{dce, get_summary_stats};
 use crate::aig_sim::gate_simd::{self, Vec256};
 use crate::gatify::ir2gate::{self, GatifyOptions};
 use crate::prove_gate_fn_equiv_common::{EquivResult, GateFormalBackend};
-use crate::prove_gate_fn_equiv_sat::prove_gate_fn_equiv_with_backend;
+use crate::prove_gate_fn_equiv_sat::{ValidationError, prove_gate_fn_equiv_with_backend};
 
 use crate::test_utils::{
     Opt as SampleOpt, load_bf16_add_sample, load_bf16_mul_sample, make_ripple_carry_adder,
@@ -63,15 +63,15 @@ pub fn oracle_equiv_sat_with_backend(
     lhs: &GateFn,
     rhs: &GateFn,
     backend: GateFormalBackend,
-) -> bool {
-    matches!(
-        prove_gate_fn_equiv_with_backend(lhs, rhs, backend),
-        Ok(EquivResult::Proved)
-    )
+) -> std::result::Result<bool, ValidationError> {
+    match prove_gate_fn_equiv_with_backend(lhs, rhs, backend)? {
+        EquivResult::Proved => Ok(true),
+        EquivResult::Disproved(_) => Ok(false),
+    }
 }
 
 /// Checks equivalence of two `GateFn`s using the default backend.
-pub fn oracle_equiv_sat(lhs: &GateFn, rhs: &GateFn) -> bool {
+pub fn oracle_equiv_sat(lhs: &GateFn, rhs: &GateFn) -> std::result::Result<bool, ValidationError> {
     oracle_equiv_sat_with_backend(lhs, rhs, GateFormalBackend::Cadical)
 }
 
@@ -123,12 +123,12 @@ pub fn mcmc_iteration(
     paranoid: bool,
     simd_inputs: &[Vec256],
     baseline_outputs: &Vec<Vec256>,
-) -> McmcIterationOutput {
+) -> std::result::Result<McmcIterationOutput, ValidationError> {
     let mut iteration_best_gfn_updated = false;
 
     if context.all_transforms.is_empty() {
         // No transforms available to apply
-        return McmcIterationOutput {
+        return Ok(McmcIterationOutput {
             output_state: current_gfn,
             output_cost: current_cost,
             best_updated: false,
@@ -137,7 +137,7 @@ pub fn mcmc_iteration(
             oracle_time_micros: 0,
             transform_always_equivalent: true,
             transform: None,
-        };
+        });
     }
 
     let dist = WeightedIndex::new(&context.weights).expect("non-empty weights");
@@ -161,7 +161,7 @@ pub fn mcmc_iteration(
     );
 
     if candidate_locations.is_empty() {
-        return McmcIterationOutput {
+        return Ok(McmcIterationOutput {
             output_state: current_gfn,
             output_cost: current_cost,
             best_updated: false,
@@ -169,7 +169,7 @@ pub fn mcmc_iteration(
             oracle_time_micros: 0,
             transform_always_equivalent: true,
             transform: Some(current_transform_kind),
-        };
+        });
     }
 
     let chosen_location = candidate_locations.choose(context.rng).unwrap();
@@ -198,7 +198,7 @@ pub fn mcmc_iteration(
                 let sim_equiv = *baseline_outputs == candidate_out;
                 let sim_time_micros = sim_start.elapsed().as_micros();
                 if !sim_equiv {
-                    return McmcIterationOutput {
+                    return Ok(McmcIterationOutput {
                         output_state: current_gfn,
                         output_cost: current_cost,
                         best_updated: false,
@@ -206,14 +206,14 @@ pub fn mcmc_iteration(
                         oracle_time_micros: sim_time_micros,
                         transform_always_equivalent: chosen_transform.always_equivalent(),
                         transform: Some(current_transform_kind),
-                    };
+                    });
                 }
                 oracle_time_micros = sim_time_micros;
                 let sat_res = oracle_equiv_sat_with_backend(
                     &current_gfn,
                     &candidate_gfn,
                     context.gate_formal_backend,
-                );
+                )?;
                 if paranoid {
                     let external_res = crate::check_equivalence::prove_same_gate_fn_via_ir(
                         &current_gfn,
@@ -232,7 +232,7 @@ pub fn mcmc_iteration(
             log::trace!("is_equiv: {:?}", is_equiv);
 
             if !is_equiv {
-                McmcIterationOutput {
+                Ok(McmcIterationOutput {
                     output_state: current_gfn,
                     output_cost: current_cost,
                     best_updated: false,
@@ -240,7 +240,7 @@ pub fn mcmc_iteration(
                     oracle_time_micros,
                     transform_always_equivalent: chosen_transform.always_equivalent(),
                     transform: Some(current_transform_kind),
-                }
+                })
             } else {
                 // Apply DCE to remove any dead nodes, reducing memory footprint.
                 let candidate_gfn_dce = dce::dce(&candidate_gfn);
@@ -257,7 +257,7 @@ pub fn mcmc_iteration(
                         *best_cost = new_candidate_cost;
                         iteration_best_gfn_updated = true;
                     }
-                    McmcIterationOutput {
+                    Ok(McmcIterationOutput {
                         output_state: candidate_gfn_dce,
                         output_cost: new_candidate_cost,
                         best_updated: iteration_best_gfn_updated,
@@ -267,9 +267,9 @@ pub fn mcmc_iteration(
                         oracle_time_micros,
                         transform_always_equivalent: chosen_transform.always_equivalent(),
                         transform: Some(current_transform_kind),
-                    }
+                    })
                 } else {
-                    McmcIterationOutput {
+                    Ok(McmcIterationOutput {
                         output_state: current_gfn,
                         output_cost: current_cost,
                         best_updated: false,
@@ -277,7 +277,7 @@ pub fn mcmc_iteration(
                         oracle_time_micros,
                         transform_always_equivalent: chosen_transform.always_equivalent(),
                         transform: Some(current_transform_kind),
-                    }
+                    })
                 }
             }
         }
@@ -287,7 +287,7 @@ pub fn mcmc_iteration(
                 current_transform_kind,
                 e
             );
-            McmcIterationOutput {
+            Ok(McmcIterationOutput {
                 output_state: current_gfn,
                 output_cost: current_cost,
                 best_updated: false,
@@ -295,7 +295,7 @@ pub fn mcmc_iteration(
                 oracle_time_micros: 0,
                 transform_always_equivalent: true,
                 transform: Some(current_transform_kind),
-            }
+            })
         }
     }
 }
@@ -487,7 +487,7 @@ pub fn mcmc(
             paranoid,
             &simd_inputs,
             &baseline_outputs,
-        );
+        )?;
         log::trace!(
             "MCMC iteration completed: {:?}",
             options.start_iteration + iterations_count
@@ -850,7 +850,7 @@ fn write_checkpoint(
     gate_formal_backend: GateFormalBackend,
 ) -> Result<()> {
     // Cross-check equivalence
-    let equiv_ok_sat = oracle_equiv_sat_with_backend(original_gfn, best_gfn, gate_formal_backend);
+    let equiv_ok_sat = oracle_equiv_sat_with_backend(original_gfn, best_gfn, gate_formal_backend)?;
     use crate::check_equivalence::{IrCheckResult, prove_same_gate_fn_via_ir_status};
 
     let ir_status = prove_same_gate_fn_via_ir_status(original_gfn, best_gfn);
@@ -977,4 +977,22 @@ struct ProgressEntry {
     proposed_samples_per_sec: f64,
     accepted_samples_per_sec: f64,
     temperature: f64,
+}
+
+#[cfg(all(test, not(any(feature = "with-z3-system", feature = "with-z3-built"))))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oracle_equiv_sat_propagates_backend_errors() {
+        let g = make_ripple_carry_adder(1);
+        let err = oracle_equiv_sat_with_backend(&g, &g, GateFormalBackend::Z3).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::UnsupportedBackend {
+                backend: GateFormalBackend::Z3,
+                ..
+            }
+        ));
+    }
 }

--- a/xlsynth-g8r/src/process_ir_path.rs
+++ b/xlsynth-g8r/src/process_ir_path.rs
@@ -24,7 +24,7 @@ use crate::aig_sim::count_toggles;
 use crate::check_equivalence;
 use crate::gatify::ir2gate;
 use crate::ir2gates;
-use crate::prove_gate_fn_equiv_varisat::ValidationBackend;
+use crate::prove_gate_fn_equiv_common::GateFormalBackend;
 use crate::use_count::get_id_to_use_count;
 use xlsynth_pir::ir;
 use xlsynth_pir::ir_range_info::IrRangeInfo;
@@ -162,8 +162,8 @@ pub struct Options {
     /// to a SIMD batch boundary, then capped by this value when present.
     pub max_fraig_sim_samples: Option<usize>,
 
-    /// SAT backend used to validate proposed FRAIG equivalence classes.
-    pub fraig_validation_backend: ValidationBackend,
+    /// Gate-level formal backend used for proof steps.
+    pub gate_formal_backend: GateFormalBackend,
 
     pub quiet: bool,
     pub emit_netlist: bool,
@@ -489,7 +489,7 @@ pub fn process_ir_path_with_gatefn(
             &gate_fn,
             sim_samples,
             iteration_bounds,
-            options.fraig_validation_backend,
+            options.gate_formal_backend,
             &mut rng,
         );
         if !fraig_result.is_ok() {

--- a/xlsynth-g8r/src/prove_gate_fn_equiv_common.rs
+++ b/xlsynth-g8r/src/prove_gate_fn_equiv_common.rs
@@ -2,6 +2,54 @@
 
 use xlsynth::IrBits;
 
+/// User-facing gate-level formal proof backend selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateFormalBackend {
+    Cadical,
+    Varisat,
+    Z3,
+    /// Lower both sides through XLS IR and use the IR equivalence checker.
+    Ir,
+}
+
+impl GateFormalBackend {
+    pub const CLI_VALUES: [&'static str; 4] = ["cadical", "varisat", "z3", "ir"];
+    pub const DEFAULT_CLI_VALUE: &'static str = "cadical";
+
+    /// Parses a user-facing backend name.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value.to_ascii_lowercase().as_str() {
+            "cadical" => Ok(Self::Cadical),
+            "varisat" => Ok(Self::Varisat),
+            "z3" => Ok(Self::Z3),
+            "ir" => Ok(Self::Ir),
+            _ => Err(value.to_string()),
+        }
+    }
+
+    /// Returns the canonical lower-case backend name.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cadical => "cadical",
+            Self::Varisat => "varisat",
+            Self::Z3 => "z3",
+            Self::Ir => "ir",
+        }
+    }
+}
+
+impl Default for GateFormalBackend {
+    fn default() -> Self {
+        Self::Cadical
+    }
+}
+
+impl std::fmt::Display for GateFormalBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum EquivResult {
     Proved,

--- a/xlsynth-g8r/src/prove_gate_fn_equiv_sat.rs
+++ b/xlsynth-g8r/src/prove_gate_fn_equiv_sat.rs
@@ -1,23 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! Validates equivalence classes proposed by `propose_equiv`.
+//! SAT-backed gate-function equivalence and equivalence-class validation.
 //!
 //! For a given equivalence class we will either get confirmation that they are
 //! all equivalent or a counterexample that demonstrates a case in which they
 //! are not equivalent.
 //!
 //! The default backend is CaDiCaL. Varisat remains available for comparison and
-//! fallback testing.
+//! context-reuse testing; Z3 and IR backends are dispatched through the common
+//! gate-formal backend API where supported.
 
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ops::Not;
 
-use crate::aig::gate::{AigNode, AigRef, GateFn};
+use crate::aig::gate::{AigBitVector, AigNode, AigOperand, AigRef, GateFn, Output};
 use crate::aig::get_summary_stats::get_gate_depth;
 use crate::aig::topo::extract_cone;
 use crate::propose_equiv::EquivNode;
-pub use crate::prove_gate_fn_equiv_common::EquivResult;
+pub use crate::prove_gate_fn_equiv_common::{EquivResult, GateFormalBackend};
 use varisat::ExtendFormula;
 use xlsynth::IrBits;
 
@@ -55,7 +56,11 @@ pub enum ValidationError {
     CadicalConfigError(String),
     CadicalSolveInterrupted,
     ModelUnavailable,
-    UnknownBackend(String),
+    UnsupportedBackend {
+        backend: GateFormalBackend,
+        operation: &'static str,
+    },
+    IrEquivalenceError(String),
 }
 
 impl std::fmt::Display for ValidationError {
@@ -66,67 +71,29 @@ impl std::fmt::Display for ValidationError {
 
 impl std::error::Error for ValidationError {}
 
-pub const VALIDATION_BACKEND_ENV: &str = "XLSYNTH_G8R_VALIDATION_BACKEND";
 pub const CADICAL_CONFIG_ENV: &str = "XLSYNTH_G8R_CADICAL_CONFIG";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ValidationBackend {
-    Varisat,
-    Cadical,
-}
-
-impl ValidationBackend {
-    fn from_env() -> Result<Self, ValidationError> {
-        match env::var(VALIDATION_BACKEND_ENV) {
-            Ok(value) => Self::parse(&value),
-            Err(env::VarError::NotPresent) => Ok(Self::default()),
-            Err(env::VarError::NotUnicode(value)) => Err(ValidationError::UnknownBackend(
-                value.to_string_lossy().to_string(),
-            )),
-        }
-    }
-
-    /// Parses a user-facing backend name.
-    pub fn parse(value: &str) -> Result<Self, ValidationError> {
-        match value {
-            "varisat" | "Varisat" | "VARISAT" => Ok(Self::Varisat),
-            "cadical" | "CaDiCaL" | "CADICAL" => Ok(Self::Cadical),
-            other => Err(ValidationError::UnknownBackend(other.to_string())),
-        }
-    }
-
-    /// Returns the canonical lower-case backend name.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Varisat => "varisat",
-            Self::Cadical => "cadical",
-        }
-    }
-}
-
-impl Default for ValidationBackend {
-    fn default() -> Self {
-        Self::Cadical
-    }
-}
-
-impl std::fmt::Display for ValidationBackend {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+fn resolve_equivalence_class_backend(
+    backend: GateFormalBackend,
+) -> Result<GateFormalBackend, ValidationError> {
+    match backend {
+        GateFormalBackend::Cadical => Ok(GateFormalBackend::Cadical),
+        GateFormalBackend::Varisat => Ok(GateFormalBackend::Varisat),
+        GateFormalBackend::Z3 | GateFormalBackend::Ir => Ok(backend),
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SatSolveResult {
+pub(crate) enum SatSolveResult {
     Sat,
     Unsat,
 }
 
-trait SatModel<Lit: Copy> {
+pub(crate) trait SatModel<Lit: Copy> {
     fn lit_value(&self, lit: Lit) -> bool;
 }
 
-trait IncrementalSat {
+pub(crate) trait IncrementalSat {
     type Lit: Copy + Eq + std::hash::Hash + Not<Output = Self::Lit>;
     type Model: SatModel<Self::Lit> + Clone;
 
@@ -140,7 +107,7 @@ trait IncrementalSat {
 }
 
 #[derive(Clone)]
-struct VarisatModel {
+pub(crate) struct VarisatModel {
     true_lits: HashSet<varisat::Lit>,
 }
 
@@ -187,7 +154,7 @@ impl<'a> IncrementalSat for varisat::Solver<'a> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct CadicalLit(i32);
+pub(crate) struct CadicalLit(i32);
 
 impl Not for CadicalLit {
     type Output = Self;
@@ -197,13 +164,13 @@ impl Not for CadicalLit {
     }
 }
 
-struct CadicalSat {
+pub(crate) struct CadicalSat {
     solver: cadical::Solver,
     next_var: i32,
 }
 
 impl CadicalSat {
-    fn new() -> Result<Self, ValidationError> {
+    pub(crate) fn new() -> Result<Self, ValidationError> {
         let solver = match env::var(CADICAL_CONFIG_ENV) {
             Ok(config) => cadical::Solver::with_config(&config)
                 .map_err(|e| ValidationError::CadicalConfigError(format!("{config}: {e}")))?,
@@ -222,7 +189,7 @@ impl CadicalSat {
 }
 
 #[derive(Clone)]
-struct CadicalModel {
+pub(crate) struct CadicalModel {
     values: Vec<bool>,
 }
 
@@ -550,8 +517,11 @@ fn build_gate_fn<S: IncrementalSat>(
     (map, outputs)
 }
 
-/// Checks equivalence of two gate functions using a SAT solver.
-pub fn prove_gate_fn_equiv<'a>(a: &GateFn, b: &GateFn, ctx: &mut Ctx<'a>) -> EquivResult {
+fn prove_gate_fn_equiv_with_solver<S: IncrementalSat>(
+    a: &GateFn,
+    b: &GateFn,
+    solver: &mut S,
+) -> Result<EquivResult, ValidationError> {
     assert_eq!(a.inputs.len(), b.inputs.len());
     assert_eq!(a.outputs.len(), b.outputs.len());
 
@@ -560,60 +530,102 @@ pub fn prove_gate_fn_equiv<'a>(a: &GateFn, b: &GateFn, ctx: &mut Ctx<'a>) -> Equ
         assert_eq!(ia.get_bit_count(), ib.get_bit_count());
         let mut lits = Vec::new();
         for _ in 0..ia.get_bit_count() {
-            lits.push(ctx.solver.new_lit());
+            lits.push(solver.sat_new_lit());
         }
         input_lits.push(lits);
     }
 
-    let (_map_a, outputs_a) = build_gate_fn(&mut ctx.solver, a, &input_lits);
-    let (_map_b, outputs_b) = build_gate_fn(&mut ctx.solver, b, &input_lits);
+    let (_map_a, outputs_a) = build_gate_fn(solver, a, &input_lits);
+    let (_map_b, outputs_b) = build_gate_fn(solver, b, &input_lits);
 
     // Build XOR miters for each corresponding output bit.
     let mut miters = Vec::new();
     for (la, lb) in outputs_a.iter().zip(outputs_b.iter()) {
-        let m = ctx.solver.new_lit();
-        add_tseitsin_xor(&mut ctx.solver, *la, *lb, m);
+        let m = solver.sat_new_lit();
+        add_tseitsin_xor(solver, *la, *lb, m);
         miters.push(m);
     }
 
     // Fresh literal that stands for "outputs differ in *some* bit".
-    let diff = ctx.solver.new_lit();
+    let diff = solver.sat_new_lit();
     // diff -> OR(miters)  === (!diff OR m1 OR m2 ...)
     let mut clause = Vec::with_capacity(miters.len() + 1);
     clause.push(!diff);
     clause.extend(miters.iter().cloned());
-    ctx.solver.add_clause(&clause);
+    solver.sat_add_clause(&clause);
 
     // Ask the solver to find an assignment where outputs differ.
-    ctx.solver.assume(&[diff]);
-    match ctx.solver.solve() {
-        Ok(false) => EquivResult::Proved, // UNSAT ⇒ no way for outputs to differ.
-        Ok(true) => {
-            let model = ctx.solver.model().expect("model available when SAT");
-            let model_set: HashSet<varisat::Lit> = model.iter().cloned().collect();
+    match solver.sat_solve_assuming(&[diff])? {
+        SatSolveResult::Unsat => Ok(EquivResult::Proved), // UNSAT => no way for outputs to differ.
+        SatSolveResult::Sat => {
+            let model = solver.sat_model()?;
             let mut map = HashMap::new();
             for (i, inp) in a.inputs.iter().enumerate() {
                 for (j, op) in inp.bit_vector.iter_lsb_to_msb().enumerate() {
                     let lit = input_lits[i][j];
-                    map.insert(op.node, model_set.contains(&lit));
+                    map.insert(op.node, model.lit_value(lit));
                 }
             }
             let cex = a.map_to_inputs(map);
-            EquivResult::Disproved(cex)
+            Ok(EquivResult::Disproved(cex))
         }
-        Err(e) => panic!("Solver error: {:?}", e),
     }
+}
+
+/// Checks equivalence of two gate functions using a selected backend.
+pub fn prove_gate_fn_equiv_with_backend(
+    a: &GateFn,
+    b: &GateFn,
+    backend: GateFormalBackend,
+) -> Result<EquivResult, ValidationError> {
+    match backend {
+        GateFormalBackend::Cadical => {
+            let mut solver = CadicalSat::new()?;
+            prove_gate_fn_equiv_with_solver(a, b, &mut solver)
+        }
+        GateFormalBackend::Varisat => {
+            let mut solver = varisat::Solver::new();
+            prove_gate_fn_equiv_with_solver(a, b, &mut solver)
+        }
+        GateFormalBackend::Z3 => {
+            #[cfg(any(feature = "with-z3-system", feature = "with-z3-built"))]
+            {
+                let mut ctx = crate::prove_gate_fn_equiv_z3::Ctx::new();
+                Ok(crate::prove_gate_fn_equiv_z3::prove_gate_fn_equiv(
+                    a, b, &mut ctx,
+                ))
+            }
+
+            #[cfg(not(any(feature = "with-z3-system", feature = "with-z3-built")))]
+            {
+                Err(ValidationError::UnsupportedBackend {
+                    backend,
+                    operation: "pairwise gate function equivalence",
+                })
+            }
+        }
+        GateFormalBackend::Ir => {
+            use crate::check_equivalence::{IrCheckResult, prove_same_gate_fn_via_ir_status};
+
+            match prove_same_gate_fn_via_ir_status(a, b) {
+                IrCheckResult::Equivalent => Ok(EquivResult::Proved),
+                IrCheckResult::NotEquivalent => Ok(EquivResult::Disproved(Vec::new())),
+                other => Err(ValidationError::IrEquivalenceError(format!("{other:?}"))),
+            }
+        }
+    }
+}
+
+/// Checks equivalence of two gate functions using a Varisat context.
+pub fn prove_gate_fn_equiv<'a>(a: &GateFn, b: &GateFn, ctx: &mut Ctx<'a>) -> EquivResult {
+    prove_gate_fn_equiv_with_solver(a, b, &mut ctx.solver).expect("solver error")
 }
 
 pub fn validate_equivalence_classes(
     gate_fn: &GateFn,
     equiv_classes: &[&[EquivNode]],
 ) -> Result<ValidationResult, ValidationError> {
-    validate_equivalence_classes_with_backend(
-        gate_fn,
-        equiv_classes,
-        ValidationBackend::from_env()?,
-    )
+    validate_equivalence_classes_with_backend(gate_fn, equiv_classes, GateFormalBackend::default())
 }
 
 /// Validates classes whose members and class order have already been
@@ -625,17 +637,17 @@ pub fn validate_equivalence_classes_presorted(
     validate_equivalence_classes_presorted_with_backend(
         gate_fn,
         equiv_classes,
-        ValidationBackend::from_env()?,
+        GateFormalBackend::default(),
     )
 }
 
 pub fn validate_equivalence_classes_with_backend(
     gate_fn: &GateFn,
     equiv_classes: &[&[EquivNode]],
-    backend: ValidationBackend,
+    backend: GateFormalBackend,
 ) -> Result<ValidationResult, ValidationError> {
-    match backend {
-        ValidationBackend::Varisat => {
+    match resolve_equivalence_class_backend(backend)? {
+        GateFormalBackend::Varisat => {
             let mut solver = varisat::Solver::new();
             validate_equivalence_classes_with_solver(
                 gate_fn,
@@ -644,12 +656,20 @@ pub fn validate_equivalence_classes_with_backend(
                 /* classes_are_depth_sorted= */ false,
             )
         }
-        ValidationBackend::Cadical => {
+        GateFormalBackend::Cadical => {
             let mut solver = CadicalSat::new()?;
             validate_equivalence_classes_with_solver(
                 gate_fn,
                 equiv_classes,
                 &mut solver,
+                /* classes_are_depth_sorted= */ false,
+            )
+        }
+        GateFormalBackend::Z3 | GateFormalBackend::Ir => {
+            validate_equivalence_classes_pairwise_with_backend(
+                gate_fn,
+                equiv_classes,
+                backend,
                 /* classes_are_depth_sorted= */ false,
             )
         }
@@ -659,10 +679,10 @@ pub fn validate_equivalence_classes_with_backend(
 pub fn validate_equivalence_classes_presorted_with_backend(
     gate_fn: &GateFn,
     equiv_classes: &[&[EquivNode]],
-    backend: ValidationBackend,
+    backend: GateFormalBackend,
 ) -> Result<ValidationResult, ValidationError> {
-    match backend {
-        ValidationBackend::Varisat => {
+    match resolve_equivalence_class_backend(backend)? {
+        GateFormalBackend::Varisat => {
             let mut solver = varisat::Solver::new();
             validate_equivalence_classes_with_solver(
                 gate_fn,
@@ -671,7 +691,7 @@ pub fn validate_equivalence_classes_presorted_with_backend(
                 /* classes_are_depth_sorted= */ true,
             )
         }
-        ValidationBackend::Cadical => {
+        GateFormalBackend::Cadical => {
             let mut solver = CadicalSat::new()?;
             validate_equivalence_classes_with_solver(
                 gate_fn,
@@ -680,7 +700,94 @@ pub fn validate_equivalence_classes_presorted_with_backend(
                 /* classes_are_depth_sorted= */ true,
             )
         }
+        GateFormalBackend::Z3 | GateFormalBackend::Ir => {
+            validate_equivalence_classes_pairwise_with_backend(
+                gate_fn,
+                equiv_classes,
+                backend,
+                /* classes_are_depth_sorted= */ true,
+            )
+        }
     }
+}
+
+fn gate_fn_with_single_output(
+    gate_fn: &GateFn,
+    equiv_node: EquivNode,
+    output_name: &str,
+) -> GateFn {
+    let mut operand = AigOperand::from(equiv_node.aig_ref());
+    if equiv_node.is_inverted() {
+        operand = operand.negate();
+    }
+    let mut out = gate_fn.clone();
+    out.outputs = vec![Output {
+        name: output_name.to_string(),
+        bit_vector: AigBitVector::from_bit(operand),
+    }];
+    out
+}
+
+fn validate_equivalence_classes_pairwise_with_backend(
+    gate_fn: &GateFn,
+    equiv_classes: &[&[EquivNode]],
+    backend: GateFormalBackend,
+    classes_are_depth_sorted: bool,
+) -> Result<ValidationResult, ValidationError> {
+    let sorted_equiv_classes: Vec<Vec<EquivNode>> = if classes_are_depth_sorted {
+        equiv_classes
+            .iter()
+            .map(|equiv_class| equiv_class.to_vec())
+            .collect()
+    } else {
+        let all_nodes: Vec<AigRef> = gate_fn
+            .gates
+            .iter()
+            .enumerate()
+            .map(|(id, _)| AigRef { id })
+            .collect();
+        let depth_stats = get_gate_depth(gate_fn, &all_nodes);
+        let mut sorted_equiv_classes: Vec<Vec<EquivNode>> = equiv_classes
+            .iter()
+            .map(|equiv_class| sorted_equiv_class(equiv_class, &depth_stats.ref_to_depth))
+            .collect();
+        sorted_equiv_classes.sort_unstable_by_key(|equiv_class| {
+            let representative = equiv_class[0];
+            (
+                equiv_node_depth_key(&depth_stats.ref_to_depth, representative),
+                equiv_class.len(),
+            )
+        });
+        sorted_equiv_classes
+    };
+
+    let mut validation_result = ValidationResult {
+        proven_equiv_sets: Vec::new(),
+        cex_inputs: Vec::new(),
+    };
+    for equiv_class in sorted_equiv_classes {
+        let mut known_equiv = vec![equiv_class[0]];
+        for &candidate in &equiv_class[1..] {
+            let representative = known_equiv[0];
+            let representative_fn =
+                gate_fn_with_single_output(gate_fn, representative, "representative");
+            let candidate_fn = gate_fn_with_single_output(gate_fn, candidate, "candidate");
+            match prove_gate_fn_equiv_with_backend(&representative_fn, &candidate_fn, backend)? {
+                EquivResult::Proved => known_equiv.push(candidate),
+                EquivResult::Disproved(cex) => {
+                    if !cex.is_empty() {
+                        validation_result.cex_inputs.push(cex);
+                    }
+                    break;
+                }
+            }
+        }
+
+        if known_equiv.len() > 1 {
+            validation_result.proven_equiv_sets.push(known_equiv);
+        }
+    }
+    Ok(validation_result)
 }
 
 fn validate_equivalence_classes_with_solver<S: IncrementalSat>(
@@ -808,7 +915,7 @@ mod tests {
     };
 
     use super::{
-        ValidationBackend, ValidationResult, validate_equivalence_classes,
+        GateFormalBackend, ValidationResult, validate_equivalence_classes,
         validate_equivalence_classes_with_backend,
     };
     #[allow(unused_imports)]
@@ -854,13 +961,13 @@ mod tests {
         let varisat = validate_equivalence_classes_with_backend(
             &setup.g,
             &classes,
-            ValidationBackend::Varisat,
+            GateFormalBackend::Varisat,
         )
         .unwrap();
         let cadical = validate_equivalence_classes_with_backend(
             &setup.g,
             &classes,
-            ValidationBackend::Cadical,
+            GateFormalBackend::Cadical,
         )
         .unwrap();
 
@@ -929,13 +1036,13 @@ mod tests {
         let varisat = validate_equivalence_classes_with_backend(
             &setup.g,
             &[proposed_class],
-            ValidationBackend::Varisat,
+            GateFormalBackend::Varisat,
         )
         .unwrap();
         let cadical = validate_equivalence_classes_with_backend(
             &setup.g,
             &[proposed_class],
-            ValidationBackend::Cadical,
+            GateFormalBackend::Cadical,
         )
         .unwrap();
 

--- a/xlsynth-g8r/src/prove_gate_fn_equiv_z3.rs
+++ b/xlsynth-g8r/src/prove_gate_fn_equiv_z3.rs
@@ -3,7 +3,7 @@
 //! Gate-level equivalence checking using the Z3 SMT solver.
 //!
 //! This implementation mirrors the SAT‐based checker in
-//! `prove_gate_fn_equiv_varisat.rs`, but uses the Z3 SMT solver instead of
+//! `prove_gate_fn_equiv_sat.rs`, but uses the Z3 SMT solver instead of
 //! Varisat.  By sharing the same public interface we can swap solvers by
 //! choosing the appropriate module at the call-site.
 

--- a/xlsynth-g8r/tests/array_index_lowering_equiv_test.rs
+++ b/xlsynth-g8r/tests/array_index_lowering_equiv_test.rs
@@ -3,7 +3,7 @@
 use xlsynth_g8r::check_equivalence;
 use xlsynth_g8r::gatify::ir2gate::{ArrayIndexLoweringStrategy, GatifyOptions, gatify};
 use xlsynth_g8r::ir2gate_utils::AdderMapping;
-use xlsynth_g8r::prove_gate_fn_equiv_varisat::{Ctx, EquivResult, prove_gate_fn_equiv};
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{Ctx, EquivResult, prove_gate_fn_equiv};
 use xlsynth_pir::ir_parser;
 
 fn build_direct_array_index_ir_text(

--- a/xlsynth-g8r/tests/aug_opt_selected_opposite_subtracts_qor.rs
+++ b/xlsynth-g8r/tests/aug_opt_selected_opposite_subtracts_qor.rs
@@ -4,7 +4,7 @@ use xlsynth_g8r::aig::get_summary_stats::get_aig_stats;
 use xlsynth_g8r::gatify::ir2gate::{GatifyOptions, gatify_prepared_fn};
 use xlsynth_g8r::ir2gate_utils::AdderMapping;
 use xlsynth_g8r::prove_gate_fn_equiv_common::EquivResult;
-use xlsynth_g8r::prove_gate_fn_equiv_varisat::{
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{
     Ctx as VarisatCtx, prove_gate_fn_equiv as prove_gate_fn_equiv_sat,
 };
 use xlsynth_pir::aug_opt::{AugOptMode, AugOptOptions, run_aug_opt_over_ir_text_with_stats};

--- a/xlsynth-g8r/tests/ext_nary_add_ir2gates_test.rs
+++ b/xlsynth-g8r/tests/ext_nary_add_ir2gates_test.rs
@@ -4,7 +4,7 @@ use xlsynth::{IrBits, IrValue};
 use xlsynth_g8r::aig::get_summary_stats::get_aig_stats;
 use xlsynth_g8r::ir2gate_utils::AdderMapping;
 use xlsynth_g8r::ir2gates;
-use xlsynth_g8r::prove_gate_fn_equiv_varisat::{Ctx, EquivResult, prove_gate_fn_equiv};
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{Ctx, EquivResult, prove_gate_fn_equiv};
 use xlsynth_pir::ir::{
     ExtNaryAddArchitecture, ExtNaryAddTerm, FileTable, MemberType, Node, NodePayload, Package,
     PackageMember, Param, ParamId, Type,

--- a/xlsynth-g8r/tests/ir_aig_sharing_candidates_test.rs
+++ b/xlsynth-g8r/tests/ir_aig_sharing_candidates_test.rs
@@ -5,7 +5,7 @@ use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
 use xlsynth_g8r::gatify::ir2gate::GatifyOptions;
 use xlsynth_g8r::ir_aig_sharing::{
     CandidateProofResult, IrAigCandidateRhs, IrAigSharingOptions, get_equivalences,
-    prove_equivalence_candidates_varisat,
+    prove_equivalence_candidates_cadical, prove_equivalence_candidates_varisat,
 };
 use xlsynth_g8r::ir2gate_utils::AdderMapping;
 use xlsynth_pir::ir_parser::Parser as PirParser;
@@ -75,4 +75,16 @@ top fn main(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
             .any(|p| matches!(p.result, CandidateProofResult::Proved)),
         "expected at least one candidate to be proven equivalent"
     );
+
+    let cadical_proofs =
+        prove_equivalence_candidates_cadical(pir_fn, &gate_fn, &hits, &gatify_opts)
+            .expect("prove equivalence candidates with cadical");
+    assert_eq!(cadical_proofs.len(), proofs.len());
+    for (cadical, varisat) in cadical_proofs.iter().zip(proofs.iter()) {
+        assert_eq!(cadical.candidate, varisat.candidate);
+        assert_eq!(
+            std::mem::discriminant(&cadical.result),
+            std::mem::discriminant(&varisat.result)
+        );
+    }
 }

--- a/xlsynth-g8r/tests/test_gate_equiv_varisat.rs
+++ b/xlsynth-g8r/tests/test_gate_equiv_varisat.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
-use xlsynth_g8r::prove_gate_fn_equiv_varisat::{Ctx, EquivResult, prove_gate_fn_equiv};
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{Ctx, EquivResult, prove_gate_fn_equiv};
 
 #[test]
 fn test_simple_equivalence() {


### PR DESCRIPTION
The underyling engine for gate-level work is not specified uniformly with --gate-formal-backend. It defaults to cadical. For use cases like ir-aig-sharing which only supported verisat before, cadical seems to be about 20% faster.