### PR TITLE
aot: consume XLS-authored runtime feature requirements

### DIFF
--- a/xlsynth-aot-runtime/src/lib.rs
+++ b/xlsynth-aot-runtime/src/lib.rs
@@ -410,15 +410,7 @@ impl StandaloneRunner {
         let temp_buffer =
             AlignedBuffer::new(layout.temp_buffer_size, layout.temp_buffer_alignment)?;
 
-        let required_features = if artifact_metadata.has_asserts {
-            FEATURE_ASSERTIONS
-        } else {
-            0
-        } | if artifact_metadata.has_traces {
-            FEATURE_TRACES
-        } else {
-            0
-        };
+        let required_features = required_runtime_feature_bits(artifact_metadata);
         let mut runtime = std::ptr::null_mut();
         let create_status = unsafe {
             xls_standalone_aot_runtime_create(
@@ -497,6 +489,20 @@ impl Drop for StandaloneRunner {
     }
 }
 
+fn required_runtime_feature_bits(artifact_metadata: &AotArtifactMetadata) -> u32 {
+    let assertion_features = if artifact_metadata.has_asserts {
+        FEATURE_ASSERTIONS
+    } else {
+        0
+    };
+    let trace_features = if artifact_metadata.has_traces {
+        FEATURE_TRACES
+    } else {
+        0
+    };
+    assertion_features | trace_features
+}
+
 fn describe_runtime_status(status: u32) -> String {
     match status {
         STATUS_OK => "runtime returned success without an object".to_string(),
@@ -504,5 +510,39 @@ fn describe_runtime_status(status: u32) -> String {
         STATUS_UNSUPPORTED_FEATURE => "unsupported runtime feature".to_string(),
         STATUS_ALLOCATION_FAILED => "allocation failed".to_string(),
         other => format!("unknown status {other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact_metadata(has_asserts: bool, has_traces: bool) -> AotArtifactMetadata {
+        AotArtifactMetadata {
+            abi_version: SUPPORTED_ARTIFACT_ABI_VERSION,
+            entrypoint_symbol: "entrypoint",
+            has_asserts,
+            has_traces,
+        }
+    }
+
+    #[test]
+    fn required_runtime_feature_bits_follow_generated_artifact_metadata() {
+        assert_eq!(
+            required_runtime_feature_bits(&artifact_metadata(false, false)),
+            0
+        );
+        assert_eq!(
+            required_runtime_feature_bits(&artifact_metadata(true, false)),
+            FEATURE_ASSERTIONS
+        );
+        assert_eq!(
+            required_runtime_feature_bits(&artifact_metadata(false, true)),
+            FEATURE_TRACES
+        );
+        assert_eq!(
+            required_runtime_feature_bits(&artifact_metadata(true, true)),
+            FEATURE_ASSERTIONS | FEATURE_TRACES
+        );
     }
 }

--- a/xlsynth/src/aot_builder.rs
+++ b/xlsynth/src/aot_builder.rs
@@ -12,8 +12,8 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::aot_entrypoint_metadata::{
-    get_entrypoint_function_signature, AotEntrypointMetadata, AotFunctionSignature, AotType,
-    AotTypeLayout,
+    get_entrypoint_function_signature, get_entrypoint_runtime_features, AotEntrypointMetadata,
+    AotFunctionSignature, AotRuntimeFeature, AotType, AotTypeLayout,
 };
 use crate::aot_lib::{AotCompiled, AotResult};
 use crate::dslx_bridge::{convert_imported_module, BridgeBuilder};
@@ -154,15 +154,21 @@ pub fn compile_ir_to_aot(ir_text: &str, top: &str) -> AotResult<AotCompiled> {
 ///
 /// The wrapper gives emitted objects a deterministic artifact-scoped exported
 /// symbol without mutating the caller's original function names. Standalone
-/// generation currently follows the direct-call closure only; callback-bearing
-/// nodes such as `trace` and `cover` are rejected before compilation because
-/// their runtime callbacks are not part of the first standalone ABI.
+/// generation uses XLS-produced entrypoint metadata as the authority for the
+/// reachable callback-bearing nodes. `trace` and `cover` requirements are
+/// rejected before standalone artifacts are emitted because their runtime
+/// callbacks are not part of the first standalone ABI.
 fn compile_ir_to_standalone_aot(
     ir_text: &str,
     top: &str,
     base_name: &str,
 ) -> AotResult<(AotCompiled, AotRuntimeFeatures)> {
-    let runtime_features = classify_reachable_runtime_features(ir_text, top)?;
+    let wrapper_name = format!("__xlsynth_standalone_{base_name}");
+    let wrapped_ir = append_standalone_wrapper_ir(ir_text, top, &wrapper_name)?;
+    let compiled = AotCompiled::compile_ir(&wrapped_ir, &wrapper_name)?;
+    let runtime_feature_requirements = get_entrypoint_runtime_features(&compiled.entrypoints_proto)
+        .map_err(|e| XlsynthError(format!("AOT metadata parse failed: {}", e.0)))?;
+    let runtime_features = AotRuntimeFeatures::from_xls_requirements(&runtime_feature_requirements);
     if runtime_features.has_traces {
         return Err(XlsynthError(
             "AOT standalone runtime does not support `trace` nodes".to_string(),
@@ -173,94 +179,25 @@ fn compile_ir_to_standalone_aot(
         ));
     }
 
-    let wrapper_name = format!("__xlsynth_standalone_{base_name}");
-    let wrapped_ir = append_standalone_wrapper_ir(ir_text, top, &wrapper_name)?;
-    let compiled = AotCompiled::compile_ir(&wrapped_ir, &wrapper_name)?;
     Ok((compiled, runtime_features))
 }
 
-/// Classifies runtime features reachable from one selected top function.
-///
-/// The traversal assumes canonical XLS IR text and follows only direct function
-/// references that the standalone generator knows how to preserve.
-fn classify_reachable_runtime_features(ir_text: &str, top: &str) -> AotResult<AotRuntimeFeatures> {
-    let package = crate::ir_package::IrPackage::parse_ir(ir_text, Some("standalone_aot.ir"))
-        .map_err(|e| XlsynthError(format!("AOT runtime feature parse failed: {}", e.0)))?;
-    let mut pending = vec![top.to_string()];
-    let mut visited = HashSet::new();
-    let mut runtime_features = AotRuntimeFeatures {
-        has_asserts: false,
-        has_traces: false,
-        has_covers: false,
-    };
-
-    while let Some(function_name) = pending.pop() {
-        if visited.insert(function_name.clone()) {
-            let function = package.get_function(&function_name).map_err(|e| {
-                XlsynthError(format!(
-                    "AOT runtime feature function lookup failed for `{function_name}`: {}",
-                    e.0
-                ))
-            })?;
-            let function_ir = function.to_ir_string().map_err(|e| {
-                XlsynthError(format!(
-                    "AOT runtime feature IR formatting failed for `{function_name}`: {}",
-                    e.0
-                ))
-            })?;
-            runtime_features.merge(classify_runtime_features_in_function(&function_ir));
-            pending.extend(referenced_function_names(&function_ir));
-        }
-    }
-
-    Ok(runtime_features)
-}
-
 impl AotRuntimeFeatures {
-    /// Merges runtime features discovered in another reachable function.
-    fn merge(&mut self, other: Self) {
-        self.has_asserts |= other.has_asserts;
-        self.has_traces |= other.has_traces;
-        self.has_covers |= other.has_covers;
+    fn from_xls_requirements(features: &[AotRuntimeFeature]) -> Self {
+        let mut runtime_features = Self {
+            has_asserts: false,
+            has_traces: false,
+            has_covers: false,
+        };
+        for feature in features {
+            match feature {
+                AotRuntimeFeature::Assertions => runtime_features.has_asserts = true,
+                AotRuntimeFeature::Traces => runtime_features.has_traces = true,
+                AotRuntimeFeature::Covers => runtime_features.has_covers = true,
+            }
+        }
+        runtime_features
     }
-}
-
-/// Classifies the runtime features used by one canonical XLS IR function.
-fn classify_runtime_features_in_function(function_ir: &str) -> AotRuntimeFeatures {
-    AotRuntimeFeatures {
-        has_asserts: function_ir.lines().any(|line| line.contains(" = assert(")),
-        has_traces: function_ir.lines().any(|line| line.contains(" = trace(")),
-        has_covers: function_ir.lines().any(|line| line.contains(" = cover(")),
-    }
-}
-
-/// Returns direct function references carried by canonical XLS IR node attrs.
-///
-/// The standalone generator intentionally recognizes only the direct-call
-/// attributes it can preserve today, so adding another call-bearing node shape
-/// requires extending this list as part of that feature work.
-fn referenced_function_names(function_ir: &str) -> Vec<String> {
-    function_ir
-        .lines()
-        .flat_map(|line| {
-            ["to_apply=", "body="]
-                .iter()
-                .copied()
-                .filter_map(move |attribute| function_attr_value(line, attribute))
-        })
-        .collect()
-}
-
-/// Extracts one unquoted canonical XLS IR function-reference attribute value.
-fn function_attr_value(line: &str, attribute: &str) -> Option<String> {
-    line.split_once(attribute)
-        .map(|(_, suffix)| {
-            suffix
-                .chars()
-                .take_while(|ch| !matches!(ch, ',' | ')' | ' ' | '\t'))
-                .collect::<String>()
-        })
-        .filter(|value| !value.is_empty())
 }
 
 /// Appends an artifact-scoped forwarding wrapper around the requested top.

--- a/xlsynth/src/aot_entrypoint_metadata.rs
+++ b/xlsynth/src/aot_entrypoint_metadata.rs
@@ -23,6 +23,14 @@ pub struct AotEntrypointMetadata {
     pub temp_buffer_alignment: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Runtime callbacks that XLS says a standalone AOT artifact may need.
+pub enum AotRuntimeFeature {
+    Assertions,
+    Traces,
+    Covers,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// A simplified Rust representation of an XLS type from AOT metadata.
 ///
@@ -110,6 +118,23 @@ struct AotEntrypointProto {
 
     #[prost(message, optional, tag = "23")]
     function_metadata: Option<FunctionMetadataProto>,
+
+    #[prost(message, optional, tag = "26")]
+    standalone_runtime_feature_requirements: Option<AotRuntimeFeatureRequirementsProto>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct AotRuntimeFeatureRequirementsProto {
+    #[prost(enumeration = "AotRuntimeFeatureProto", repeated, tag = "1")]
+    required_feature: Vec<i32>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, prost::Enumeration)]
+enum AotRuntimeFeatureProto {
+    Invalid = 0,
+    Assertions = 1,
+    Traces = 2,
+    Covers = 3,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, prost::Enumeration)]
@@ -234,6 +259,18 @@ pub fn get_entrypoint_function_signature(
     parse_entrypoint_function_signature(&entrypoint)
 }
 
+/// Decodes the XLS-authored standalone runtime features for one AOT entrypoint.
+///
+/// Presence of the requirements envelope is part of the protocol: consumers
+/// that need standalone-runtime policy must be able to distinguish "producer
+/// reported no required features" from "producer predates this metadata".
+pub fn get_entrypoint_runtime_features(
+    entrypoints_proto: &[u8],
+) -> Result<Vec<AotRuntimeFeature>, XlsynthError> {
+    let entrypoint = decode_single_entrypoint(entrypoints_proto)?;
+    parse_runtime_features(&entrypoint)
+}
+
 fn decode_single_entrypoint(entrypoints_proto: &[u8]) -> Result<AotEntrypointProto, XlsynthError> {
     let decoded = AotPackageEntrypointsProto::decode(entrypoints_proto)
         .map_err(|e| XlsynthError(format!("Failed decoding AOT entrypoints proto: {e}")))?;
@@ -287,6 +324,41 @@ fn parse_entrypoint_metadata(
         .unwrap_or(1)
         .max(1),
     })
+}
+
+fn parse_runtime_features(
+    entrypoint: &AotEntrypointProto,
+) -> Result<Vec<AotRuntimeFeature>, XlsynthError> {
+    let requirements = entrypoint
+        .standalone_runtime_feature_requirements
+        .as_ref()
+        .ok_or_else(|| {
+            XlsynthError(
+                "AOT producer metadata is missing standalone_runtime_feature_requirements; upgrade to an XLS producer that emits standalone runtime feature authority"
+                    .to_string(),
+            )
+        })?;
+
+    let mut runtime_features = Vec::with_capacity(requirements.required_feature.len());
+    for raw_feature in &requirements.required_feature {
+        let feature = AotRuntimeFeatureProto::try_from(*raw_feature).map_err(|_| {
+            XlsynthError(format!(
+                "Entrypoint metadata had unknown standalone runtime feature value: {raw_feature}"
+            ))
+        })?;
+        let feature = match feature {
+            AotRuntimeFeatureProto::Invalid => {
+                return Err(XlsynthError(
+                    "Entrypoint metadata had INVALID standalone runtime feature".to_string(),
+                ));
+            }
+            AotRuntimeFeatureProto::Assertions => AotRuntimeFeature::Assertions,
+            AotRuntimeFeatureProto::Traces => AotRuntimeFeature::Traces,
+            AotRuntimeFeatureProto::Covers => AotRuntimeFeature::Covers,
+        };
+        runtime_features.push(feature);
+    }
+    Ok(runtime_features)
 }
 
 fn parse_entrypoint_function_signature(
@@ -541,6 +613,12 @@ mod tests {
 
     use super::*;
 
+    fn empty_runtime_feature_requirements() -> Option<AotRuntimeFeatureRequirementsProto> {
+        Some(AotRuntimeFeatureRequirementsProto {
+            required_feature: Vec::new(),
+        })
+    }
+
     #[test]
     fn get_entrypoint_metadata_rejects_empty_proto() {
         let encoded = AotPackageEntrypointsProto {
@@ -571,6 +649,7 @@ mod tests {
                 inputs_layout: None,
                 outputs_layout: None,
                 function_metadata: None,
+                standalone_runtime_feature_requirements: empty_runtime_feature_requirements(),
             }],
         }
         .encode_to_vec();
@@ -583,6 +662,92 @@ mod tests {
         assert_eq!(metadata.output_buffer_alignments, vec![8]);
         assert_eq!(metadata.temp_buffer_size, 16);
         assert_eq!(metadata.temp_buffer_alignment, 8);
+    }
+
+    #[test]
+    fn get_entrypoint_runtime_features_rejects_missing_requirements_envelope() {
+        let encoded = AotPackageEntrypointsProto {
+            entrypoint: vec![AotEntrypointProto {
+                function_symbol: Some("foo".to_string()),
+                input_buffer_sizes: vec![1],
+                input_buffer_alignments: vec![1],
+                output_buffer_sizes: vec![1],
+                output_buffer_alignments: vec![1],
+                temp_buffer_size: Some(0),
+                temp_buffer_alignment: Some(1),
+                inputs_layout: None,
+                outputs_layout: None,
+                function_metadata: None,
+                standalone_runtime_feature_requirements: None,
+            }],
+        }
+        .encode_to_vec();
+
+        let err = get_entrypoint_runtime_features(&encoded).unwrap_err();
+        assert!(
+            err.to_string().contains("upgrade to an XLS producer"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn get_entrypoint_runtime_features_accepts_present_empty_requirements() {
+        let encoded = AotPackageEntrypointsProto {
+            entrypoint: vec![AotEntrypointProto {
+                function_symbol: Some("foo".to_string()),
+                input_buffer_sizes: vec![1],
+                input_buffer_alignments: vec![1],
+                output_buffer_sizes: vec![1],
+                output_buffer_alignments: vec![1],
+                temp_buffer_size: Some(0),
+                temp_buffer_alignment: Some(1),
+                inputs_layout: None,
+                outputs_layout: None,
+                function_metadata: None,
+                standalone_runtime_feature_requirements: empty_runtime_feature_requirements(),
+            }],
+        }
+        .encode_to_vec();
+
+        let runtime_features = get_entrypoint_runtime_features(&encoded).unwrap();
+        assert!(runtime_features.is_empty());
+    }
+
+    #[test]
+    fn get_entrypoint_runtime_features_parses_requirements() {
+        let encoded = AotPackageEntrypointsProto {
+            entrypoint: vec![AotEntrypointProto {
+                function_symbol: Some("foo".to_string()),
+                input_buffer_sizes: vec![1],
+                input_buffer_alignments: vec![1],
+                output_buffer_sizes: vec![1],
+                output_buffer_alignments: vec![1],
+                temp_buffer_size: Some(0),
+                temp_buffer_alignment: Some(1),
+                inputs_layout: None,
+                outputs_layout: None,
+                function_metadata: None,
+                standalone_runtime_feature_requirements: Some(AotRuntimeFeatureRequirementsProto {
+                    required_feature: vec![
+                        AotRuntimeFeatureProto::Assertions as i32,
+                        AotRuntimeFeatureProto::Traces as i32,
+                        AotRuntimeFeatureProto::Covers as i32,
+                    ],
+                }),
+            }],
+        }
+        .encode_to_vec();
+
+        let runtime_features = get_entrypoint_runtime_features(&encoded).unwrap();
+        assert_eq!(
+            runtime_features,
+            vec![
+                AotRuntimeFeature::Assertions,
+                AotRuntimeFeature::Traces,
+                AotRuntimeFeature::Covers,
+            ]
+        );
     }
 
     #[test]
@@ -599,6 +764,7 @@ mod tests {
                 inputs_layout: None,
                 outputs_layout: None,
                 function_metadata: None,
+                standalone_runtime_feature_requirements: empty_runtime_feature_requirements(),
             }],
         }
         .encode_to_vec();
@@ -625,6 +791,7 @@ mod tests {
                 inputs_layout: None,
                 outputs_layout: None,
                 function_metadata: None,
+                standalone_runtime_feature_requirements: empty_runtime_feature_requirements(),
             }],
         }
         .encode_to_vec();
@@ -652,6 +819,7 @@ mod tests {
                     inputs_layout: None,
                     outputs_layout: None,
                     function_metadata: None,
+                    standalone_runtime_feature_requirements: empty_runtime_feature_requirements(),
                 },
                 AotEntrypointProto {
                     function_symbol: Some("bar".to_string()),
@@ -664,6 +832,7 @@ mod tests {
                     inputs_layout: None,
                     outputs_layout: None,
                     function_metadata: None,
+                    standalone_runtime_feature_requirements: empty_runtime_feature_requirements(),
                 },
             ],
         }
@@ -714,6 +883,7 @@ mod tests {
                         sv_result_type: None,
                     }),
                 }),
+                standalone_runtime_feature_requirements: None,
             }],
         }
         .encode_to_vec();
@@ -756,6 +926,7 @@ mod tests {
                         sv_result_type: None,
                     }),
                 }),
+                standalone_runtime_feature_requirements: None,
             }],
         }
         .encode_to_vec();


### PR DESCRIPTION
Decode the producer-owned runtime-feature requirements envelope from entrypoint metadata and use it
as the standalone admission authority. Remove the Rust IR-text classifier, fail clearly when older
producer metadata omits the envelope, and keep runtime feature-bit construction covered in
xlsynth-aot-runtime.

<!-- spr-stack:start -->
**Stack**:
-   #980
- ➡ #971

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->