### PR TITLE
aot: consume producer-owned runtime link metadata

### DIFF
--- a/xlsynth-aot-runtime/build.rs
+++ b/xlsynth-aot-runtime/build.rs
@@ -3,33 +3,34 @@
 use std::path::{Path, PathBuf};
 
 const XLS_AOT_RUNTIME_PATH_ENV: &str = "XLS_AOT_RUNTIME_PATH";
+const XLS_AOT_RUNTIME_LINK_CONFIG_PATH_ENV: &str = "XLS_AOT_RUNTIME_LINK_CONFIG_PATH";
 const XLSYNTH_ARTIFACT_CONFIG_ENV: &str = "XLSYNTH_ARTIFACT_CONFIG";
 
-fn path_from_artifact_config(config_path: &Path) -> PathBuf {
-    if !config_path.is_absolute() {
-        panic!(
-            "{XLSYNTH_ARTIFACT_CONFIG_ENV} must be absolute, got {}",
-            config_path.display()
-        );
-    }
-    let config_text = std::fs::read_to_string(config_path).unwrap_or_else(|error| {
-        panic!(
-            "failed to read {XLSYNTH_ARTIFACT_CONFIG_ENV} {}: {error}",
-            config_path.display()
-        )
-    });
-    let config = config_text.parse::<toml::Table>().unwrap_or_else(|error| {
-        panic!(
-            "failed to parse {XLSYNTH_ARTIFACT_CONFIG_ENV} {}: {error}",
-            config_path.display()
-        )
-    });
+struct RuntimeInputs {
+    archive_path: PathBuf,
+    link_config_path: PathBuf,
+}
+
+struct RuntimeLinkConfig {
+    system_libraries: Vec<String>,
+    frameworks: Vec<String>,
+}
+
+fn parse_toml_file(path: &Path, label: &str) -> toml::Table {
+    let config_text = std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("failed to read {label} {}: {error}", path.display()));
+    config_text
+        .parse::<toml::Table>()
+        .unwrap_or_else(|error| panic!("failed to parse {label} {}: {error}", path.display()))
+}
+
+fn resolve_artifact_config_path(config_path: &Path, config: &toml::Table, key: &str) -> PathBuf {
     let raw_path = config
-        .get("aot_runtime_path")
+        .get(key)
         .and_then(toml::Value::as_str)
         .unwrap_or_else(|| {
             panic!(
-                "{XLSYNTH_ARTIFACT_CONFIG_ENV} {} is missing string field aot_runtime_path",
+                "{XLSYNTH_ARTIFACT_CONFIG_ENV} {} is missing string field {key}",
                 config_path.display()
             )
         });
@@ -49,25 +50,122 @@ fn path_from_artifact_config(config_path: &Path) -> PathBuf {
     }
 }
 
