### PR TITLE
aot: emit imported parametric specializations in owner modules

### DIFF
--- a/xlsynth/src/aot_builder.rs
+++ b/xlsynth/src/aot_builder.rs
@@ -8,7 +8,7 @@
 //! ABI metadata, and emits a `Runner` that packs and unpacks bridge values
 //! directly.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -17,7 +17,7 @@ use crate::aot_entrypoint_metadata::{
     AotTypeLayout,
 };
 use crate::aot_lib::{AotCompiled, AotResult};
-use crate::dslx_bridge::convert_imported_module;
+use crate::dslx_bridge::{convert_imported_module, BridgeBuilder};
 use crate::rust_bridge_builder::{
     render_rust_module_fragments, rust_type_path_between_dslx_modules, RustBridgeBuilder,
 };
@@ -1120,6 +1120,29 @@ struct TypedDslxParam {
     ty: TypedDslxType,
 }
 
+/// One concrete parametric struct definition that typed AOT must materialize.
+///
+/// Rust bridge generation normally emits concrete parametric structs when the
+/// defining module itself references them. Typed AOT needs a package-level view
+/// so direct imported instantiations can still be emitted in the defining
+/// module even when only another module mentions them.
+struct TypedConcreteParametricStruct {
+    /// Exact DSLX struct declaration being specialized.
+    ///
+    /// Definition identity matters because sibling imports may both declare a
+    /// parametric struct with the same DSLX identifier.
+    struct_def: dslx::StructDef,
+    /// Canonical DSLX module name that owns the original struct declaration.
+    defining_module_name: String,
+    /// Concrete Rust struct identifier to emit inside the defining module.
+    ///
+    /// The suffix is derived from the fully bound parametric values, so it is
+    /// also the concrete-value portion of this specialization's key.
+    rust_name: String,
+    /// Concrete fields rendered relative to the defining module.
+    fields: Vec<TypedDslxField>,
+}
+
 /// The typed DSLX view of one AOT entrypoint signature.
 ///
 /// This is the semantic counterpart to `AotFunctionSignature`: it preserves
@@ -1194,6 +1217,17 @@ struct TypedDslxTypecheckedModules {
 struct ResolvedDslxTypeAnnotation<'a> {
     type_info: &'a dslx::TypeInfo,
     annotation: dslx::TypeAnnotation,
+}
+
+impl TypedDslxType {
+    fn rust_type(&self) -> &str {
+        match self {
+            TypedDslxType::Bits { rust_type, .. }
+            | TypedDslxType::Enum { rust_type, .. }
+            | TypedDslxType::Struct { rust_type, .. }
+            | TypedDslxType::Array { rust_type, .. } => rust_type,
+        }
+    }
 }
 
 /// A non-empty DSLX import subject such as `foo` or `foo.bar`.
@@ -1870,6 +1904,266 @@ impl TypedDslxTypeContext {
         }
         self.rust_type_for_concrete_type(local_module_name, current_type_info, ty)
     }