-fn resolve_archive_path() -> PathBuf {
-    if let Some(path) = std::env::var_os(XLS_AOT_RUNTIME_PATH_ENV) {
-        PathBuf::from(path)
+fn runtime_inputs_from_artifact_config(config_path: &Path) -> RuntimeInputs {
+    if !config_path.is_absolute() {
+        panic!(
+            "{XLSYNTH_ARTIFACT_CONFIG_ENV} must be absolute, got {}",
+            config_path.display()
+        );
+    }
+    let config = parse_toml_file(config_path, XLSYNTH_ARTIFACT_CONFIG_ENV);
+    RuntimeInputs {
+        archive_path: resolve_artifact_config_path(config_path, &config, "aot_runtime_path"),
+        link_config_path: resolve_artifact_config_path(
+            config_path,
+            &config,
+            "aot_runtime_link_config_path",
+        ),
+    }
+}
+
+fn resolve_runtime_inputs() -> RuntimeInputs {
+    let archive_path = std::env::var_os(XLS_AOT_RUNTIME_PATH_ENV);
+    let link_config_path = std::env::var_os(XLS_AOT_RUNTIME_LINK_CONFIG_PATH_ENV);
+    if archive_path.is_some() || link_config_path.is_some() {
+        let archive_path = archive_path.unwrap_or_else(|| {
+            panic!(
+                "{} is required when {} is set",
+                XLS_AOT_RUNTIME_PATH_ENV, XLS_AOT_RUNTIME_LINK_CONFIG_PATH_ENV
+            )
+        });
+        let link_config_path = link_config_path.unwrap_or_else(|| {
+            panic!(
+                "{} is required when {} is set",
+                XLS_AOT_RUNTIME_LINK_CONFIG_PATH_ENV, XLS_AOT_RUNTIME_PATH_ENV
+            )
+        });
+        RuntimeInputs {
+            archive_path: PathBuf::from(archive_path),
+            link_config_path: PathBuf::from(link_config_path),
+        }
     } else if let Some(config_path) = std::env::var_os(XLSYNTH_ARTIFACT_CONFIG_ENV) {
-        path_from_artifact_config(Path::new(&config_path))
+        runtime_inputs_from_artifact_config(Path::new(&config_path))
     } else {
         panic!(
-            "standalone AOT runtime linking requires either {} or {}",
-            XLS_AOT_RUNTIME_PATH_ENV, XLSYNTH_ARTIFACT_CONFIG_ENV
+            "standalone AOT runtime linking requires either {} + {} or {}",
+            XLS_AOT_RUNTIME_PATH_ENV,
+            XLS_AOT_RUNTIME_LINK_CONFIG_PATH_ENV,
+            XLSYNTH_ARTIFACT_CONFIG_ENV
         );
+    }
+}
+
+fn read_string_array(table: &toml::Table, path: &Path, field_name: &str) -> Vec<String> {
+    table
+        .get(field_name)
+        .and_then(toml::Value::as_array)
+        .unwrap_or_else(|| {
+            panic!(
+                "standalone AOT runtime link config {} is missing array field {field_name}",
+                path.display()
+            )
+        })
+        .iter()
+        .map(|value| {
+            value.as_str().unwrap_or_else(|| {
+                panic!(
+                    "standalone AOT runtime link config {} has non-string item in {field_name}",
+                    path.display()
+                )
+            })
+        })
+        .map(str::to_owned)
+        .collect()
+}
+
+fn read_link_config(path: &Path, target_os: &str) -> RuntimeLinkConfig {
+    let config = parse_toml_file(path, "standalone AOT runtime link config");
+    let format_version = config
+        .get("format_version")
+        .and_then(toml::Value::as_integer)
+        .unwrap_or_else(|| {
+            panic!(
+                "standalone AOT runtime link config {} is missing integer field format_version",
+                path.display()
+            )
+        });
+    if format_version != 1 {
+        panic!(
+            "unsupported standalone AOT runtime link config version {} in {}",
+            format_version,
+            path.display()
+        );
+    }
+    let target_table = config
+        .get("targets")
+        .and_then(toml::Value::as_table)
+        .and_then(|targets| targets.get(target_os))
+        .and_then(toml::Value::as_table)
+        .unwrap_or_else(|| {
+            panic!(
+                "standalone AOT runtime link config {} has no targets.{target_os} table",
+                path.display()
+            )
+        });
+    RuntimeLinkConfig {
+        system_libraries: read_string_array(target_table, path, "system_libraries"),
+        frameworks: read_string_array(target_table, path, "frameworks"),
     }
 }
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed={XLS_AOT_RUNTIME_PATH_ENV}");
+    println!("cargo:rerun-if-env-changed={XLS_AOT_RUNTIME_LINK_CONFIG_PATH_ENV}");
     println!("cargo:rerun-if-env-changed={XLSYNTH_ARTIFACT_CONFIG_ENV}");
 
-    let archive_path = resolve_archive_path();
+    let inputs = resolve_runtime_inputs();
+    let archive_path = &inputs.archive_path;
     if archive_path.file_name().and_then(|name| name.to_str()) != Some("libxls_aot_runtime.a") {
         panic!(
             "standalone AOT runtime archive must be named libxls_aot_runtime.a, got {}",
@@ -80,6 +178,13 @@ fn main() {
         );
     }
 
+    if !inputs.link_config_path.is_file() {
+        panic!(
+            "standalone AOT runtime link config does not exist: {}",
+            inputs.link_config_path.display()
+        );
+    }
+
     let archive_dir = archive_path.parent().unwrap_or_else(|| {
         panic!(
             "standalone AOT runtime archive has no parent directory: {}",
@@ -87,21 +192,19 @@ fn main() {
         )
     });
     println!("cargo:rerun-if-changed={}", archive_path.display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        inputs.link_config_path.display()
+    );
     println!("cargo:rustc-link-search=native={}", archive_dir.display());
     println!("cargo:rustc-link-lib=static=xls_aot_runtime");
 
-    // The XLS-owned archive packages real C++ runtime code instead of the old
-    // Rust-side shim, so final Rust binaries must link the platform support it
-    // would receive automatically from a native C++ driver.
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    if target_os == "macos" {
-        println!("cargo:rustc-link-lib=dylib=c++");
-        println!("cargo:rustc-link-lib=framework=CoreFoundation");
-    } else if target_os == "linux" {
-        println!("cargo:rustc-link-lib=dylib=c++");
-        println!("cargo:rustc-link-lib=dylib=c++abi");
-        println!("cargo:rustc-link-lib=dylib=unwind");
-        println!("cargo:rustc-link-lib=dylib=pthread");
-        println!("cargo:rustc-link-lib=dylib=dl");
+    let link_config = read_link_config(&inputs.link_config_path, target_os.as_str());
+    for library in link_config.system_libraries {
+        println!("cargo:rustc-link-lib=dylib={library}");
+    }
+    for framework in link_config.frameworks {
+        println!("cargo:rustc-link-lib=framework={framework}");
     }
 }

--- a/xlsynth-aot-runtime/build.rs
+++ b/xlsynth-aot-runtime/build.rs
@@ -57,6 +57,7 @@ fn runtime_inputs_from_artifact_config(config_path: &Path) -> RuntimeInputs {
             config_path.display()
         );
     }
+    println!("cargo:rerun-if-changed={}", config_path.display());
     let config = parse_toml_file(config_path, XLSYNTH_ARTIFACT_CONFIG_ENV);
     RuntimeInputs {
         archive_path: resolve_artifact_config_path(config_path, &config, "aot_runtime_path"),

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.47.0";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.48.0";
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 6;
 
 struct ArtifactPaths {

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.45.0";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.47.0";
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 6;
 
 struct ArtifactPaths {

--- a/xlsynth/docs/aot_compilation.md
+++ b/xlsynth/docs/aot_compilation.md
@@ -40,11 +40,13 @@ The `xlsynth` AOT framework consists of the following pieces:
   Rust code at build time.
 - Add `xlsynth-aot-runtime` as a normal dependency of the crate that includes
   the generated wrapper source.
-- Provide the XLS-owned standalone runtime archive to the build through
-  `XLSYNTH_ARTIFACT_CONFIG` or `XLS_AOT_RUNTIME_PATH`. Bazel consumers normally
-  receive `XLSYNTH_ARTIFACT_CONFIG` from the selected `rules_xlsynth` runtime
-  bundle; direct Cargo consumers can point `XLS_AOT_RUNTIME_PATH` at the
-  same-version `libxls_aot_runtime.a` release artifact.
+- Provide the XLS-owned standalone runtime archive and its producer-owned link
+  config to the build through `XLSYNTH_ARTIFACT_CONFIG` or the paired
+  `XLS_AOT_RUNTIME_PATH` / `XLS_AOT_RUNTIME_LINK_CONFIG_PATH` environment
+  variables. Bazel consumers normally receive `XLSYNTH_ARTIFACT_CONFIG` from
+  the selected `rules_xlsynth` runtime bundle; direct Cargo consumers can point
+  the paired variables at the same-version `libxls_aot_runtime.a` and
+  `libxls_aot_runtime_link.toml` release artifacts.
 - Add `mod`s in the project code (e.g. `lib.rs`) that pull in the generated Rust
   code via `include!`.
 - Call the exported API to create the AOT object and invoke its `run` method.


### PR DESCRIPTION
Read the XLS-owned runtime link manifest alongside `libxls_aot_runtime.a` and turn it into the Cargo link directives for the current target. That removes the Rust-side duplicate of the platform support-library list, so the producer artifact itself stays authoritative about what must be linked.

For example, the XLS-owned input can look like:

```toml
format_version = 1

[targets.macos]
system_libraries = ["c++"]
frameworks = ["CoreFoundation"]

[targets.linux]
system_libraries = ["c++", "c++abi", "unwind", "pthread", "dl"]
frameworks = []
```

With that input, macOS builds emit the `c++` and `CoreFoundation` link directives, while Linux builds emit the Linux support libraries from the manifest. This PR wires that contract through both supported entry paths: `XLSYNTH_ARTIFACT_CONFIG` now resolves the runtime archive plus `aot_runtime_link_config_path`, and direct Cargo users provide the paired `XLS_AOT_RUNTIME_PATH` / `XLS_AOT_RUNTIME_LINK_CONFIG_PATH` variables.

The build script validates the manifest version and target entry, fails clearly when the archive/config pair is incomplete or malformed, and uses the selected target table instead of hard-coded Rust lists. The AOT docs describe the paired-input contract for direct Cargo consumers.

<!-- spr-stack:start -->
**Stack**:
-   #980
-   #971
- ➡ #968

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