+}
+
+struct TypedConcreteParametricStructCollector<'a> {
+    context: &'a TypedDslxTypeContext,
+    current_module_name: String,
+    structs: Vec<TypedConcreteParametricStruct>,
+}
+
+impl<'a> TypedConcreteParametricStructCollector<'a> {
+    fn new(context: &'a TypedDslxTypeContext) -> Self {
+        Self {
+            context,
+            current_module_name: String::new(),
+            structs: Vec::new(),
+        }
+    }
+
+    fn collect_type(
+        &mut self,
+        current_module_name: &str,
+        current_type_info: &dslx::TypeInfo,
+        type_annotation: Option<&dslx::TypeAnnotation>,
+        ty: &dslx::Type,
+    ) -> AotResult<()> {
+        if let Some(type_annotation) = type_annotation {
+            if let Some(array_annotation) = type_annotation.to_array_type_annotation() {
+                if ty.is_array() {
+                    let element_annotation = array_annotation.get_element_type();
+                    let element_ty = ty.get_array_element_type();
+                    self.collect_type(
+                        current_module_name,
+                        current_type_info,
+                        Some(&element_annotation),
+                        &element_ty,
+                    )?;
+                    return Ok(());
+                }
+            }
+            if let Some(type_ref_annotation) = type_annotation.to_type_ref_type_annotation() {
+                if type_ref_annotation.get_parametric_count() > 0 && ty.is_struct() {
+                    let struct_def = ty.get_struct_def()?;
+                    let Some(defining_module) = self
+                        .context
+                        .defining_module_for_struct(Some(current_type_info), &struct_def)?
+                    else {
+                        return Err(XlsynthError(format!(
+                            "AOT typed DSLX specialization collection could not find defining module for struct `{}`",
+                            struct_def.get_identifier()
+                        )));
+                    };
+                    let rust_name = RustBridgeBuilder::rust_type_name_from_dslx_module(
+                        &defining_module.dslx_name,
+                        &defining_module.type_info,
+                        Some(type_annotation),
+                        ty,
+                    )?;
+                    let lowered = lower_typed_dslx_type(
+                        self.context,
+                        &defining_module.dslx_name,
+                        &defining_module.type_info,
+                        Some(type_annotation),
+                        ty,
+                        rust_name.clone(),
+                    )?;
+                    let TypedDslxType::Struct { fields, .. } = lowered else {
+                        unreachable!("parametric structs lower to struct types");
+                    };
+                    let already_collected = self.structs.iter().any(|existing| {
+                        existing.defining_module_name == defining_module.dslx_name
+                            && existing.struct_def.is_same_definition(&struct_def)
+                            && existing.rust_name == rust_name
+                    });
+                    if !already_collected {
+                        self.structs.push(TypedConcreteParametricStruct {
+                            struct_def,
+                            defining_module_name: defining_module.dslx_name.clone(),
+                            rust_name,
+                            fields,
+                        });
+                    }
+                }
+            }
+        }
+
+        if ty.is_struct() {
+            let struct_def = ty.get_struct_def()?;
+            let struct_type_info = self
+                .context
+                .type_info_for_struct(current_type_info, &struct_def)?;
+            let struct_module_name = self
+                .context
+                .defining_module_for_struct(Some(current_type_info), &struct_def)?
+                .map(|module| module.dslx_name.as_str())
+                .unwrap_or(current_module_name);
+            let member_count = struct_def.get_member_count();
+            for index in 0..member_count {
+                let member = struct_def.get_member(index);
+                let field_annotation = member.get_type();
+                let field_ty = if struct_def.is_parametric() {
+                    ty.get_struct_member_type(index)
+                } else {
+                    struct_type_info.get_type_for_struct_member(&member)
+                };
+                let field_type_info = self.context.type_context_for_resolved_type(
+                    struct_type_info,
+                    Some(&field_annotation),
+                    &field_ty,
+                )?;
+                self.collect_type(
+                    struct_module_name,
+                    field_type_info,
+                    Some(&field_annotation),
+                    &field_ty,
+                )?;
+            }
+        } else if ty.is_array() {
+            let element_ty = ty.get_array_element_type();
+            self.collect_type(current_module_name, current_type_info, None, &element_ty)?;
+        }
+        Ok(())
+    }
+
+    fn into_structs(self) -> Vec<TypedConcreteParametricStruct> {
+        self.structs
+    }
+}
+
+impl BridgeBuilder for TypedConcreteParametricStructCollector<'_> {
+    fn start_module(&mut self, module_name: &str) -> Result<(), XlsynthError> {
+        self.current_module_name = module_name.to_string();
+        Ok(())
+    }
+
+    fn end_module(&mut self, _module_name: &str) -> Result<(), XlsynthError> {
+        Ok(())
+    }
+
+    fn add_enum_def(
+        &mut self,
+        _dslx_name: &str,
+        _is_signed: bool,
+        _underlying_bit_count: usize,
+        _members: &[(String, crate::IrValue)],
+    ) -> Result<(), XlsynthError> {
+        Ok(())
+    }
+
+    fn add_struct_def(
+        &mut self,
+        _dslx_name: &str,
+        _members: &[crate::dslx_bridge::StructMemberData],
+    ) -> Result<(), XlsynthError> {
+        Ok(())
+    }
+
+    fn add_struct_def_typed(
+        &mut self,
+        _dslx_name: &str,
+        type_info: &dslx::TypeInfo,
+        members: &[crate::dslx_bridge::StructMemberData],
+    ) -> Result<(), XlsynthError> {
+        let module_name = self.current_module_name.clone();
+        for member in members {
+            self.collect_type(
+                &module_name,
+                type_info,
+                Some(&member.type_annotation),
+                &member.concrete_type,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn add_alias(
+        &mut self,
+        _dslx_name: &str,
+        _type_annotation: &dslx::TypeAnnotation,
+        _ty: &dslx::Type,
+    ) -> Result<(), XlsynthError> {
+        Ok(())
+    }
+
+    fn add_alias_typed(
+        &mut self,
+        _dslx_name: &str,
+        type_info: &dslx::TypeInfo,
+        type_annotation: &dslx::TypeAnnotation,
+        ty: &dslx::Type,
+    ) -> Result<(), XlsynthError> {
+        let module_name = self.current_module_name.clone();
+        self.collect_type(&module_name, type_info, Some(type_annotation), ty)
+    }
+
+    fn add_constant(
+        &mut self,
+        _name: &str,
+        _constant_def: &dslx::ConstantDef,
+        _ty: &dslx::Type,
+        _ir_value: &crate::IrValue,
+    ) -> Result<(), XlsynthError> {
+        Ok(())
+    }
+
+    fn add_function_signature_typed(
+        &mut self,
+        _dslx_name: &str,
+        type_info: &dslx::TypeInfo,
+        params: &[crate::dslx_bridge::FunctionParamData],
+        return_type_annotation: Option<&dslx::TypeAnnotation>,
+        return_type: Option<&dslx::Type>,
+    ) -> Result<(), XlsynthError> {
+        let module_name = self.current_module_name.clone();
+        for param in params {
+            if let Some(concrete_type) = &param.concrete_type {
+                self.collect_type(
+                    &module_name,
+                    type_info,
+                    Some(&param.type_annotation),
+                    concrete_type,
+                )?;
+            }
+        }
+        if let (Some(type_annotation), Some(ty)) = (return_type_annotation, return_type) {
+            self.collect_type(&module_name, type_info, Some(type_annotation), ty)?;
+        }
+        Ok(())
+    }
+}
+
+fn collect_typed_concrete_parametric_structs(
+    context: &TypedDslxTypeContext,
+    typechecked: &TypedDslxTypecheckedModules,
+) -> AotResult<Vec<TypedConcreteParametricStruct>> {
+    let mut collector = TypedConcreteParametricStructCollector::new(context);
+    for module in typechecked
+        .bridge_modules
+        .iter()
+        .chain(std::iter::once(&typechecked.top_module))
+    {
+        convert_imported_module(module, &mut collector)?;
+    }
+    Ok(collector.into_structs())
+}
+
+fn render_typed_concrete_parametric_struct(
+    concrete_struct: &TypedConcreteParametricStruct,
+) -> String {
+    let mut lines = vec![
+        "#[allow(non_camel_case_types)]".to_string(),
+        "#[derive(Debug, Clone, PartialEq, Eq)]".to_string(),
+        format!("pub struct {} {{", concrete_struct.rust_name),
+    ];
+    lines.extend(
+        concrete_struct
+            .fields
+            .iter()
+            .map(|field| format!("    pub {}: {},", field.name, field.ty.rust_type())),
+    );
+    lines.push("}\n".to_string());
+    lines.join("\n")
 }
 
 /// Lowers one DSLX type into the semantic model used by typed AOT generation.
@@ -2839,17 +3133,49 @@ fn render_typed_dslx_generated_module(
         signature,
         &typed_signature,
     )?;
+    let concrete_parametric_structs =
+        collect_typed_concrete_parametric_structs(&context, &typechecked)?;
+    let mut leading_items_by_module =
+        concrete_parametric_structs
+            .into_iter()
+            .fold(BTreeMap::new(), |mut items, item| {
+                items
+                    .entry(item.defining_module_name.clone())
+                    .or_insert_with(Vec::new)
+                    .push(render_typed_concrete_parametric_struct(&item));
+                items
+            });
 
     let mut modules = Vec::with_capacity(spec.type_module_paths.len() + 1);
     for bridge_module in &typechecked.bridge_modules {
-        let mut builder = RustBridgeBuilder::new();
+        let module_name = bridge_module.get_module().get_name();
+        let mut builder = RustBridgeBuilder::new()
+            .with_leading_items(
+                leading_items_by_module
+                    .remove(&module_name)
+                    .unwrap_or_default(),
+            )
+            .with_deferred_parametric_struct_emission();
         convert_imported_module(bridge_module, &mut builder)?;
         modules.push(builder.module_fragment());
     }
 
-    let mut top_builder = RustBridgeBuilder::new().with_runner_items(runner_epilogue);
+    let top_module_name = typechecked.top_module.get_module().get_name();
+    let mut top_builder = RustBridgeBuilder::new()
+        .with_leading_items(
+            leading_items_by_module
+                .remove(&top_module_name)
+                .unwrap_or_default(),
+        )
+        .with_deferred_parametric_struct_emission()
+        .with_runner_items(runner_epilogue);
     convert_imported_module(&typechecked.top_module, &mut top_builder)?;
     modules.push(top_builder.module_fragment());
+    if let Some((module_name, _)) = leading_items_by_module.into_iter().next() {
+        return Err(XlsynthError(format!(
+            "AOT typed DSLX specialization collection requires bridge module `{module_name}` to be emitted"
+        )));
+    }
 
     Ok(format!(
         "// SPDX-License-Identifier: Apache-2.0\n// Generated by xlsynth::aot_builder from DSLX build spec {:?}.\n\n{}\n",
@@ -3179,5 +3505,52 @@ mod tests {
         assert_eq!(typed_signature.params.len(), 1);
         assert_eq!(typed_dslx_leaf_count(&typed_signature.params[0].ty), 1);
         assert_eq!(typed_dslx_leaf_count(&typed_signature.return_type), 1);
+    }
+
+    // Verifies: concrete specializations remain distinct when sibling imports
+    // declare same-named parametric structs with the same bound values.
+    // Catches: dedupe keyed only by generated Rust name.
+    #[test]
+    fn concrete_parametric_struct_collection_uses_struct_definition_identity_when_names_collide() {
+        let tmpdir = xlsynth_test_helpers::make_test_tmpdir(
+            "xlsynth_aot_builder_duplicate_parametric_struct_names",
+        );
+        let a_path = tmpdir.path().join("a.x");
+        let b_path = tmpdir.path().join("b.x");
+        let top_path = tmpdir.path().join("top.x");
+        std::fs::write(&a_path, "pub struct Widget<N: u32> { value: bits[N] }").unwrap();
+        std::fs::write(&b_path, "pub struct Widget<N: u32> { value: bits[N] }").unwrap();
+        std::fs::write(
+            &top_path,
+            "import a; import b; pub fn frob(lhs: a::Widget<u32:8>, rhs: b::Widget<u32:8>) -> (a::Widget<u32:8>, b::Widget<u32:8>) { (lhs, rhs) }",
+        )
+        .unwrap();
+
+        let dslx_options = DslxConvertOptions {
+            additional_search_paths: vec![tmpdir.path()],
+            ..Default::default()
+        };
+        let spec = TypedDslxAotBuildSpec {
+            name: "duplicate_parametric_struct_names",
+            dslx_path: &top_path,
+            top: "frob",
+            dslx_options,
+            type_module_paths: vec![&a_path, &b_path],
+        };
+        let top_dslx_text = std::fs::read_to_string(&top_path).unwrap();
+        let typechecked = typecheck_typed_dslx_modules(&spec, &top_dslx_text).unwrap();
+        let context = TypedDslxTypeContext::new(&typechecked);
+
+        let structs = collect_typed_concrete_parametric_structs(&context, &typechecked)
+            .expect("same-named imported parametric structs should remain distinct");
+
+        assert_eq!(structs.len(), 2);
+        assert_eq!(
+            structs
+                .iter()
+                .map(|item| (item.defining_module_name.as_str(), item.rust_name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("a", "Widget__N_8"), ("b", "Widget__N_8")]
+        );
     }
 }

--- a/xlsynth/src/rust_bridge_builder.rs
+++ b/xlsynth/src/rust_bridge_builder.rs
@@ -25,7 +25,9 @@ pub struct RustBridgeBuilder {
     lines: Vec<String>,
     module_path: Vec<String>,
     runner_items: Option<String>,
+    leading_items: Vec<String>,
     emitted_parametric_structs: BTreeSet<String>,
+    defer_parametric_struct_emission: bool,
 }
 
 /// Rust items generated for one DSLX module, before parent modules are
@@ -107,7 +109,9 @@ impl RustBridgeBuilder {
             lines: vec![],
             module_path: vec![],
             runner_items: None,
+            leading_items: vec![],
             emitted_parametric_structs: BTreeSet::new(),
+            defer_parametric_struct_emission: false,
         }
     }
 
@@ -117,6 +121,25 @@ impl RustBridgeBuilder {
     /// definitions for the top function.
     pub(crate) fn with_runner_items(mut self, runner_items: impl Into<String>) -> Self {
         self.runner_items = Some(runner_items.into());
+        self
+    }
+
+    /// Adds generated items immediately after the module preamble.
+    pub(crate) fn with_leading_items(
+        mut self,
+        leading_items: impl IntoIterator<Item = String>,
+    ) -> Self {
+        self.leading_items = leading_items.into_iter().collect();
+        self
+    }
+
+    /// Defers concrete parametric struct definitions to a package-level pass.
+    ///
+    /// Typed DSLX AOT generation uses this when it renders several modules
+    /// together and has already collected the concrete specializations that
+    /// should be emitted in their defining modules.
+    pub(crate) fn with_deferred_parametric_struct_emission(mut self) -> Self {
+        self.defer_parametric_struct_emission = true;
         self
     }
 
@@ -360,6 +383,9 @@ impl RustBridgeBuilder {
         if type_ref_annotation.get_parametric_count() == 0 {
             return Ok(());
         }
+        if self.defer_parametric_struct_emission {
+            return Ok(());
+        }
         let Some(rust_ty) = Self::convert_type_ref_annotation(
             &self.module_path,
             Some(type_info),
@@ -448,6 +474,7 @@ impl BridgeBuilder for RustBridgeBuilder {
             "#![allow(unused_imports)]".to_string(),
             "use xlsynth::{IrValue, IrUBits, IrSBits};\n".to_string(),
         ];
+        self.lines.extend(self.leading_items.clone());
         Ok(())
     }
 

--- a/xlsynth/tests/aot-test-crate/src/lib.rs
+++ b/xlsynth/tests/aot-test-crate/src/lib.rs
@@ -263,11 +263,11 @@ mod tests {
         Ok(())
     }
 
-    // Verifies: imported concrete aliases execute while direct imported
-    // parametric instantiations remain unsupported.
-    // Catches: imported alias encode/decode regressions.
+    // Verifies: direct imported concrete parametric instantiations execute and
+    // owner-module emission handles nested arrays plus multi-parameter shapes.
+    // Catches: regressions back to alias-only imported parametric support.
     #[test]
-    fn parametric_imports_aot_executes_imported_aliases() -> Result<(), XlsynthError> {
+    fn parametric_imports_aot_executes_direct_imports() -> Result<(), XlsynthError> {
         use super::parametric_imports_aot::{parametric_imports, parametric_lib};
         use parametric_imports::{Box__N_8, LocalMode, Mixed__N_4};
 
@@ -276,17 +276,28 @@ mod tests {
             remote: parametric_lib::RemotePlain { id: ub(40) },
             nested: [[ub(1), ub(2), ub(3), ub(4)], [ub(5), ub(6), ub(7), ub(8)]],
             boxes: [Box__N_8 { value: ub(50) }, Box__N_8 { value: ub(51) }],
+            remote_boxes: [
+                parametric_lib::RemoteBox__N_8 { value: ub(52) },
+                parametric_lib::RemoteBox__N_8 { value: ub(53) },
+            ],
         };
-        let imported_alias = parametric_lib::RemoteBox__N_8 { value: ub(60) };
+        let imported_direct = parametric_lib::RemoteBox__N_8 { value: ub(60) };
+        let imported_pair = parametric_lib::RemotePair__A_8__B_23 {
+            left: ub(61),
+            right: ub(62),
+        };
 
         let mut runner = parametric_imports::new_runner()?;
-        let result = runner.run(&mixed, &imported_alias)?;
+        let result = runner.run(&mixed, &imported_direct, &imported_pair)?;
 
         assert_eq!(result.mixed.mode, LocalMode::Busy);
         assert_eq!(result.mixed.remote.id.to_u64()?, 40);
         assert_eq!(result.mixed.nested[1][2].to_u64()?, 7);
         assert_eq!(result.mixed.boxes[1].value.to_u64()?, 51);
-        assert_eq!(result.imported_alias.value.to_u64()?, 60);
+        assert_eq!(result.mixed.remote_boxes[1].value.to_u64()?, 53);
+        assert_eq!(result.imported_direct.value.to_u64()?, 60);
+        assert_eq!(result.imported_pair.left.to_u64()?, 61);
+        assert_eq!(result.imported_pair.right.to_u64()?, 62);
         Ok(())
     }
 
@@ -317,7 +328,9 @@ mod tests {
         assert!(imports.contains("pub struct Mixed__N_4"));
         assert!(imports.contains("pub remote: super::parametric_lib::RemotePlain"));
         assert!(imports.contains("pub boxes: [Box__N_8; 2]"));
-        assert!(imports.contains("imported_alias: &ImportedAlias"));
+        assert!(imports.contains("pub remote_boxes: [super::parametric_lib::RemoteBox__N_8; 2]"));
+        assert!(imports.contains("imported_direct: &super::parametric_lib::RemoteBox__N_8"));
+        assert!(imports.contains("imported_pair: &super::parametric_lib::RemotePair__A_8__B_23"));
     }
 
     // Verifies: duplicate imported type names use canonical nested paths.

--- a/xlsynth/tests/aot-test-crate/src/parametric_imports.x
+++ b/xlsynth/tests/aot-test-crate/src/parametric_imports.x
@@ -16,22 +16,25 @@ struct Mixed<N: u32> {
     remote: parametric_lib::RemotePlain,
     nested: u8[N][2],
     boxes: Box<u32:8>[2],
+    remote_boxes: parametric_lib::RemoteBox<u32:8>[2],
 }
 
 type Mixed4 = Mixed<u32:4>;
-type ImportedAlias = parametric_lib::RemoteBox8;
 
 struct ParametricImportsResult {
     mixed: Mixed4,
-    imported_alias: ImportedAlias,
+    imported_direct: parametric_lib::RemoteBox<u32:8>,
+    imported_pair: parametric_lib::RemotePair<u32:8, u32:23>,
 }
 
 pub fn exercise_parametric_imports(
     mixed: Mixed4,
-    imported_alias: ImportedAlias,
+    imported_direct: parametric_lib::RemoteBox<u32:8>,
+    imported_pair: parametric_lib::RemotePair<u32:8, u32:23>,
 ) -> ParametricImportsResult {
     ParametricImportsResult {
         mixed,
-        imported_alias,
+        imported_direct,
+        imported_pair,
     }
 }

--- a/xlsynth/tests/aot-test-crate/src/parametric_lib.x
+++ b/xlsynth/tests/aot-test-crate/src/parametric_lib.x
@@ -8,6 +8,11 @@ pub struct RemoteBox<N: u32> {
     value: bits[N],
 }
 
+pub struct RemotePair<A: u32, B: u32> {
+    left: bits[A],
+    right: bits[B],
+}
+
 pub type RemoteBox8 = RemoteBox<u32:8>;
 
 pub fn force_remote_box8(x: RemoteBox<u32:8>) -> RemoteBox<u32:8> {

--- a/xlsynth/tests/aot-test-crate/tests/goldens/parametric_arrays_wrapper.rs
+++ b/xlsynth/tests/aot-test-crate/tests/goldens/parametric_arrays_wrapper.rs
@@ -12,21 +12,21 @@ pub mod parametric_arrays {
         pub items: [IrUBits<8>; 4],
     }
 
-    pub type ArrayBox4 = ArrayBox__N_4;
-
     #[allow(non_camel_case_types)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct Box__N_8 {
         pub value: IrUBits<8>,
     }
 
-    pub type Box8Array4 = [Box__N_8; 4];
-
     #[allow(non_camel_case_types)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct Box__N_16 {
         pub value: IrUBits<16>,
     }
+
+    pub type ArrayBox4 = ArrayBox__N_4;
+
+    pub type Box8Array4 = [Box__N_8; 4];
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct OuterBox {

--- a/xlsynth/tests/aot-test-crate/tests/goldens/parametric_imports_wrapper.rs
+++ b/xlsynth/tests/aot-test-crate/tests/goldens/parametric_imports_wrapper.rs
@@ -6,6 +6,22 @@ pub mod parametric_imports {
     #![allow(unused_imports)]
     use xlsynth::{IrSBits, IrUBits, IrValue};
 
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct Mixed__N_4 {
+        pub mode: LocalMode,
+        pub remote: super::parametric_lib::RemotePlain,
+        pub nested: [[IrUBits<8>; 4]; 2],
+        pub boxes: [Box__N_8; 2],
+        pub remote_boxes: [super::parametric_lib::RemoteBox__N_8; 2],
+    }
+
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct Box__N_8 {
+        pub value: IrUBits<8>,
+    }
+
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum LocalMode {
         Idle = 0,
@@ -21,29 +37,13 @@ pub mod parametric_imports {
         }
     }
 
-    #[allow(non_camel_case_types)]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct Box__N_8 {
-        pub value: IrUBits<8>,
-    }
-
-    #[allow(non_camel_case_types)]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct Mixed__N_4 {
-        pub mode: LocalMode,
-        pub remote: super::parametric_lib::RemotePlain,
-        pub nested: [[IrUBits<8>; 4]; 2],
-        pub boxes: [Box__N_8; 2],
-    }
-
     pub type Mixed4 = Mixed__N_4;
-
-    pub type ImportedAlias = super::parametric_lib::RemoteBox8;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct ParametricImportsResult {
         pub mixed: Mixed4,
-        pub imported_alias: ImportedAlias,
+        pub imported_direct: super::parametric_lib::RemoteBox__N_8,
+        pub imported_pair: super::parametric_lib::RemotePair__A_8__B_23,
     }
 
     unsafe extern "C" {
@@ -52,9 +52,9 @@ pub mod parametric_imports {
     }
 
     const ENTRYPOINTS_PROTO: &[u8] = include_bytes!("parametric_imports.entrypoints.pb");
-    const INPUT_BUFFER_SIZES: &[usize] = &[12, 1];
-    const INPUT_BUFFER_ALIGNMENTS: &[usize] = &[8, 8];
-    const OUTPUT_BUFFER_SIZES: &[usize] = &[13];
+    const INPUT_BUFFER_SIZES: &[usize] = &[14, 1, 8];
+    const INPUT_BUFFER_ALIGNMENTS: &[usize] = &[8, 8, 8];
+    const OUTPUT_BUFFER_SIZES: &[usize] = &[24];
     const OUTPUT_BUFFER_ALIGNMENTS: &[usize] = &[8];
 
     const INPUT0_LAYOUT: &[xlsynth::aot_entrypoint_metadata::AotElementLayout] = &[
@@ -118,6 +118,16 @@ pub mod parametric_imports {
             data_size: 1,
             padded_size: 1,
         },
+        xlsynth::aot_entrypoint_metadata::AotElementLayout {
+            offset: 12,
+            data_size: 1,
+            padded_size: 1,
+        },
+        xlsynth::aot_entrypoint_metadata::AotElementLayout {
+            offset: 13,
+            data_size: 1,
+            padded_size: 1,
+        },
     ];
     const INPUT1_LAYOUT: &[xlsynth::aot_entrypoint_metadata::AotElementLayout] =
         &[xlsynth::aot_entrypoint_metadata::AotElementLayout {
@@ -125,6 +135,18 @@ pub mod parametric_imports {
             data_size: 1,
             padded_size: 1,
         }];
+    const INPUT2_LAYOUT: &[xlsynth::aot_entrypoint_metadata::AotElementLayout] = &[
+        xlsynth::aot_entrypoint_metadata::AotElementLayout {
+            offset: 0,
+            data_size: 1,
+            padded_size: 1,
+        },
+        xlsynth::aot_entrypoint_metadata::AotElementLayout {
+            offset: 4,
+            data_size: 3,
+            padded_size: 4,
+        },
+    ];
     const OUTPUT0_LAYOUT: &[xlsynth::aot_entrypoint_metadata::AotElementLayout] = &[
         xlsynth::aot_entrypoint_metadata::AotElementLayout {
             offset: 0,
@@ -191,11 +213,31 @@ pub mod parametric_imports {
             data_size: 1,
             padded_size: 1,
         },
+        xlsynth::aot_entrypoint_metadata::AotElementLayout {
+            offset: 13,
+            data_size: 1,
+            padded_size: 1,
+        },
+        xlsynth::aot_entrypoint_metadata::AotElementLayout {
+            offset: 14,
+            data_size: 1,
+            padded_size: 1,
+        },
+        xlsynth::aot_entrypoint_metadata::AotElementLayout {
+            offset: 16,
+            data_size: 1,
+            padded_size: 1,
+        },
+        xlsynth::aot_entrypoint_metadata::AotElementLayout {
+            offset: 20,
+            data_size: 3,
+            padded_size: 4,
+        },
     ];
 
     #[allow(clippy::deref_addrof, clippy::explicit_auto_deref, clippy::identity_op)]
     fn encode_input_0(_value: &Mixed4, dst: &mut [u8]) -> Result<(), xlsynth::XlsynthError> {
-        debug_assert_eq!(dst.len(), 12);
+        debug_assert_eq!(dst.len(), 14);
         dst.fill(0);
         let encoded_value: u64 = match (*_value).mode {
             LocalMode::Idle => 0,
@@ -224,12 +266,23 @@ pub mod parametric_imports {
                 &encoded_bytes,
             );
         }
-        debug_assert_eq!(INPUT0_LAYOUT.len(), 12);
+        for index_3 in 0..2 {
+            let encoded_bytes = ((((*_value).remote_boxes)[index_3]).value).to_le_bytes()?;
+            xlsynth::aot_runner::write_leaf_element(
+                dst,
+                &INPUT0_LAYOUT[0usize + 12 + index_3],
+                &encoded_bytes,
+            );
+        }
+        debug_assert_eq!(INPUT0_LAYOUT.len(), 14);
         Ok(())
     }
 
     #[allow(clippy::deref_addrof, clippy::explicit_auto_deref, clippy::identity_op)]
-    fn encode_input_1(_value: &ImportedAlias, dst: &mut [u8]) -> Result<(), xlsynth::XlsynthError> {
+    fn encode_input_1(
+        _value: &super::parametric_lib::RemoteBox__N_8,
+        dst: &mut [u8],
+    ) -> Result<(), xlsynth::XlsynthError> {
         debug_assert_eq!(dst.len(), 1);
         dst.fill(0);
         let encoded_bytes = ((*_value).value).to_le_bytes()?;
@@ -239,8 +292,23 @@ pub mod parametric_imports {
     }
 
     #[allow(clippy::deref_addrof, clippy::explicit_auto_deref, clippy::identity_op)]
+    fn encode_input_2(
+        _value: &super::parametric_lib::RemotePair__A_8__B_23,
+        dst: &mut [u8],
+    ) -> Result<(), xlsynth::XlsynthError> {
+        debug_assert_eq!(dst.len(), 8);
+        dst.fill(0);
+        let encoded_bytes = ((*_value).left).to_le_bytes()?;
+        xlsynth::aot_runner::write_leaf_element(dst, &INPUT2_LAYOUT[0usize], &encoded_bytes);
+        let encoded_bytes = ((*_value).right).to_le_bytes()?;
+        xlsynth::aot_runner::write_leaf_element(dst, &INPUT2_LAYOUT[0usize + 1], &encoded_bytes);
+        debug_assert_eq!(INPUT2_LAYOUT.len(), 2);
+        Ok(())
+    }
+
+    #[allow(clippy::deref_addrof, clippy::explicit_auto_deref, clippy::identity_op)]
     fn decode_output_0(src: &[u8]) -> Result<ParametricImportsResult, xlsynth::XlsynthError> {
-        debug_assert_eq!(src.len(), 13);
+        debug_assert_eq!(src.len(), 24);
         let mut decoded_bytes_0 = vec![0u8; 1];
         xlsynth::aot_runner::read_leaf_element(src, &OUTPUT0_LAYOUT[0usize], &mut decoded_bytes_0);
         let decoded_bits_1 = xlsynth::IrUBits::<2>::from_le_bytes(&decoded_bytes_0)?;
@@ -323,28 +391,72 @@ pub mod parametric_imports {
                     )))
                 }
             };
-        let decoded_value_18 = Mixed4 {
+        let mut decoded_items_19 = Vec::with_capacity(2);
+        for index_3 in 0..2 {
+            let mut decoded_bytes_20 = vec![0u8; 1];
+            xlsynth::aot_runner::read_leaf_element(
+                src,
+                &OUTPUT0_LAYOUT[0usize + 12 + index_3],
+                &mut decoded_bytes_20,
+            );
+            let decoded_value_21 = xlsynth::IrUBits::<8>::from_le_bytes(&decoded_bytes_20)?;
+            let decoded_value_22 = super::parametric_lib::RemoteBox__N_8 {
+                value: decoded_value_21,
+            };
+            decoded_items_19.push(decoded_value_22);
+        }
+        let decoded_value_18: [super::parametric_lib::RemoteBox__N_8; 2] =
+            match std::convert::TryInto::try_into(decoded_items_19) {
+                Ok(value) => value,
+                Err(values) => {
+                    return Err(xlsynth::XlsynthError(format!(
+                        "AOT decode internal error: expected 2 array elements, got {}",
+                        values.len()
+                    )))
+                }
+            };
+        let decoded_value_23 = Mixed4 {
             mode: decoded_value_3,
             remote: decoded_value_6,
             nested: decoded_value_7,
             boxes: decoded_value_13,
+            remote_boxes: decoded_value_18,
         };
-        let mut decoded_bytes_19 = vec![0u8; 1];
+        let mut decoded_bytes_24 = vec![0u8; 1];
         xlsynth::aot_runner::read_leaf_element(
             src,
-            &OUTPUT0_LAYOUT[0usize + 12],
-            &mut decoded_bytes_19,
+            &OUTPUT0_LAYOUT[0usize + 14],
+            &mut decoded_bytes_24,
         );
-        let decoded_value_20 = xlsynth::IrUBits::<8>::from_le_bytes(&decoded_bytes_19)?;
-        let decoded_value_21 = ImportedAlias {
-            value: decoded_value_20,
+        let decoded_value_25 = xlsynth::IrUBits::<8>::from_le_bytes(&decoded_bytes_24)?;
+        let decoded_value_26 = super::parametric_lib::RemoteBox__N_8 {
+            value: decoded_value_25,
         };
-        let decoded_value_22 = ParametricImportsResult {
-            mixed: decoded_value_18,
-            imported_alias: decoded_value_21,
+        let mut decoded_bytes_27 = vec![0u8; 1];
+        xlsynth::aot_runner::read_leaf_element(
+            src,
+            &OUTPUT0_LAYOUT[0usize + 15],
+            &mut decoded_bytes_27,
+        );
+        let decoded_value_28 = xlsynth::IrUBits::<8>::from_le_bytes(&decoded_bytes_27)?;
+        let mut decoded_bytes_29 = vec![0u8; 3];
+        xlsynth::aot_runner::read_leaf_element(
+            src,
+            &OUTPUT0_LAYOUT[0usize + 15 + 1],
+            &mut decoded_bytes_29,
+        );
+        let decoded_value_30 = xlsynth::IrUBits::<23>::from_le_bytes(&decoded_bytes_29)?;
+        let decoded_value_31 = super::parametric_lib::RemotePair__A_8__B_23 {
+            left: decoded_value_28,
+            right: decoded_value_30,
         };
-        debug_assert_eq!(OUTPUT0_LAYOUT.len(), 13);
-        Ok(decoded_value_22)
+        let decoded_value_32 = ParametricImportsResult {
+            mixed: decoded_value_23,
+            imported_direct: decoded_value_26,
+            imported_pair: decoded_value_31,
+        };
+        debug_assert_eq!(OUTPUT0_LAYOUT.len(), 17);
+        Ok(decoded_value_32)
     }
 
     pub fn descriptor() -> xlsynth::AotEntrypointDescriptor<'static> {
@@ -395,10 +507,12 @@ pub mod parametric_imports {
         pub fn run_with_events(
             &mut self,
             mixed: &Mixed4,
-            imported_alias: &ImportedAlias,
+            imported_direct: &super::parametric_lib::RemoteBox__N_8,
+            imported_pair: &super::parametric_lib::RemotePair__A_8__B_23,
         ) -> Result<xlsynth::AotRunResult<ParametricImportsResult>, xlsynth::XlsynthError> {
             encode_input_0(mixed, self.inner.input_mut(0))?;
-            encode_input_1(imported_alias, self.inner.input_mut(1))?;
+            encode_input_1(imported_direct, self.inner.input_mut(1))?;
+            encode_input_2(imported_pair, self.inner.input_mut(2))?;
             let result = self
                 .inner
                 .run_with_events(|inner| decode_output_0(inner.output(0)))?;
@@ -418,10 +532,12 @@ pub mod parametric_imports {
         pub fn run(
             &mut self,
             mixed: &Mixed4,
-            imported_alias: &ImportedAlias,
+            imported_direct: &super::parametric_lib::RemoteBox__N_8,
+            imported_pair: &super::parametric_lib::RemotePair__A_8__B_23,
         ) -> Result<ParametricImportsResult, xlsynth::XlsynthError> {
             encode_input_0(mixed, self.inner.input_mut(0))?;
-            encode_input_1(imported_alias, self.inner.input_mut(1))?;
+            encode_input_1(imported_direct, self.inner.input_mut(1))?;
+            encode_input_2(imported_pair, self.inner.input_mut(2))?;
             self.inner.run()?;
             decode_output_0(self.inner.output(0))
         }
@@ -437,15 +553,22 @@ pub mod parametric_lib {
     #![allow(unused_imports)]
     use xlsynth::{IrSBits, IrUBits, IrValue};
 
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct RemotePlain {
-        pub id: IrUBits<8>,
-    }
-
     #[allow(non_camel_case_types)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct RemoteBox__N_8 {
         pub value: IrUBits<8>,
+    }
+
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct RemotePair__A_8__B_23 {
+        pub left: IrUBits<8>,
+        pub right: IrUBits<23>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct RemotePlain {
+        pub id: IrUBits<8>,
     }
 
     pub type RemoteBox8 = RemoteBox__N_8;

--- a/xlsynth/tests/aot-test-crate/tests/goldens/parametric_shapes_wrapper.rs
+++ b/xlsynth/tests/aot-test-crate/tests/goldens/parametric_shapes_wrapper.rs
@@ -12,21 +12,21 @@ pub mod parametric_shapes {
         pub value: IrUBits<8>,
     }
 
-    pub type Box8 = Box__N_8;
-
     #[allow(non_camel_case_types)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct Box__N_16 {
         pub value: IrUBits<16>,
     }
 
-    pub type Box16 = Box__N_16;
-
     #[allow(non_camel_case_types)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct Matrix__R_2__C_3 {
         pub rows: [[IrUBits<8>; 3]; 2],
     }
+
+    pub type Box8 = Box__N_8;
+
+    pub type Box16 = Box__N_16;
 
     pub type Matrix2x3 = Matrix__R_2__C_3;
 

--- a/xlsynth/tests/aot-test-crate/tests/goldens/parametric_values_wrapper.rs
+++ b/xlsynth/tests/aot-test-crate/tests/goldens/parametric_values_wrapper.rs
@@ -12,21 +12,21 @@ pub mod parametric_values {
         pub value: IrUBits<8>,
     }
 
-    pub type ExprBox8 = ExprBox__N_8;
-
     #[allow(non_camel_case_types)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct SignedTag__S_m3 {
         pub payload: IrUBits<8>,
     }
 
-    pub type NegativeTag = SignedTag__S_m3;
-
     #[allow(non_camel_case_types)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct WideTag__W_18446744073709551616 {
         pub payload: IrUBits<8>,
     }
+
+    pub type ExprBox8 = ExprBox__N_8;
+
+    pub type NegativeTag = SignedTag__S_m3;
 
     pub type HugeTag = WideTag__W_18446744073709551616;
 


### PR DESCRIPTION
## Summary

- emit imported concrete parametric struct specializations in the generated module that owns the DSLX declaration
- dedupe those specializations by defining module, exact struct identity, and bound values
- add regression coverage for direct imports, duplicate same-named imports, nested arrays, and an APFloat-shaped two-parameter case

## Testing

- `cargo test -p xlsynth --lib rust_bridge_builder`
- `cargo test -p xlsynth --lib aot_builder`
- `cargo test -p xlsynth-aot-test-crate`
- `cargo clippy -p xlsynth --tests --no-deps`
- `cargo fmt --all --check`
