### PR TITLE
Support alias assignments in netlists in gv-sta.

### DIFF
--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -117,14 +117,18 @@ xlsynth-driver gv2ir \
 ```
 
 - Optional flags:
+  - `--module_name <NAME>` – select the netlist module to convert. Required when the netlist contains multiple modules.
   - `--collapse_sequential <BOOL>` – if true (default), collapse sequential state variables by substituting next_state during projection. If false and a pin function references a sequential state variable (e.g., `IQ`/`IQN`), projection will fail.
+  - `--output_function_name <NAME>` – override the emitted XLS IR function name. Use this when the netlist module is named `top`, because `top` is reserved in XLS IR.
 
 Example (ASAP7):
 
 ```shell
 xlsynth-driver gv2ir \
   --netlist add_mul.vg \
-  --liberty_proto ~/asap7.proto > add_mul.ir
+  --liberty_proto ~/asap7.proto \
+  --module_name top \
+  --output_function_name top_fn > add_mul.ir
 ```
 
 ### `gv2block`: gate-level netlist to Block IR

--- a/xlsynth-driver/src/gv2ir.rs
+++ b/xlsynth-driver/src/gv2ir.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
-use xlsynth_g8r::netlist::gv2ir::convert_gv2ir_paths;
+use xlsynth_g8r::netlist::gv2ir::{convert_gv2ir_paths_with_options, Gv2IrOptions};
 
 pub fn handle_gv2ir(matches: &clap::ArgMatches) {
     let netlist_path = matches.get_one::<String>("netlist").unwrap();
@@ -12,10 +12,16 @@ pub fn handle_gv2ir(matches: &clap::ArgMatches) {
         .copied()
         .unwrap_or(true);
 
-    match convert_gv2ir_paths(
+    let opts = Gv2IrOptions {
+        module_name: matches.get_one::<String>("module_name").cloned(),
+        collapse_sequential,
+        output_function_name: matches.get_one::<String>("output_function_name").cloned(),
+    };
+
+    match convert_gv2ir_paths_with_options(
         Path::new(netlist_path),
         Path::new(liberty_proto_path),
-        collapse_sequential,
+        &opts,
     ) {
         Ok(ir_text) => println!("{}", ir_text),
         Err(e) => {

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -1773,12 +1773,25 @@ fn main() {
                         .action(ArgAction::Set),
                 )
                 .arg(
+                    Arg::new("module_name")
+                        .long("module_name")
+                        .help("Netlist module to convert. Required when the netlist contains multiple modules.")
+                        .action(ArgAction::Set),
+                )
+                .arg(
                     Arg::new("collapse_sequential")
                         .long("collapse_sequential")
                         .value_name("BOOL")
                         .default_value("true")
                         .value_parser(clap::value_parser!(bool))
                         .help("If true, collapse sequential state variables by substituting next_state.")
+                        .action(ArgAction::Set),
+                )
+                .arg(
+                    Arg::new("output_function_name")
+                        .long("output_function_name")
+                        .value_name("NAME")
+                        .help("Override the function name emitted in the XLS IR package. Required when the netlist module name is 'top'.")
                         .action(ArgAction::Set),
                 )
         )

--- a/xlsynth-driver/tests/gv2aig_test.rs
+++ b/xlsynth-driver/tests/gv2aig_test.rs
@@ -299,7 +299,7 @@ endmodule
 }
 
 #[test]
-fn gv2aig_with_liberty_rejects_preserved_assigns() {
+fn gv2aig_with_liberty_supports_preserved_assigns() {
     let liberty_text = r#"
 cells: {
   name: "BUF"
@@ -310,23 +310,16 @@ cells: {
 "#;
     let netlist_text = r#"
 module top(a, y);
-  input a;
+  input [1:0] a;
   output y;
-  assign y = a;
+  wire [1:0] tmp;
+  assign tmp = {a[0], a[1]};
+  BUF u0 (.A(tmp[1]), .Y(y));
 endmodule
 "#;
 
-    let (_temp_dir, _out_path, output) = run_gv2aig(netlist_text, Some(liberty_text));
-    assert!(
-        !output.status.success(),
-        "preserved assigns with liberty should fail\nstdout={}\nstderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("does not support preserved continuous assigns"),
-        "unexpected stderr: {}",
-        String::from_utf8_lossy(&output.stderr),
-    );
+    let (_temp_dir, out_path, output) = run_gv2aig(netlist_text, Some(liberty_text));
+    assert_success(&output);
+    load_aiger_auto_from_path(&out_path, GateBuilderOptions::no_opt())
+        .expect("load liberty-backed preserved assign aiger");
 }

--- a/xlsynth-g8r/src/netlist/bit_ref.rs
+++ b/xlsynth-g8r/src/netlist/bit_ref.rs
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bit-level helpers for parsed gate-level net references.
+
+use crate::netlist::parse::{AssignExpr, Net, NetIndex, NetRef};
+use anyhow::{Result, anyhow};
+use string_interner::symbol::SymbolU32;
+use string_interner::{StringInterner, backend::StringBackend};
+
+/// One concrete bit of a parsed net, identified by declared bit number.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct NetBit {
+    pub net: NetIndex,
+    pub bit_number: u32,
+}
+
+/// One bit referenced by an expression that is restricted to wiring and
+/// constants.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum NetBitRef {
+    Net(NetBit),
+    Literal(bool),
+}
+
+/// Returns the width of a packed select range.
+pub fn select_width_bits(msb: u32, lsb: u32) -> usize {
+    (u32::abs_diff(msb, lsb) as usize) + 1
+}
+
+/// Returns the declared bit number at an lsb-based offset within a select.
+pub fn select_bit_number(msb: u32, lsb: u32, bit_offset: usize) -> Option<u32> {
+    if bit_offset >= select_width_bits(msb, lsb) {
+        return None;
+    }
+    let offset = bit_offset as u32;
+    if msb >= lsb {
+        Some(lsb + offset)
+    } else {
+        Some(lsb - offset)
+    }
+}
+
+/// Resolves a net name for diagnostics.
+pub fn net_name(
+    idx: NetIndex,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> String {
+    nets.get(idx.0)
+        .and_then(|net| interner.resolve(net.name))
+        .unwrap_or("<unknown>")
+        .to_string()
+}
+
+/// Renders a concrete net bit using scalar spelling when the net is 1-bit.
+pub fn render_net_bit(
+    bit: NetBit,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> String {
+    if nets[bit.net.0].width_bits() == 1 {
+        net_name(bit.net, nets, interner)
+    } else {
+        format!("{}[{}]", net_name(bit.net, nets, interner), bit.bit_number)
+    }
+}
+
+/// Renders a parsed net reference for diagnostics.
+pub fn render_net_ref(
+    net_ref: &NetRef,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> String {
+    match net_ref {
+        NetRef::Simple(idx) => net_name(*idx, nets, interner),
+        NetRef::BitSelect(idx, bit) => format!("{}[{}]", net_name(*idx, nets, interner), bit),
+        NetRef::PartSelect(idx, msb, lsb) => {
+            format!("{}[{}:{}]", net_name(*idx, nets, interner), msb, lsb)
+        }
+        NetRef::Literal(bits) => format!("{}", bits),
+        NetRef::Unconnected => "<unconnected>".to_string(),
+        NetRef::Concat(elems) => {
+            let parts: Vec<String> = elems
+                .iter()
+                .map(|elem| render_net_ref(elem, nets, interner))
+                .collect();
+            format!("{{{}}}", parts.join(", "))
+        }
+    }
+}
+
+/// Returns a net reference's packed width in bits.
+pub fn net_ref_width_bits(
+    net_ref: &NetRef,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> Result<usize> {
+    match net_ref {
+        NetRef::Simple(idx) => {
+            let net = nets.get(idx.0).ok_or_else(|| {
+                anyhow!(
+                    "net reference '{}' uses out-of-range net index {}",
+                    render_net_ref(net_ref, nets, interner),
+                    idx.0
+                )
+            })?;
+            Ok(net.width_bits())
+        }
+        NetRef::BitSelect(idx, bit) => {
+            let net = nets.get(idx.0).ok_or_else(|| {
+                anyhow!(
+                    "bit-select '{}' uses out-of-range net index {}",
+                    render_net_ref(net_ref, nets, interner),
+                    idx.0
+                )
+            })?;
+            if net.bit_offset(*bit).is_none() {
+                return Err(anyhow!(
+                    "bit {} out of range for net '{}'",
+                    bit,
+                    net_name(*idx, nets, interner)
+                ));
+            }
+            Ok(1)
+        }
+        NetRef::PartSelect(idx, msb, lsb) => {
+            let net = nets.get(idx.0).ok_or_else(|| {
+                anyhow!(
+                    "part-select '{}' uses out-of-range net index {}",
+                    render_net_ref(net_ref, nets, interner),
+                    idx.0
+                )
+            })?;
+            let width = select_width_bits(*msb, *lsb);
+            for offset in 0..width {
+                let bit_number = select_bit_number(*msb, *lsb, offset).ok_or_else(|| {
+                    anyhow!(
+                        "invalid part-select [{}:{}] on net '{}'",
+                        msb,
+                        lsb,
+                        net_name(*idx, nets, interner)
+                    )
+                })?;
+                if net.bit_offset(bit_number).is_none() {
+                    return Err(anyhow!(
+                        "bit {} out of range for net '{}'",
+                        bit_number,
+                        net_name(*idx, nets, interner)
+                    ));
+                }
+            }
+            Ok(width)
+        }
+        NetRef::Literal(bits) => Ok(bits.get_bit_count()),
+        NetRef::Unconnected => Ok(0),
+        NetRef::Concat(elems) => {
+            if elems.is_empty() {
+                return Err(anyhow!("empty concatenation is unsupported"));
+            }
+            elems.iter().try_fold(0usize, |acc, elem| {
+                Ok(acc + net_ref_width_bits(elem, nets, interner)?)
+            })
+        }
+    }
+}
+
+/// Expands a reference into lsb-first bit sources.
+pub fn net_ref_lsb_bit_refs(
+    net_ref: &NetRef,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> Result<Vec<NetBitRef>> {
+    match net_ref {
+        NetRef::Simple(idx) => {
+            let net = nets.get(idx.0).ok_or_else(|| {
+                anyhow!(
+                    "net reference '{}' uses out-of-range net index {}",
+                    render_net_ref(net_ref, nets, interner),
+                    idx.0
+                )
+            })?;
+            let mut bits = Vec::with_capacity(net.width_bits());
+            for offset in 0..net.width_bits() {
+                let bit_number = net.bit_number(offset).ok_or_else(|| {
+                    anyhow!(
+                        "internal error computing bit {} for net '{}'",
+                        offset,
+                        net_name(*idx, nets, interner)
+                    )
+                })?;
+                bits.push(NetBitRef::Net(NetBit {
+                    net: *idx,
+                    bit_number,
+                }));
+            }
+            Ok(bits)
+        }
+        NetRef::BitSelect(idx, bit) => {
+            net_ref_width_bits(net_ref, nets, interner)?;
+            Ok(vec![NetBitRef::Net(NetBit {
+                net: *idx,
+                bit_number: *bit,
+            })])
+        }
+        NetRef::PartSelect(idx, msb, lsb) => {
+            let width = net_ref_width_bits(net_ref, nets, interner)?;
+            let mut bits = Vec::with_capacity(width);
+            for offset in 0..width {
+                let bit_number = select_bit_number(*msb, *lsb, offset).ok_or_else(|| {
+                    anyhow!(
+                        "invalid part-select [{}:{}] on net '{}'",
+                        msb,
+                        lsb,
+                        net_name(*idx, nets, interner)
+                    )
+                })?;
+                bits.push(NetBitRef::Net(NetBit {
+                    net: *idx,
+                    bit_number,
+                }));
+            }
+            Ok(bits)
+        }
+        NetRef::Literal(bits) => {
+            let mut out = Vec::with_capacity(bits.get_bit_count());
+            for i in 0..bits.get_bit_count() {
+                out.push(NetBitRef::Literal(bits.get_bit(i).unwrap_or(false)));
+            }
+            Ok(out)
+        }
+        NetRef::Unconnected => Ok(Vec::new()),
+        NetRef::Concat(elems) => {
+            if elems.is_empty() {
+                return Err(anyhow!("empty concatenation is unsupported"));
+            }
+            let mut out = Vec::new();
+            for elem in elems.iter().rev() {
+                out.extend(net_ref_lsb_bit_refs(elem, nets, interner)?);
+            }
+            Ok(out)
+        }
+    }
+}
+
+/// Expands a left-hand-side reference into lsb-first concrete target bits.
+pub fn net_ref_lsb_targets(
+    net_ref: &NetRef,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> Result<Vec<NetBit>> {
+    let mut out = Vec::new();
+    for bit_ref in net_ref_lsb_bit_refs(net_ref, nets, interner)? {
+        match bit_ref {
+            NetBitRef::Net(bit) => out.push(bit),
+            NetBitRef::Literal(_) => {
+                return Err(anyhow!(
+                    "left-hand side '{}' cannot contain a literal",
+                    render_net_ref(net_ref, nets, interner)
+                ));
+            }
+        }
+    }
+    if out.is_empty() {
+        return Err(anyhow!(
+            "left-hand side '{}' does not target any net bits",
+            render_net_ref(net_ref, nets, interner)
+        ));
+    }
+    Ok(out)
+}
+
+/// Returns the width of a supported assign expression.
+pub fn assign_expr_width_bits(
+    expr: &AssignExpr,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> Result<usize> {
+    match expr {
+        AssignExpr::Leaf(net_ref) => net_ref_width_bits(net_ref, nets, interner),
+        AssignExpr::Not(inner) => assign_expr_width_bits(inner, nets, interner),
+        AssignExpr::And(lhs, rhs) | AssignExpr::Or(lhs, rhs) | AssignExpr::Xor(lhs, rhs) => {
+            let lhs_width = assign_expr_width_bits(lhs, nets, interner)?;
+            let rhs_width = assign_expr_width_bits(rhs, nets, interner)?;
+            if lhs_width != rhs_width {
+                return Err(anyhow!(
+                    "bitwise assign expression width mismatch: lhs {} bits rhs {} bits",
+                    lhs_width,
+                    rhs_width
+                ));
+            }
+            Ok(lhs_width)
+        }
+    }
+}

--- a/xlsynth-g8r/src/netlist/gatefn_from_netlist.rs
+++ b/xlsynth-g8r/src/netlist/gatefn_from_netlist.rs
@@ -6,7 +6,8 @@ use crate::aig::gate::{AigBitVector, AigOperand, GateFn};
 use crate::gate_builder::{GateBuilder, GateBuilderOptions};
 use crate::liberty::cell_formula::Term;
 use crate::liberty_proto::Library;
-use crate::netlist::parse::{Net, NetIndex, NetRef, NetlistModule};
+use crate::netlist::bit_ref;
+use crate::netlist::parse::{AssignExpr, Net, NetIndex, NetRef, NetlistModule};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use string_interner::symbol::SymbolU32;
@@ -236,6 +237,13 @@ struct ResolvedNetValues {
     values: HashMap<NetIndex, Vec<Option<AigOperand>>>,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct PendingAssignBit {
+    assign_index: usize,
+    rhs_bit_index: usize,
+    target: bit_ref::NetBit,
+}
+
 impl ResolvedNetValues {
     fn new() -> Self {
         Self {
@@ -341,7 +349,28 @@ impl ResolvedNetValues {
                 }
                 Ok(Some(AigBitVector::from_lsb_is_index_0(&ops)))
             }
-            NetRef::Unconnected | NetRef::Concat(_) => Ok(None),
+            NetRef::Unconnected => Ok(None),
+            NetRef::Concat(_) => {
+                let bit_refs = bit_ref::net_ref_lsb_bit_refs(net_ref, nets, interner)
+                    .map_err(|e| e.to_string())?;
+                let mut bits = Vec::with_capacity(bit_refs.len());
+                for bit_ref in bit_refs {
+                    match bit_ref {
+                        bit_ref::NetBitRef::Net(bit) => {
+                            let Some(op) =
+                                self.resolve_bit(bit.net, bit.bit_number, nets, interner)?
+                            else {
+                                return Ok(None);
+                            };
+                            bits.push(op);
+                        }
+                        bit_ref::NetBitRef::Literal(value) => {
+                            bits.push(if value { gb.get_true() } else { gb.get_false() })
+                        }
+                    }
+                }
+                Ok(Some(AigBitVector::from_lsb_is_index_0(&bits)))
+            }
         }
     }
 
@@ -443,7 +472,28 @@ impl ResolvedNetValues {
             }
             NetRef::Literal(_) => Err("output destination cannot be a literal".to_string()),
             NetRef::Unconnected => Ok(()),
-            NetRef::Concat(_) => Err("concat output destination is not supported".to_string()),
+            NetRef::Concat(_) => {
+                let targets = bit_ref::net_ref_lsb_targets(dst_ref, nets, interner)
+                    .map_err(|e| e.to_string())?;
+                if src_bv.get_bit_count() != targets.len() {
+                    return Err(format!(
+                        "width mismatch assigning to '{}': expected {} bits but got {}",
+                        bit_ref::render_net_ref(dst_ref, nets, interner),
+                        targets.len(),
+                        src_bv.get_bit_count()
+                    ));
+                }
+                for (offset, target) in targets.iter().copied().enumerate() {
+                    self.write_bit(
+                        target.net,
+                        target.bit_number,
+                        *src_bv.get_lsb(offset),
+                        nets,
+                        interner,
+                    )?;
+                }
+                Ok(())
+            }
         }
     }
 
@@ -527,15 +577,8 @@ fn process_instance_outputs(
                         type_name, inst_name, port_name, e
                     )
                 })?;
-            match netref {
-                NetRef::Simple(_) | NetRef::BitSelect(_, _) | NetRef::PartSelect(_, _, _) => {
-                    let src_bv = AigBitVector::from_bit(out_op);
-                    resolved.write_ref(netref, &src_bv, nets, interner)?;
-                }
-                _ => {
-                    // Only net destinations are supported for output pins.
-                }
-            }
+            let src_bv = AigBitVector::from_bit(out_op);
+            resolved.write_ref(netref, &src_bv, nets, interner)?;
             processed_any_output = true;
         }
     }
@@ -579,12 +622,6 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
     dff_cells_inverted: &std::collections::HashSet<String>,
     options: &GateFnProjectOptions,
 ) -> Result<GateFn, String> {
-    if !module.assigns.is_empty() {
-        return Err(
-            "Liberty-backed netlist projection does not support preserved continuous assigns"
-                .to_string(),
-        );
-    }
     let used_cell_names: HashSet<String> = module
         .instances
         .iter()
@@ -601,11 +638,25 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
     let mut gb = GateBuilder::new(module_name.to_string(), GateBuilderOptions::no_opt());
     let mut resolved = ResolvedNetValues::new();
     collect_module_io_nets(module, nets, interner, &mut gb, &mut resolved);
+    let module_output_bits = collect_module_output_bits(module, nets)?;
+    let mut pending_assigns = build_pending_assign_bits(module, nets, interner)?;
     let mut used_as_input = HashSet::new();
     let mut driven = HashSet::new();
     for port in &module.ports {
         if port.direction == crate::netlist::parse::PortDirection::Input {
             driven.insert(port.name);
+        }
+    }
+    for assign in &module.assigns {
+        let mut lhs_nets = Vec::new();
+        assign.lhs.collect_net_indices(&mut lhs_nets);
+        for net_idx in lhs_nets {
+            driven.insert(nets[net_idx.0].name);
+        }
+        let mut rhs_nets = Vec::new();
+        assign.rhs.collect_net_indices(&mut rhs_nets);
+        for net_idx in rhs_nets {
+            used_as_input.insert(nets[net_idx.0].name);
         }
     }
     for inst in &module.instances {
@@ -642,8 +693,18 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
     check_undriven_nets(&used_as_input, &driven, interner);
     let mut unprocessed: Vec<_> = module.instances.iter().collect();
     let mut processed_any = true;
-    while !unprocessed.is_empty() && processed_any {
+    while (!unprocessed.is_empty() || !pending_assigns.is_empty()) && processed_any {
         processed_any = false;
+        let (next_pending_assigns, processed_assign) = process_pending_assign_bits(
+            pending_assigns,
+            module,
+            &mut resolved,
+            nets,
+            interner,
+            &mut gb,
+        )?;
+        pending_assigns = next_pending_assigns;
+        processed_any |= processed_assign;
         let mut i = 0;
         while i < unprocessed.len() {
             let inst = unprocessed[i];
@@ -692,7 +753,15 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
                 i += 1;
             }
         }
-        if !processed_any && !unprocessed.is_empty() {
+        if !processed_any && unprocessed.is_empty() && !pending_assigns.is_empty() {
+            if pending_assigns
+                .iter()
+                .all(|pending_bit| !module_output_bits.contains(&pending_bit.target))
+            {
+                break;
+            }
+        }
+        if !processed_any && (!unprocessed.is_empty() || !pending_assigns.is_empty()) {
             // Build a short, actionable diagnostic to help pinpoint why instances
             // could not be resolved. We show up to a bounded number of examples
             // with their missing inputs.
@@ -747,6 +816,20 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
                 msg.push_str(&line);
                 msg.push('\n');
             }
+            if !pending_assigns.is_empty() {
+                msg.push_str(&format!(
+                    "Unresolved continuous assign bits: {}\n",
+                    pending_assigns.len()
+                ));
+                for pending_bit in pending_assigns.iter().take(10) {
+                    let assign = &module.assigns[pending_bit.assign_index];
+                    msg.push_str(&format!(
+                        "- assign to '{}' at {} remains unresolved\n",
+                        bit_ref::render_net_bit(pending_bit.target, nets, interner),
+                        assign.span.to_human_string()
+                    ));
+                }
+            }
             msg.push_str(r#"Hint: re-run with RUST_LOG=trace to log skipped instances and their missing nets during processing."#);
             return Err(msg);
         }
@@ -795,6 +878,32 @@ fn collect_module_io_nets(
             resolved.seed_input(net_idx, &bv);
         }
     }
+}
+
+fn collect_module_output_bits(
+    module: &NetlistModule,
+    nets: &[Net],
+) -> Result<HashSet<bit_ref::NetBit>, String> {
+    let mut output_bits = HashSet::new();
+    for port in &module.ports {
+        if port.direction != crate::netlist::parse::PortDirection::Output {
+            continue;
+        }
+        let net_idx = module
+            .find_net_index(port.name, nets)
+            .ok_or_else(|| "output port net not found".to_string())?;
+        let net = &nets[net_idx.0];
+        for offset in 0..net.width_bits() {
+            let bit_number = net
+                .bit_number(offset)
+                .ok_or_else(|| "internal error computing output bit number".to_string())?;
+            output_bits.insert(bit_ref::NetBit {
+                net: net_idx,
+                bit_number,
+            });
+        }
+    }
+    Ok(output_bits)
 }
 
 fn build_instance_input_map(
@@ -960,7 +1069,10 @@ fn write_bv_to_port_destination(
             continue;
         }
         match dst_ref {
-            NetRef::Simple(_) | NetRef::BitSelect(_, _) | NetRef::PartSelect(_, _, _) => {
+            NetRef::Simple(_)
+            | NetRef::BitSelect(_, _)
+            | NetRef::PartSelect(_, _, _)
+            | NetRef::Concat(_) => {
                 resolved.write_ref(dst_ref, src_bv, nets, interner)?;
             }
             NetRef::Literal(_) => {
@@ -972,12 +1084,182 @@ fn write_bv_to_port_destination(
             NetRef::Unconnected => {
                 // Nothing to write.
             }
-            NetRef::Concat(_) => {
-                return Err("concat destination not supported in DFF override".to_string());
-            }
         }
     }
     Ok(())
+}
+
+fn is_bare_literal_assign_expr(expr: &AssignExpr) -> bool {
+    matches!(expr, AssignExpr::Leaf(NetRef::Literal(_)))
+}
+
+fn eval_assign_net_ref_bit(
+    net_ref: &NetRef,
+    rhs_bit_index: usize,
+    allow_literal_zero_extend: bool,
+    resolved: &ResolvedNetValues,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    gb: &mut GateBuilder,
+) -> Result<Option<AigOperand>, String> {
+    let bit_refs =
+        bit_ref::net_ref_lsb_bit_refs(net_ref, nets, interner).map_err(|e| e.to_string())?;
+    if rhs_bit_index >= bit_refs.len() {
+        if allow_literal_zero_extend && matches!(net_ref, NetRef::Literal(_)) {
+            return Ok(Some(gb.get_false()));
+        }
+        return Err(format!(
+            "bit {} out of range for {}-bit expression '{}'",
+            rhs_bit_index,
+            bit_refs.len(),
+            bit_ref::render_net_ref(net_ref, nets, interner)
+        ));
+    }
+    match bit_refs[rhs_bit_index] {
+        bit_ref::NetBitRef::Net(bit) => {
+            resolved.resolve_bit(bit.net, bit.bit_number, nets, interner)
+        }
+        bit_ref::NetBitRef::Literal(value) => {
+            Ok(Some(if value { gb.get_true() } else { gb.get_false() }))
+        }
+    }
+}
+
+fn eval_assign_expr_bit(
+    expr: &AssignExpr,
+    rhs_bit_index: usize,
+    allow_literal_zero_extend: bool,
+    resolved: &ResolvedNetValues,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    gb: &mut GateBuilder,
+) -> Result<Option<AigOperand>, String> {
+    match expr {
+        AssignExpr::Leaf(net_ref) => eval_assign_net_ref_bit(
+            net_ref,
+            rhs_bit_index,
+            allow_literal_zero_extend,
+            resolved,
+            nets,
+            interner,
+            gb,
+        ),
+        AssignExpr::Not(inner) => {
+            let Some(value) = eval_assign_expr_bit(
+                inner,
+                rhs_bit_index,
+                allow_literal_zero_extend,
+                resolved,
+                nets,
+                interner,
+                gb,
+            )?
+            else {
+                return Ok(None);
+            };
+            Ok(Some(gb.add_not(value)))
+        }
+        AssignExpr::And(lhs, rhs) | AssignExpr::Or(lhs, rhs) | AssignExpr::Xor(lhs, rhs) => {
+            let Some(lhs_value) = eval_assign_expr_bit(
+                lhs,
+                rhs_bit_index,
+                allow_literal_zero_extend,
+                resolved,
+                nets,
+                interner,
+                gb,
+            )?
+            else {
+                return Ok(None);
+            };
+            let Some(rhs_value) = eval_assign_expr_bit(
+                rhs,
+                rhs_bit_index,
+                allow_literal_zero_extend,
+                resolved,
+                nets,
+                interner,
+                gb,
+            )?
+            else {
+                return Ok(None);
+            };
+            Ok(Some(match expr {
+                AssignExpr::And(_, _) => gb.add_and_binary(lhs_value, rhs_value),
+                AssignExpr::Or(_, _) => gb.add_or_binary(lhs_value, rhs_value),
+                AssignExpr::Xor(_, _) => gb.add_xor_binary(lhs_value, rhs_value),
+                _ => unreachable!(),
+            }))
+        }
+    }
+}
+
+fn build_pending_assign_bits(
+    module: &NetlistModule,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> Result<Vec<PendingAssignBit>, String> {
+    let mut pending = Vec::new();
+    for (assign_index, assign) in module.assigns.iter().enumerate() {
+        let lhs_bits =
+            bit_ref::net_ref_lsb_targets(&assign.lhs, nets, interner).map_err(|e| e.to_string())?;
+        let rhs_width = bit_ref::assign_expr_width_bits(&assign.rhs, nets, interner)
+            .map_err(|e| e.to_string())?;
+        let allow_literal_zero_extend = is_bare_literal_assign_expr(&assign.rhs);
+        if lhs_bits.len() != rhs_width && !allow_literal_zero_extend {
+            return Err(format!(
+                "assign to '{}' has lhs width {} but rhs width {}; Liberty-backed projection requires exact-width assigns except for bare literal tie-offs",
+                bit_ref::render_net_ref(&assign.lhs, nets, interner),
+                lhs_bits.len(),
+                rhs_width
+            ));
+        }
+        for (rhs_bit_index, target) in lhs_bits.into_iter().enumerate() {
+            pending.push(PendingAssignBit {
+                assign_index,
+                rhs_bit_index,
+                target,
+            });
+        }
+    }
+    Ok(pending)
+}
+
+fn process_pending_assign_bits(
+    pending: Vec<PendingAssignBit>,
+    module: &NetlistModule,
+    resolved: &mut ResolvedNetValues,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    gb: &mut GateBuilder,
+) -> Result<(Vec<PendingAssignBit>, bool), String> {
+    let mut next_pending = Vec::new();
+    let mut processed_any = false;
+    for pending_bit in pending {
+        let assign = &module.assigns[pending_bit.assign_index];
+        let Some(value) = eval_assign_expr_bit(
+            &assign.rhs,
+            pending_bit.rhs_bit_index,
+            is_bare_literal_assign_expr(&assign.rhs),
+            resolved,
+            nets,
+            interner,
+            gb,
+        )?
+        else {
+            next_pending.push(pending_bit);
+            continue;
+        };
+        resolved.write_bit(
+            pending_bit.target.net,
+            pending_bit.target.bit_number,
+            value,
+            nets,
+            interner,
+        )?;
+        processed_any = true;
+    }
+    Ok((next_pending, processed_any))
 }
 
 /// Implements DFF output overrides for identity (Q=D) and inverted (QN=NOT(D)).
@@ -1059,7 +1341,8 @@ mod tests {
     use crate::aig_sim::gate_sim::{self, Collect};
     use crate::liberty_proto::{Cell, Library, Pin, PinDirection};
     use crate::netlist::parse::{
-        Net, NetRef, NetlistInstance, NetlistModule, NetlistPort, PortDirection,
+        Net, NetRef, NetlistInstance, NetlistModule, NetlistPort, Parser, PortDirection,
+        TokenScanner,
     };
     use string_interner::{StringInterner, backend::StringBackend};
     use xlsynth::IrBits;
@@ -1157,6 +1440,21 @@ mod tests {
         got.outputs.into_iter().nth(output_index).unwrap()
     }
 
+    fn project_parsed_netlist(src: &'static str) -> GateFn {
+        let mut parser = Parser::new(TokenScanner::from_str(src));
+        let modules = parser.parse_file().expect("parse netlist");
+        assert_eq!(modules.len(), 1);
+        project_gatefn_from_netlist_and_liberty(
+            &modules[0],
+            &parser.nets,
+            &parser.interner,
+            &projection_order_test_liberty(),
+            &HashSet::new(),
+            &HashSet::new(),
+        )
+        .expect("project parsed netlist")
+    }
+
     fn dffhq_identity_cells() -> HashSet<String> {
         let mut dff_cells_identity = HashSet::new();
         dff_cells_identity.insert("DFFHQ".to_string());
@@ -1183,6 +1481,30 @@ mod tests {
 
     fn bool_ir(values: &[bool]) -> Vec<IrBits> {
         values.iter().copied().map(IrBits::bool).collect()
+    }
+
+    #[test]
+    fn test_liberty_projection_supports_preserved_concat_assigns() {
+        let gate_fn = project_parsed_netlist(
+            r#"
+module top (a, y);
+  input [1:0] a;
+  output y;
+  wire [1:0] a;
+  wire y;
+  wire [1:0] tmp;
+  assign tmp = {a[0], a[1]};
+  BUF u0 (.A(tmp[1]), .Y(y));
+endmodule
+"#,
+        );
+
+        let y_from_bit0_one =
+            eval_output_by_name(&gate_fn, vec![IrBits::make_ubits(2, 0b01).unwrap()], "y");
+        assert_bits(&y_from_bit0_one, &[true]);
+        let y_from_bit0_zero =
+            eval_output_by_name(&gate_fn, vec![IrBits::make_ubits(2, 0b10).unwrap()], "y");
+        assert_bits(&y_from_bit0_zero, &[false]);
     }
 
     fn assert_bits(bits: &IrBits, expected_lsb_to_msb: &[bool]) {

--- a/xlsynth-g8r/src/netlist/gv2aig.rs
+++ b/xlsynth-g8r/src/netlist/gv2aig.rs
@@ -7,7 +7,7 @@ use crate::netlist::assigns_to_gatefn::project_gatefn_from_structural_assigns;
 use crate::netlist::gatefn_from_netlist::{
     GateFnProjectOptions, project_gatefn_from_netlist_and_liberty_with_options,
 };
-use crate::netlist::io::{load_liberty_from_path, parse_netlist_from_path};
+use crate::netlist::io::{load_liberty_from_path, parse_netlist_from_path, select_module};
 use anyhow::{Result, anyhow};
 use std::path::Path;
 
@@ -28,69 +28,13 @@ impl Default for Gv2AigOptions {
     }
 }
 
-fn select_module<'a>(
-    parsed: &'a crate::netlist::io::ParsedNetlist,
-    module_name: &Option<String>,
-) -> Result<&'a crate::netlist::parse::NetlistModule> {
-    if let Some(module_name) = module_name {
-        parsed
-            .modules
-            .iter()
-            .find(|m| {
-                parsed
-                    .interner
-                    .resolve(m.name)
-                    .is_some_and(|s| s == module_name.as_str())
-            })
-            .ok_or_else(|| {
-                let mut available: Vec<String> = parsed
-                    .modules
-                    .iter()
-                    .map(|m| {
-                        parsed
-                            .interner
-                            .resolve(m.name)
-                            .unwrap_or("<unknown>")
-                            .to_string()
-                    })
-                    .collect();
-                available.sort();
-                anyhow!(format!(
-                    "module '{}' not found in netlist; available modules: [{}]",
-                    module_name,
-                    available.join(", ")
-                ))
-            })
-    } else if parsed.modules.len() == 1 {
-        Ok(&parsed.modules[0])
-    } else {
-        let mut available: Vec<String> = parsed
-            .modules
-            .iter()
-            .map(|m| {
-                parsed
-                    .interner
-                    .resolve(m.name)
-                    .unwrap_or("<unknown>")
-                    .to_string()
-            })
-            .collect();
-        available.sort();
-        Err(anyhow!(format!(
-            "netlist contains {} modules; specify --module_name; available modules: [{}]",
-            parsed.modules.len(),
-            available.join(", ")
-        )))
-    }
-}
-
 pub fn convert_gv2aig_paths_with_optional_liberty(
     netlist_path: &Path,
     liberty_proto_path: Option<&Path>,
     opts: &Gv2AigOptions,
 ) -> Result<GateFn> {
     let parsed = parse_netlist_from_path(netlist_path)?;
-    let module = select_module(&parsed, &opts.module_name)?;
+    let module = select_module(&parsed, opts.module_name.as_deref())?;
 
     let Some(liberty_proto_path) = liberty_proto_path else {
         // See STRUCTURAL_ASSIGNS.md for the exact Liberty-free assign subset and
@@ -98,12 +42,6 @@ pub fn convert_gv2aig_paths_with_optional_liberty(
         return project_gatefn_from_structural_assigns(module, &parsed.nets, &parsed.interner)
             .map_err(|e| anyhow!(e));
     };
-
-    if !module.assigns.is_empty() {
-        return Err(anyhow!(
-            "Liberty-backed gv2aig does not support preserved continuous assigns; rerun without --liberty_proto only for assign-only structural netlists"
-        ));
-    }
 
     let liberty_lib = load_liberty_from_path(liberty_proto_path)?;
 

--- a/xlsynth-g8r/src/netlist/gv2ir.rs
+++ b/xlsynth-g8r/src/netlist/gv2ir.rs
@@ -4,43 +4,90 @@ use crate::aig_serdes::gate2ir::gate_fn_to_xlsynth_ir;
 use crate::netlist::gatefn_from_netlist::{
     GateFnProjectOptions, project_gatefn_from_netlist_and_liberty_with_options,
 };
-use crate::netlist::io::load_liberty_from_path;
-use crate::netlist::parse::{Parser as NetlistParser, TokenScanner};
-use anyhow::{Context, Result, anyhow};
-use flate2::bufread::MultiGzDecoder as BufMultiGzDecoder;
+use crate::netlist::io::{load_liberty_from_path, parse_netlist_from_path, select_module};
+use anyhow::{Result, anyhow};
 use std::collections::HashSet;
-use std::fs::File;
-use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 
-fn open_reader(path: &Path) -> Result<(Box<dyn Read>, bool)> {
-    let is_gz = path.extension().map(|e| e == "gz").unwrap_or(false);
-    if is_gz {
-        let f =
-            File::open(path).with_context(|| format!("opening netlist '{}'", path.display()))?;
-        let br = BufReader::new(f);
-        Ok((Box::new(BufMultiGzDecoder::new(br)), true))
-    } else {
-        let f =
-            File::open(path).with_context(|| format!("opening netlist '{}'", path.display()))?;
-        Ok((Box::new(f), false))
+#[derive(Debug, Clone)]
+pub struct Gv2IrOptions {
+    /// Optional module name to select when the netlist contains multiple
+    /// modules.
+    pub module_name: Option<String>,
+
+    /// If true, collapse sequential state variables by substituting next_state.
+    pub collapse_sequential: bool,
+
+    /// Optional function name to use in the emitted XLS IR package.
+    pub output_function_name: Option<String>,
+}
+
+impl Default for Gv2IrOptions {
+    fn default() -> Self {
+        Self {
+            module_name: None,
+            collapse_sequential: true,
+            output_function_name: None,
+        }
     }
 }
 
-fn line_lookup(path: &Path, is_gz: bool) -> Box<dyn Fn(u32) -> Option<String>> {
-    let path = path.to_path_buf();
-    Box::new(move |lineno| {
-        let f = File::open(&path).ok()?;
-        if is_gz {
-            let br = BufReader::new(f);
-            let gz = BufMultiGzDecoder::new(br);
-            let rdr = BufReader::new(gz);
-            rdr.lines().nth((lineno - 1) as usize).and_then(Result::ok)
-        } else {
-            let rdr = BufReader::new(f);
-            rdr.lines().nth((lineno - 1) as usize).and_then(Result::ok)
-        }
-    })
+fn select_output_function_name(raw: &str, override_name: Option<&str>) -> Result<String> {
+    let name = override_name.unwrap_or(raw);
+    if name == "top" {
+        return Err(anyhow!(
+            "gv2ir would emit XLS IR function name 'top', but 'top' is reserved; pass --output_function_name <NAME> to choose a valid emitted function name"
+        ));
+    }
+    if !is_valid_xls_function_name(name) {
+        return Err(anyhow!(
+            "gv2ir would emit invalid XLS IR function name '{}'; pass --output_function_name <NAME> to choose a valid emitted function name",
+            name
+        ));
+    }
+    Ok(name.to_string())
+}
+
+fn is_valid_xls_function_name(name: &str) -> bool {
+    if is_xls_ir_keyword(name) {
+        return false;
+    }
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn is_xls_ir_keyword(name: &str) -> bool {
+    matches!(
+        name,
+        "after_all"
+            | "array"
+            | "assert"
+            | "bits"
+            | "block"
+            | "chan"
+            | "cover"
+            | "file_number"
+            | "fn"
+            | "gate"
+            | "instantiation"
+            | "map"
+            | "next_value"
+            | "package"
+            | "proc"
+            | "recv"
+            | "reg"
+            | "ret"
+            | "send"
+            | "state"
+            | "token"
+            | "trace"
+    )
 }
 
 pub fn convert_gv2ir_paths(
@@ -48,54 +95,51 @@ pub fn convert_gv2ir_paths(
     liberty_proto_path: &Path,
     collapse_sequential: bool,
 ) -> Result<String> {
-    // Netlist parse
-    let (reader, is_gz) = open_reader(netlist_path)?;
-    let lookup = line_lookup(netlist_path, is_gz);
-    let scanner = TokenScanner::with_line_lookup(reader, lookup);
-    let mut parser: NetlistParser<Box<dyn Read>> = NetlistParser::new(scanner);
-    let modules = parser.parse_file().map_err(|e| {
-        anyhow!(format!(
-            "{} @ {}\n{}\n{}^",
-            e.message,
-            e.span.to_human_string(),
-            parser
-                .get_line(e.span.start.lineno)
-                .unwrap_or_else(|| "<line unavailable>".to_string()),
-            " ".repeat((e.span.start.colno as usize).saturating_sub(1))
-        ))
-    })?;
-    if modules.len() != 1 {
-        return Err(anyhow!(format!(
-            "expected exactly one module, got {}",
-            modules.len()
-        )));
-    }
-    let module = &modules[0];
-    if !module.assigns.is_empty() {
-        return Err(anyhow!(
-            "gv2ir does not support preserved continuous assigns"
-        ));
-    }
+    convert_gv2ir_paths_with_options(
+        netlist_path,
+        liberty_proto_path,
+        &Gv2IrOptions {
+            module_name: None,
+            collapse_sequential,
+            output_function_name: None,
+        },
+    )
+}
+
+pub fn convert_gv2ir_paths_with_options(
+    netlist_path: &Path,
+    liberty_proto_path: &Path,
+    opts: &Gv2IrOptions,
+) -> Result<String> {
+    let parsed = parse_netlist_from_path(netlist_path)?;
+    let module = select_module(&parsed, opts.module_name.as_deref())?;
+    let module_function_name = parsed
+        .interner
+        .resolve(module.name)
+        .ok_or_else(|| anyhow!("could not resolve module name symbol"))?;
+    let output_function_name =
+        select_output_function_name(module_function_name, opts.output_function_name.as_deref())?;
 
     // Liberty
     let liberty_lib = load_liberty_from_path(liberty_proto_path)?;
     let empty_dff_cells = HashSet::new();
 
     // Project GateFn
-    let gate_fn = project_gatefn_from_netlist_and_liberty_with_options(
+    let mut gate_fn = project_gatefn_from_netlist_and_liberty_with_options(
         module,
-        &parser.nets,
-        &parser.interner,
+        &parsed.nets,
+        &parsed.interner,
         &liberty_lib,
         &empty_dff_cells,
         &empty_dff_cells,
         &GateFnProjectOptions {
-            collapse_sequential,
+            collapse_sequential: opts.collapse_sequential,
         },
     )
     .map_err(|e| anyhow!(e))?;
 
     // Convert to IR text
+    gate_fn.name = output_function_name;
     let flat_type = gate_fn.get_flat_type();
     let ir_pkg = gate_fn_to_xlsynth_ir(&gate_fn, "gate", &flat_type)?;
     Ok(ir_pkg.to_string())

--- a/xlsynth-g8r/src/netlist/io.rs
+++ b/xlsynth-g8r/src/netlist/io.rs
@@ -12,7 +12,7 @@
 use crate::liberty::load::{
     Library, LibraryWithTimingData, load_library_from_path, load_library_with_timing_data_from_path,
 };
-use crate::netlist::parse::{Net, NetlistModule, Parser as NetlistParser, TokenScanner};
+use crate::netlist::parse::{Net, NetlistModule, Parser as NetlistParser, PortId, TokenScanner};
 use anyhow::{Result, anyhow};
 use flate2::read::MultiGzDecoder;
 use std::fs::File;
@@ -26,6 +26,69 @@ pub struct ParsedNetlist {
     pub modules: Vec<NetlistModule>,
     pub nets: Vec<Net>,
     pub interner: StringInterner<StringBackend<SymbolU32>>,
+}
+
+/// Resolves one interned netlist symbol with an actionable error.
+pub fn resolve_symbol(
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    sym: PortId,
+    what: &str,
+) -> Result<String> {
+    interner
+        .resolve(sym)
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow!("could not resolve {} symbol", what))
+}
+
+/// Selects one module by name, or the only module when no name is provided.
+pub fn select_module<'a>(
+    parsed: &'a ParsedNetlist,
+    module_name: Option<&str>,
+) -> Result<&'a NetlistModule> {
+    if let Some(name) = module_name {
+        for module in &parsed.modules {
+            let resolved = resolve_symbol(&parsed.interner, module.name, "module name")?;
+            if resolved == name {
+                return Ok(module);
+            }
+        }
+        let mut available: Vec<String> = parsed
+            .modules
+            .iter()
+            .map(|m| {
+                parsed
+                    .interner
+                    .resolve(m.name)
+                    .unwrap_or("<unknown>")
+                    .to_string()
+            })
+            .collect();
+        available.sort();
+        return Err(anyhow!(
+            "module '{}' not found in netlist; available modules: [{}]",
+            name,
+            available.join(", ")
+        ));
+    }
+
+    if parsed.modules.len() == 1 {
+        return Ok(&parsed.modules[0]);
+    }
+
+    let mut names = Vec::with_capacity(parsed.modules.len());
+    for module in &parsed.modules {
+        names.push(resolve_symbol(
+            &parsed.interner,
+            module.name,
+            "module name",
+        )?);
+    }
+    names.sort();
+    Err(anyhow!(
+        "netlist contains {} modules; specify --module_name; available modules: [{}]",
+        parsed.modules.len(),
+        names.join(", ")
+    ))
 }
 
 /// Parse a gate-level netlist (optionally gzipped) into modules, nets, and the

--- a/xlsynth-g8r/src/netlist/mod.rs
+++ b/xlsynth-g8r/src/netlist/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod assigns_to_gatefn;
 pub mod bench_synth_netlist;
+pub mod bit_ref;
 pub mod cone;
 pub mod connectivity;
 pub mod emit;

--- a/xlsynth-g8r/src/netlist/parse.rs
+++ b/xlsynth-g8r/src/netlist/parse.rs
@@ -1372,10 +1372,7 @@ impl<R: Read + 'static> Parser<R> {
                     return Ok(expr);
                 }
                 TokenPayload::OBrace => {
-                    return Err(ScanError {
-                        message: "concatenation is not supported in assign expressions".to_string(),
-                        span: tok.span,
-                    });
+                    return Ok(AssignExpr::Leaf(self.parse_netref_expr()?));
                 }
                 _ => {}
             }
@@ -1542,7 +1539,8 @@ impl<R: Read + 'static> Parser<R> {
     /// Parses: assign <lhs> = <rhs>;
     ///
     /// The supported RHS subset is limited to bitwise `~`, `&`, `|`, and `^`
-    /// over identifiers/literals with optional selects plus parentheses.
+    /// over identifiers/literals/concats with optional selects plus
+    /// parentheses.
     fn parse_assign(&mut self) -> Result<NetlistAssign, ScanError> {
         let t_assign = self.scanner.popt()?.ok_or_else(|| ScanError {
             message: "expected 'assign'".to_string(),
@@ -2600,7 +2598,7 @@ endmodule
     }
 
     #[test]
-    fn test_parse_module_rejects_concat_in_assign_expression() {
+    fn test_parse_module_accepts_concat_in_assign_expression() {
         let src = r#"
 module m(a, b, y);
   input a;
@@ -2610,12 +2608,11 @@ module m(a, b, y);
 endmodule
 "#;
         let mut parser = Parser::new(TokenScanner::from_str(src));
-        let err = parser.parse_file().expect_err("concat should be rejected");
-        assert!(
-            err.message.contains("concatenation is not supported"),
-            "unexpected error: {}",
-            err.message
-        );
+        let modules = parser.parse_file().expect("concat assign should parse");
+        match &modules[0].assigns[0].rhs {
+            AssignExpr::Leaf(NetRef::Concat(elems)) => assert_eq!(elems.len(), 2),
+            other => panic!("expected concat assign RHS, got {:?}", other),
+        }
     }
 
     #[test]

--- a/xlsynth-g8r/src/netlist/report.rs
+++ b/xlsynth-g8r/src/netlist/report.rs
@@ -4,8 +4,8 @@
 
 use crate::liberty::LibraryWithTimingData;
 use crate::liberty_proto::Library;
-use crate::netlist::io::ParsedNetlist;
-use crate::netlist::parse::{Net, NetlistModule, PortDirection, PortId};
+pub use crate::netlist::io::{resolve_symbol, select_module};
+use crate::netlist::parse::{Net, NetlistModule, PortDirection};
 use crate::netlist::sta::{StaOptions, analyze_combinational_max_arrival};
 use anyhow::{Result, anyhow};
 use serde::Serialize;
@@ -67,53 +67,6 @@ pub struct NetlistReport {
     pub cell_levels: usize,
     pub cells: Vec<CellAreaRow>,
     pub outputs: Vec<OutputTimingRow>,
-}
-
-/// Resolves one interned netlist symbol with an actionable error.
-pub fn resolve_symbol(
-    interner: &StringInterner<StringBackend<SymbolU32>>,
-    sym: PortId,
-    what: &str,
-) -> Result<String> {
-    interner
-        .resolve(sym)
-        .map(|s| s.to_string())
-        .ok_or_else(|| anyhow!("could not resolve {} symbol", what))
-}
-
-/// Selects one module by name, or the only module when no name is provided.
-pub fn select_module<'a>(
-    parsed: &'a ParsedNetlist,
-    module_name: Option<&str>,
-) -> Result<&'a NetlistModule> {
-    if let Some(name) = module_name {
-        for module in &parsed.modules {
-            let resolved = resolve_symbol(&parsed.interner, module.name, "module name")?;
-            if resolved == name {
-                return Ok(module);
-            }
-        }
-        return Err(anyhow!("module '{}' was not found in netlist", name));
-    }
-
-    if parsed.modules.len() == 1 {
-        return Ok(&parsed.modules[0]);
-    }
-
-    let mut names = Vec::with_capacity(parsed.modules.len());
-    for module in &parsed.modules {
-        names.push(resolve_symbol(
-            &parsed.interner,
-            module.name,
-            "module name",
-        )?);
-    }
-    names.sort();
-    Err(anyhow!(
-        "netlist contains {} modules; use --module_name; available modules: [{}]",
-        parsed.modules.len(),
-        names.join(", ")
-    ))
 }
 
 /// Builds mapped standard-cell area for one selected module.
@@ -336,6 +289,26 @@ mod tests {
                     ..Default::default()
                 },
                 Cell {
+                    name: "BUF".to_string(),
+                    pins: vec![
+                        Pin {
+                            name: "A".to_string(),
+                            direction: PinDirection::Input as i32,
+                            capacitance: Some(0.0),
+                            ..Default::default()
+                        },
+                        Pin {
+                            name: "Y".to_string(),
+                            direction: PinDirection::Output as i32,
+                            function: "A".to_string(),
+                            timing_arcs: vec![timing_arc("A", 1.0, 1.0)],
+                            ..Default::default()
+                        },
+                    ],
+                    area: 1.0,
+                    ..Default::default()
+                },
+                Cell {
                     name: "NAND2".to_string(),
                     pins: vec![
                         Pin {
@@ -436,6 +409,37 @@ endmodule
     }
 
     #[test]
+    fn build_netlist_report_accepts_yosys_concat_alias_assign() {
+        let parsed = parse_netlist(
+            r#"
+module top (x, y);
+  input [31:0] x;
+  output y;
+  wire [31:0] x;
+  wire y;
+  wire [8:0] exp_x_signed__2;
+  assign exp_x_signed__2 = { 1'h0, x[30:23] };
+  BUF u0 (.A(exp_x_signed__2[8]), .Y(y));
+endmodule
+"#,
+        );
+        let module = select_module(&parsed, None).expect("select only module");
+        let library = LibraryWithTimingData::from_proto(inv_nand_library());
+        let report = build_netlist_report(
+            module,
+            &parsed.nets,
+            &parsed.interner,
+            &library,
+            StaOptions::default(),
+        )
+        .expect("build report with Yosys concat alias assign");
+        assert_eq!(report.area, 1.0);
+        assert_eq!(report.delay, 1.0);
+        assert_eq!(report.cell_count, 1);
+        assert_eq!(report.cell_levels, 1);
+    }
+
+    #[test]
     fn build_area_report_rejects_unknown_cells() {
         let parsed = parse_netlist(
             r#"
@@ -444,13 +448,13 @@ module top (a, y);
   output y;
   wire a;
   wire y;
-  BUF u0 (.A(a), .Y(y));
+  UNKNOWN u0 (.A(a), .Y(y));
 endmodule
 "#,
         );
         let module = select_module(&parsed, None).expect("select only module");
         let error = build_area_report(module, &parsed.interner, &inv_nand_library())
             .expect_err("unknown cell should be rejected");
-        assert!(error.to_string().contains("unknown cell 'BUF'"));
+        assert!(error.to_string().contains("unknown cell 'UNKNOWN'"));
     }
 }

--- a/xlsynth-g8r/src/netlist/sta.rs
+++ b/xlsynth-g8r/src/netlist/sta.rs
@@ -5,7 +5,8 @@
 //! This module implements a limited-scope, combinational max-arrival analysis:
 //! - Uses Liberty combinational timing arcs (`cell_rise`, `cell_fall`,
 //!   `rise_transition`, `fall_transition`).
-//! - Propagates rise/fall arrival and transition values net-by-net.
+//! - Propagates rise/fall arrival and transition values bit-by-bit, then
+//!   aggregates report timing back to parsed nets.
 //! - Assumes fixed transition at primary-input sources.
 //! - Uses summed input-pin capacitance on each net plus a fixed module-output
 //!   load to query timing tables.
@@ -19,10 +20,9 @@
 //!   frontier reduction relies on larger transition/load queries not producing
 //!   smaller delay/slew values. Small decreases within the
 //!   characterization-noise tolerance are treated as effectively equal.
-//! - Accepts scalar bare-literal and scalar alias continuous assigns as
-//!   zero-delay sources so mapped netlists emitted by tools such as ABC can
-//!   preserve constant outputs and wire aliases without needing synthetic
-//!   cells.
+//! - Accepts literal, alias, slice, and concat continuous assigns as zero-delay
+//!   bit sources so mapped netlists emitted by tools such as Yosys/ABC can
+//!   preserve constants and wire aliases without needing synthetic cells.
 //!
 //! At a high level, the analysis is:
 //! 1. Index each instance's cell/pin connectivity, recording one driver and all
@@ -51,6 +51,7 @@ use crate::liberty::LibraryWithTimingData;
 use crate::liberty::cell_formula::parse_formula;
 use crate::liberty::timing_table::TimingTableArrayView;
 use crate::liberty_proto::{LuTableTemplate, Pin, PinDirection, TimingArc, TimingTable};
+use crate::netlist::bit_ref;
 use crate::netlist::parse::{AssignExpr, Net, NetIndex, NetRef, NetlistModule, PortDirection};
 use anyhow::{Result, anyhow};
 use std::cmp::Ordering;
@@ -298,15 +299,93 @@ struct NetEndpoint {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ScalarAssignSource {
+enum BitAssignSource {
     Literal(bool),
-    Alias(NetIndex),
+    Alias(usize),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ResolvedTimingSource {
     Literal(bool),
-    Net(NetIndex),
+    Bit(usize),
+}
+
+#[derive(Clone, Debug)]
+struct UnsupportedAssignSource {
+    lhs_bits: Vec<usize>,
+    rendered_lhs: String,
+}
+
+#[derive(Clone, Debug)]
+struct AssignSourceAnalysis {
+    bit_sources: Vec<Option<BitAssignSource>>,
+    unsupported_sources: Vec<UnsupportedAssignSource>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PinBitSource {
+    Bit(usize),
+    Literal(bool),
+}
+
+struct StaBitIndex {
+    bits: Vec<bit_ref::NetBit>,
+    index_by_bit: HashMap<bit_ref::NetBit, usize>,
+    bits_by_net: Vec<Vec<usize>>,
+}
+
+impl StaBitIndex {
+    fn build(nets: &[Net]) -> Result<Self> {
+        let mut bits = Vec::new();
+        let mut index_by_bit = HashMap::new();
+        let mut bits_by_net = vec![Vec::new(); nets.len()];
+        for (net_raw_idx, net) in nets.iter().enumerate() {
+            let net_idx = NetIndex(net_raw_idx);
+            for offset in 0..net.width_bits() {
+                let bit_number = net.bit_number(offset).ok_or_else(|| {
+                    anyhow!(
+                        "internal error computing bit {} for net index {}",
+                        offset,
+                        net_raw_idx
+                    )
+                })?;
+                let bit = bit_ref::NetBit {
+                    net: net_idx,
+                    bit_number,
+                };
+                let bit_idx = bits.len();
+                bits.push(bit);
+                index_by_bit.insert(bit, bit_idx);
+                bits_by_net[net_raw_idx].push(bit_idx);
+            }
+        }
+        Ok(Self {
+            bits,
+            index_by_bit,
+            bits_by_net,
+        })
+    }
+
+    fn bit_index(&self, bit: bit_ref::NetBit) -> Result<usize> {
+        self.index_by_bit.get(&bit).copied().ok_or_else(|| {
+            anyhow!(
+                "net bit NetIndex({})[{}] is not present in STA bit index",
+                bit.net.0,
+                bit.bit_number
+            )
+        })
+    }
+
+    fn bit_ref_to_source(&self, bit_ref: bit_ref::NetBitRef) -> Result<PinBitSource> {
+        match bit_ref {
+            bit_ref::NetBitRef::Net(bit) => Ok(PinBitSource::Bit(self.bit_index(bit)?)),
+            bit_ref::NetBitRef::Literal(value) => Ok(PinBitSource::Literal(value)),
+        }
+    }
+
+    fn net_bits(&self, net: NetIndex) -> &[usize] {
+        &self.bits_by_net[net.0]
+    }
 }
 
 pub fn analyze_combinational_max_arrival(
@@ -353,20 +432,24 @@ fn analyze_combinational_max_arrival_proto(
 
     let lib = StaLibraryIndex::new(library)?;
     let instance_count = module.instances.len();
-    let assign_sources = scalar_assign_sources(module, nets, interner)?;
-    let assign_known_values = assign_known_values(assign_sources.as_slice(), nets, interner)?;
+    let bit_index = StaBitIndex::build(nets)?;
+    let bit_count = bit_index.bits.len();
+    let assign_analysis = analyze_assign_sources(module, nets, interner, &bit_index)?;
+    let assign_sources = assign_analysis.bit_sources;
+    let assign_known_values =
+        assign_known_values(assign_sources.as_slice(), &bit_index, nets, interner)?;
 
     let mut instance_cell_indices: Vec<usize> = Vec::with_capacity(instance_count);
     let mut instance_cell_names: Vec<String> = Vec::with_capacity(instance_count);
-    let mut instance_pin_nets: Vec<HashMap<String, Vec<NetIndex>>> =
+    let mut instance_pin_sources: Vec<HashMap<String, Vec<PinBitSource>>> =
         Vec::with_capacity(instance_count);
     let mut instance_known_pin_values: Vec<HashMap<String, bool>> =
         Vec::with_capacity(instance_count);
     let mut instance_timing_related_input_pins: Vec<HashSet<String>> =
         Vec::with_capacity(instance_count);
 
-    let mut net_drivers: Vec<Vec<NetEndpoint>> = vec![Vec::new(); nets.len()];
-    let mut net_loads: Vec<Vec<NetEndpoint>> = vec![Vec::new(); nets.len()];
+    let mut bit_drivers: Vec<Vec<NetEndpoint>> = vec![Vec::new(); bit_count];
+    let mut bit_loads: Vec<Vec<NetEndpoint>> = vec![Vec::new(); bit_count];
 
     for (inst_idx, inst) in module.instances.iter().enumerate() {
         let cell_name = resolve_symbol(interner, inst.type_name, "cell type")?;
@@ -413,11 +496,11 @@ fn analyze_combinational_max_arrival_proto(
             }
         }
 
-        let mut pin_nets: HashMap<String, Vec<NetIndex>> = HashMap::new();
+        let mut pin_sources: HashMap<String, Vec<PinBitSource>> = HashMap::new();
         let mut known_pin_values = HashMap::new();
         for (port_sym, netref) in &inst.connections {
             let pin_name = resolve_symbol(interner, *port_sym, "pin name")?;
-            if pin_nets.contains_key(pin_name.as_str()) {
+            if pin_sources.contains_key(pin_name.as_str()) {
                 return Err(anyhow!(
                     "instance '{}' of '{}' connects pin '{}' more than once; duplicate pin bindings are unsupported in basic STA",
                     resolve_symbol(interner, inst.instance_name, "instance name")
@@ -435,8 +518,23 @@ fn analyze_combinational_max_arrival_proto(
                     pin_name
                 )
             })?;
+            let bit_refs = bit_ref::net_ref_lsb_bit_refs(netref, nets, interner)?;
+            let pin_bit_sources: Vec<PinBitSource> = bit_refs
+                .into_iter()
+                .map(|bit_ref| bit_index.bit_ref_to_source(bit_ref))
+                .collect::<Result<Vec<_>>>()?;
+            if pin_bit_sources.len() > 1 {
+                return Err(anyhow!(
+                    "instance '{}' pin '{}.{}' connects {} bits; basic STA requires scalar cell pin connections after bit expansion",
+                    resolve_symbol(interner, inst.instance_name, "instance name")
+                        .unwrap_or_else(|_| "<unknown>".to_string()),
+                    cell_name,
+                    pin_name,
+                    pin_bit_sources.len()
+                ));
+            }
             if pin.direction == PinDirection::Output as i32
-                && matches!(netref, NetRef::Literal(_) | NetRef::Unconnected)
+                && !matches!(pin_bit_sources.as_slice(), [PinBitSource::Bit(_)])
             {
                 return Err(anyhow!(
                     "instance '{}' output pin '{}.{}' uses unsupported literal or unconnected binding",
@@ -446,63 +544,24 @@ fn analyze_combinational_max_arrival_proto(
                     pin_name
                 ));
             }
-            let uses_vector_connectivity = match netref {
-                NetRef::Simple(net_idx) => nets
-                    .get(net_idx.0)
-                    .map(|net| net_width_is_multibit(net.width))
-                    .unwrap_or(false),
-                NetRef::BitSelect(_, _) | NetRef::PartSelect(_, _, _) | NetRef::Concat(_) => true,
-                NetRef::Literal(_) | NetRef::Unconnected => false,
-            };
-            if uses_vector_connectivity {
-                return Err(anyhow!(
-                    "instance '{}' pin '{}.{}' uses vector connectivity; basic STA currently requires scalar net connections",
-                    resolve_symbol(interner, inst.instance_name, "instance name")
-                        .unwrap_or_else(|_| "<unknown>".to_string()),
-                    cell_name,
-                    pin_name
-                ));
-            }
-            if pin.direction == PinDirection::Input as i32
-                && timing_related_input_pins.contains(pin_name.as_str())
-                && matches!(netref, NetRef::Literal(_))
-            {
-                return Err(anyhow!(
-                    "instance '{}' timing-related input pin '{}.{}' uses a literal binding; basic STA does not model constant-tied timing inputs",
-                    resolve_symbol(interner, inst.instance_name, "instance name")
-                        .unwrap_or_else(|_| "<unknown>".to_string()),
-                    cell_name,
-                    pin_name
-                ));
-            }
-            let mut connected_nets = Vec::new();
-            netref.collect_net_indices(&mut connected_nets);
-            if let Some(value) = scalar_literal_netref_value(netref) {
-                known_pin_values.insert(pin_name.clone(), value);
-            }
-            for net_idx in &connected_nets {
-                if net_idx.0 >= nets.len() {
-                    return Err(anyhow!(
-                        "instance '{}' pin '{}' references out-of-range net index {}",
-                        resolve_symbol(interner, inst.instance_name, "instance name")
-                            .unwrap_or_else(|_| "<unknown>".to_string()),
-                        pin_name,
-                        net_idx.0
-                    ));
-                }
+            for source in &pin_bit_sources {
                 match pin.direction {
-                    d if d == PinDirection::Output as i32 => {
-                        net_drivers[net_idx.0].push(NetEndpoint {
+                    d if d == PinDirection::Output as i32 => match source {
+                        PinBitSource::Bit(bit_idx) => bit_drivers[*bit_idx].push(NetEndpoint {
                             inst_idx,
                             pin_name: pin_name.clone(),
-                        });
-                    }
-                    d if d == PinDirection::Input as i32 => {
-                        net_loads[net_idx.0].push(NetEndpoint {
+                        }),
+                        PinBitSource::Literal(_) => unreachable!(),
+                    },
+                    d if d == PinDirection::Input as i32 => match source {
+                        PinBitSource::Bit(bit_idx) => bit_loads[*bit_idx].push(NetEndpoint {
                             inst_idx,
                             pin_name: pin_name.clone(),
-                        });
-                    }
+                        }),
+                        PinBitSource::Literal(value) => {
+                            known_pin_values.insert(pin_name.clone(), *value);
+                        }
+                    },
                     _ => {
                         return Err(anyhow!(
                             "instance '{}' pin '{}.{}' has unsupported direction value {}",
@@ -515,36 +574,40 @@ fn analyze_combinational_max_arrival_proto(
                     }
                 }
             }
-            if let Some(net_idx) = connected_nets.first()
-                && let Some(value) = assign_known_values[net_idx.0]
+            if let [PinBitSource::Bit(bit_idx)] = pin_bit_sources.as_slice()
+                && let Some(value) = assign_known_values[*bit_idx]
             {
                 known_pin_values.insert(pin_name.clone(), value);
             }
-            pin_nets.insert(pin_name, connected_nets);
+            pin_sources.insert(pin_name, pin_bit_sources);
         }
-        instance_pin_nets.push(pin_nets);
+        instance_pin_sources.push(pin_sources);
         instance_known_pin_values.push(known_pin_values);
         instance_timing_related_input_pins.push(timing_related_input_pins);
     }
 
-    let mut module_output_nets: Vec<NetIndex> = Vec::new();
-    let mut has_module_output = vec![false; nets.len()];
-    let mut is_module_input = vec![false; nets.len()];
+    let mut module_output_bits: Vec<usize> = Vec::new();
+    let mut has_module_output = vec![false; bit_count];
+    let mut is_module_input = vec![false; bit_count];
     for port in &module.ports {
         let port_name = resolve_symbol(interner, port.name, "port name")
             .unwrap_or_else(|_| "<unknown>".to_string());
         match port.direction {
             PortDirection::Input => {
                 if let Some(net_idx) = module.find_net_index(port.name, nets) {
-                    is_module_input[net_idx.0] = true;
+                    for bit_idx in bit_index.net_bits(net_idx) {
+                        is_module_input[*bit_idx] = true;
+                    }
                 }
             }
             PortDirection::Output => {
-                if let Some(net_idx) = module.find_net_index(port.name, nets)
-                    && !has_module_output[net_idx.0]
-                {
-                    has_module_output[net_idx.0] = true;
-                    module_output_nets.push(net_idx);
+                if let Some(net_idx) = module.find_net_index(port.name, nets) {
+                    for bit_idx in bit_index.net_bits(net_idx) {
+                        if !has_module_output[*bit_idx] {
+                            has_module_output[*bit_idx] = true;
+                            module_output_bits.push(*bit_idx);
+                        }
+                    }
                 }
             }
             PortDirection::Inout => {
@@ -555,37 +618,52 @@ fn analyze_combinational_max_arrival_proto(
             }
         }
     }
-    module_output_nets.sort_by_key(|n| n.0);
+    module_output_bits.sort_unstable();
+
+    reject_live_unsupported_assigns(
+        assign_analysis.unsupported_sources.as_slice(),
+        assign_sources.as_slice(),
+        bit_loads.as_slice(),
+        has_module_output.as_slice(),
+        &bit_index,
+        nets,
+        interner,
+    )?;
 
     let mut successors: Vec<Vec<usize>> = vec![Vec::new(); instance_count];
     let mut indegree: Vec<usize> = vec![0; instance_count];
     let mut seen_edges: HashSet<(usize, usize)> = HashSet::new();
-    for (net_idx, drivers) in net_drivers.iter().enumerate() {
-        let has_assign_source = assign_sources[net_idx].is_some();
-        if is_module_input[net_idx] && (!drivers.is_empty() || has_assign_source) {
-            let net_name = net_name_for_index(nets, interner, NetIndex(net_idx));
+    for (bit_idx, drivers) in bit_drivers.iter().enumerate() {
+        let has_assign_source = assign_sources[bit_idx].is_some();
+        if is_module_input[bit_idx] && (!drivers.is_empty() || has_assign_source) {
+            let bit_name = bit_ref::render_net_bit(bit_index.bits[bit_idx], nets, interner);
             return Err(anyhow!(
-                "module input net '{}' also has an internal driver; basic STA does not support multiply driven primary inputs",
-                net_name
+                "module input bit '{}' also has an internal driver; basic STA does not support multiply driven primary inputs",
+                bit_name
             ));
         }
         if drivers.len() > 1 || (!drivers.is_empty() && has_assign_source) {
-            let net_name = net_name_for_index(nets, interner, NetIndex(net_idx));
+            let bit_name = bit_ref::render_net_bit(bit_index.bits[bit_idx], nets, interner);
             return Err(anyhow!(
-                "net '{}' has {} drivers; wired multi-driver nets are unsupported in basic STA",
-                net_name,
+                "net bit '{}' has {} drivers; wired multi-driver nets are unsupported in basic STA",
+                bit_name,
                 drivers.len() + usize::from(has_assign_source)
             ));
         }
     }
 
-    for (net_idx, loads) in net_loads.iter().enumerate() {
-        let ResolvedTimingSource::Net(source_net_idx) =
-            resolve_timing_source(assign_sources.as_slice(), NetIndex(net_idx), nets, interner)?
+    for (bit_idx, loads) in bit_loads.iter().enumerate() {
+        let ResolvedTimingSource::Bit(source_bit_idx) = resolve_timing_source(
+            assign_sources.as_slice(),
+            bit_idx,
+            &bit_index,
+            nets,
+            interner,
+        )?
         else {
             continue;
         };
-        let Some(driver) = net_drivers[source_net_idx.0].first() else {
+        let Some(driver) = bit_drivers[source_bit_idx].first() else {
             continue;
         };
         for load in loads {
@@ -602,10 +680,15 @@ fn analyze_combinational_max_arrival_proto(
         }
     }
 
-    let mut net_load_capacitance = vec![EdgeLoadCapacitance::default(); nets.len()];
-    for (net_idx, loads) in net_loads.iter().enumerate() {
-        let ResolvedTimingSource::Net(load_source_net_idx) =
-            resolve_timing_source(assign_sources.as_slice(), NetIndex(net_idx), nets, interner)?
+    let mut bit_load_capacitance = vec![EdgeLoadCapacitance::default(); bit_count];
+    for (bit_idx, loads) in bit_loads.iter().enumerate() {
+        let ResolvedTimingSource::Bit(load_source_bit_idx) = resolve_timing_source(
+            assign_sources.as_slice(),
+            bit_idx,
+            &bit_index,
+            nets,
+            interner,
+        )?
         else {
             continue;
         };
@@ -629,12 +712,12 @@ fn analyze_combinational_max_arrival_proto(
             cap.rise += pin_cap.rise;
             cap.fall += pin_cap.fall;
         }
-        if has_module_output[net_idx] {
+        if has_module_output[bit_idx] {
             cap.rise += options.module_output_load;
             cap.fall += options.module_output_load;
         }
-        net_load_capacitance[load_source_net_idx.0].rise += cap.rise;
-        net_load_capacitance[load_source_net_idx.0].fall += cap.fall;
+        bit_load_capacitance[load_source_bit_idx].rise += cap.rise;
+        bit_load_capacitance[load_source_bit_idx].fall += cap.fall;
     }
 
     let source_timing = SignalTiming {
@@ -658,36 +741,34 @@ fn analyze_combinational_max_arrival_proto(
             transition: 0.0,
         },
     });
-    let mut net_timing_sets: Vec<Option<SignalTimingSet>> = vec![None; nets.len()];
+    let mut bit_timing_sets: Vec<Option<SignalTimingSet>> = vec![None; bit_count];
 
-    for (net_idx, drivers) in net_drivers.iter().enumerate() {
+    for (bit_idx, drivers) in bit_drivers.iter().enumerate() {
         if !drivers.is_empty() {
             continue;
         }
-        if matches!(
-            assign_sources[net_idx],
-            Some(ScalarAssignSource::Literal(_))
-        ) {
-            net_timing_sets[net_idx] = Some(literal_source_timing_set.clone());
+        if matches!(assign_sources[bit_idx], Some(BitAssignSource::Literal(_))) {
+            bit_timing_sets[bit_idx] = Some(literal_source_timing_set.clone());
             continue;
         }
-        if matches!(assign_sources[net_idx], Some(ScalarAssignSource::Alias(_))) {
+        if matches!(assign_sources[bit_idx], Some(BitAssignSource::Alias(_))) {
             continue;
         }
-        if is_module_input[net_idx] {
-            net_timing_sets[net_idx] = Some(source_timing_set.clone());
+        if is_module_input[bit_idx] {
+            bit_timing_sets[bit_idx] = Some(source_timing_set.clone());
             continue;
         }
-        if !net_loads[net_idx].is_empty() || has_module_output[net_idx] {
+        if !bit_loads[bit_idx].is_empty() || has_module_output[bit_idx] {
             return Err(anyhow!(
-                "net '{}' is undriven and is not a module input; basic STA does not support floating source nets",
-                net_name_for_index(nets, interner, NetIndex(net_idx))
+                "net bit '{}' is undriven and is not a module input; basic STA does not support floating source nets",
+                bit_ref::render_net_bit(bit_index.bits[bit_idx], nets, interner)
             ));
         }
     }
     propagate_alias_timings(
         assign_sources.as_slice(),
-        &mut net_timing_sets,
+        &mut bit_timing_sets,
+        &bit_index,
         nets,
         interner,
     )?;
@@ -707,7 +788,7 @@ fn analyze_combinational_max_arrival_proto(
 
         let cell_idx = instance_cell_indices[inst_idx];
         let cell_name = &instance_cell_names[inst_idx];
-        let inst_pin_map = &instance_pin_nets[inst_idx];
+        let inst_pin_map = &instance_pin_sources[inst_idx];
         let known_pin_values = &instance_known_pin_values[inst_idx];
         let instance = &module.instances[inst_idx];
         let instance_name = resolve_symbol(interner, instance.instance_name, "instance name")
@@ -717,10 +798,10 @@ fn analyze_combinational_max_arrival_proto(
             if pin.direction != PinDirection::Output as i32 {
                 continue;
             }
-            let Some(output_nets) = inst_pin_map.get(pin.name.as_str()) else {
+            let Some(output_sources) = inst_pin_map.get(pin.name.as_str()) else {
                 continue;
             };
-            if output_nets.is_empty() {
+            if output_sources.is_empty() {
                 continue;
             }
             if let Some(unsupported_arc) = pin
@@ -756,9 +837,13 @@ fn analyze_combinational_max_arrival_proto(
                     pin.name
                 ));
             }
-            for output_net in output_nets {
-                let output_load = net_load_capacitance[output_net.0];
-                let output_net_name = net_name_for_index(nets, interner, *output_net);
+            for output_source in output_sources {
+                let PinBitSource::Bit(output_bit_idx) = *output_source else {
+                    continue;
+                };
+                let output_load = bit_load_capacitance[output_bit_idx];
+                let output_net_name =
+                    bit_ref::render_net_bit(bit_index.bits[output_bit_idx], nets, interner);
                 let mut accumulated: Option<SignalTimingSet> = None;
 
                 for arc in &combinational_arcs {
@@ -776,7 +861,7 @@ fn analyze_combinational_max_arrival_proto(
                         continue;
                     }
                     for related_pin_name in split_related_pin_names(arc.related_pin.as_str()) {
-                        let related_nets =
+                        let related_sources =
                             inst_pin_map.get(related_pin_name).ok_or_else(|| {
                                 anyhow!(
                                     "instance '{}' output pin '{}.{}' requires timing-related input pin '{}' to be connected",
@@ -786,7 +871,7 @@ fn analyze_combinational_max_arrival_proto(
                                     related_pin_name
                                 )
                             })?;
-                        if related_nets.is_empty() {
+                        if related_sources.is_empty() {
                             return Err(anyhow!(
                                 "instance '{}' output pin '{}.{}' has unconnected timing-related input pin '{}'",
                                 instance_name,
@@ -795,17 +880,38 @@ fn analyze_combinational_max_arrival_proto(
                                 related_pin_name
                             ));
                         }
-                        for related_net in related_nets {
-                            let input_timing_set = net_timing_sets[related_net.0].as_ref().ok_or_else(|| {
-                            anyhow!(
-                                "missing source timing for net '{}' feeding '{}.{}' (related pin '{}')",
-                                net_name_for_index(nets, interner, *related_net),
-                                cell_name,
-                                pin.name,
-                                related_pin_name
-                            )
-                        })?;
-                            let related_net_name = net_name_for_index(nets, interner, *related_net);
+                        for related_source in related_sources {
+                            let (input_timing_set, related_net_name) = match related_source {
+                                PinBitSource::Bit(related_bit_idx) => {
+                                    let timing = bit_timing_sets[*related_bit_idx]
+                                        .as_ref()
+                                        .ok_or_else(|| {
+                                            anyhow!(
+                                                "missing source timing for net bit '{}' feeding '{}.{}' (related pin '{}')",
+                                                bit_ref::render_net_bit(
+                                                    bit_index.bits[*related_bit_idx],
+                                                    nets,
+                                                    interner
+                                                ),
+                                                cell_name,
+                                                pin.name,
+                                                related_pin_name
+                                            )
+                                        })?;
+                                    (
+                                        timing,
+                                        bit_ref::render_net_bit(
+                                            bit_index.bits[*related_bit_idx],
+                                            nets,
+                                            interner,
+                                        ),
+                                    )
+                                }
+                                PinBitSource::Literal(value) => (
+                                    &literal_source_timing_set,
+                                    if *value { "1'b1" } else { "1'b0" }.to_string(),
+                                ),
+                            };
                             let context = format!(
                                 "{}.{} (instance '{}') related_pin '{}'",
                                 cell_name, pin.name, instance_name, related_pin_name
@@ -872,8 +978,8 @@ fn analyze_combinational_max_arrival_proto(
                     )
                 });
 
-                net_timing_sets[output_net.0] =
-                    Some(match net_timing_sets[output_net.0].as_ref() {
+                bit_timing_sets[output_bit_idx] =
+                    Some(match bit_timing_sets[output_bit_idx].as_ref() {
                         Some(prev) => prev.clone().merge(&out_timing_set),
                         None => out_timing_set,
                     });
@@ -889,7 +995,8 @@ fn analyze_combinational_max_arrival_proto(
         }
         propagate_alias_timings(
             assign_sources.as_slice(),
-            &mut net_timing_sets,
+            &mut bit_timing_sets,
+            &bit_index,
             nets,
             interner,
         )?;
@@ -905,17 +1012,17 @@ fn analyze_combinational_max_arrival_proto(
 
     let mut worst_output_arrival: Option<f64> = None;
     let mut cell_levels = 0usize;
-    for net_idx in &module_output_nets {
-        let timing_set = net_timing_sets[net_idx.0].as_ref().ok_or_else(|| {
+    for bit_idx in &module_output_bits {
+        let timing_set = bit_timing_sets[*bit_idx].as_ref().ok_or_else(|| {
             anyhow!(
-                "missing timing result for module output net '{}'",
-                net_name_for_index(nets, interner, *net_idx)
+                "missing timing result for module output net bit '{}'",
+                bit_ref::render_net_bit(bit_index.bits[*bit_idx], nets, interner)
             )
         })?;
         let output_arrival = timing_set.worst_arrival().ok_or_else(|| {
             anyhow!(
-                "missing edge timing candidates for module output net '{}'",
-                net_name_for_index(nets, interner, *net_idx)
+                "missing edge timing candidates for module output net bit '{}'",
+                bit_ref::render_net_bit(bit_index.bits[*bit_idx], nets, interner)
             )
         })?;
         worst_output_arrival = Some(
@@ -923,19 +1030,21 @@ fn analyze_combinational_max_arrival_proto(
                 .map(|current| current.max(output_arrival))
                 .unwrap_or(output_arrival),
         );
-        if let ResolvedTimingSource::Net(source_net_idx) =
-            resolve_timing_source(assign_sources.as_slice(), *net_idx, nets, interner)?
-        {
-            if let Some(driver) = net_drivers[source_net_idx.0].first() {
+        if let ResolvedTimingSource::Bit(source_bit_idx) = resolve_timing_source(
+            assign_sources.as_slice(),
+            *bit_idx,
+            &bit_index,
+            nets,
+            interner,
+        )? {
+            if let Some(driver) = bit_drivers[source_bit_idx].first() {
                 cell_levels = cell_levels.max(instance_levels[driver.inst_idx]);
             }
         }
     }
 
-    let net_timing: Vec<Option<SignalTiming>> = net_timing_sets
-        .into_iter()
-        .map(|timing_set| timing_set.and_then(|set| set.as_report_signal_timing()))
-        .collect();
+    let net_timing =
+        aggregate_bit_timing_by_net(bit_timing_sets.as_slice(), &bit_index, nets.len());
 
     Ok(StaReport {
         net_timing,
@@ -1219,181 +1328,210 @@ pub fn validate_output_pin_for_basic_sta(
     Ok(())
 }
 
-fn net_width_is_multibit(width: Option<(u32, u32)>) -> bool {
-    matches!(width, Some((msb, lsb)) if msb != lsb)
-}
-
-/// Returns scalar nets driven by supported zero-delay continuous assigns.
-fn scalar_assign_sources(
+/// Classifies continuous assigns into live-STA-supported bit sources and
+/// unsupported sources that may still be harmless if they are unused.
+fn analyze_assign_sources(
     module: &NetlistModule,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
-) -> Result<Vec<Option<ScalarAssignSource>>> {
-    let mut sources = vec![None; nets.len()];
+    bit_index: &StaBitIndex,
+) -> Result<AssignSourceAnalysis> {
+    let mut sources = vec![None; bit_index.bits.len()];
+    let mut unsupported_sources = Vec::new();
     for assign in &module.assigns {
-        let source = match &assign.rhs {
-            AssignExpr::Leaf(NetRef::Literal(bits)) => {
-                ScalarAssignSource::Literal(scalar_literal_bits_value(
-                    bits,
-                    &format!(
-                        "assign to '{}'",
-                        render_assign_lhs(&assign.lhs, nets, interner)
-                    ),
-                )?)
+        let lhs_targets = bit_ref::net_ref_lsb_targets(&assign.lhs, nets, interner)?;
+        let lhs_bits: Vec<usize> = lhs_targets
+            .iter()
+            .copied()
+            .map(|bit| bit_index.bit_index(bit))
+            .collect::<Result<Vec<_>>>()?;
+        if let Some(rhs_sources) =
+            supported_assign_bit_sources(&assign.rhs, lhs_bits.len(), nets, interner)?
+        {
+            if rhs_sources.len() != lhs_bits.len() {
+                unsupported_sources.push(UnsupportedAssignSource {
+                    lhs_bits,
+                    rendered_lhs: bit_ref::render_net_ref(&assign.lhs, nets, interner),
+                });
+                continue;
             }
-            AssignExpr::Leaf(rhs) => {
-                ScalarAssignSource::Alias(scalar_assign_leaf_net_index(rhs, nets, interner)?)
+            for (lhs_bit_idx, rhs_source) in lhs_bits.into_iter().zip(rhs_sources) {
+                if sources[lhs_bit_idx].is_some() {
+                    let bit_name =
+                        bit_ref::render_net_bit(bit_index.bits[lhs_bit_idx], nets, interner);
+                    return Err(anyhow!(
+                        "net bit '{}' has multiple continuous assign drivers; wired multi-driver nets are unsupported in basic STA",
+                        bit_name
+                    ));
+                }
+                sources[lhs_bit_idx] = Some(match rhs_source {
+                    bit_ref::NetBitRef::Literal(value) => BitAssignSource::Literal(value),
+                    bit_ref::NetBitRef::Net(bit) => {
+                        BitAssignSource::Alias(bit_index.bit_index(bit)?)
+                    }
+                });
             }
-            AssignExpr::Not(_)
-            | AssignExpr::And(_, _)
-            | AssignExpr::Or(_, _)
-            | AssignExpr::Xor(_, _) => {
-                return Err(anyhow!(
-                    "basic STA only supports scalar literal or alias continuous assigns; unsupported assign to '{}'",
-                    render_assign_lhs(&assign.lhs, nets, interner)
+        } else {
+            unsupported_sources.push(UnsupportedAssignSource {
+                lhs_bits,
+                rendered_lhs: bit_ref::render_net_ref(&assign.lhs, nets, interner),
+            });
+        }
+    }
+    Ok(AssignSourceAnalysis {
+        bit_sources: sources,
+        unsupported_sources,
+    })
+}
+
+/// Returns supported zero-delay assign bit sources, or `None` for unsupported
+/// expression shapes.
+fn supported_assign_bit_sources(
+    rhs: &AssignExpr,
+    lhs_width: usize,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> Result<Option<Vec<bit_ref::NetBitRef>>> {
+    match rhs {
+        AssignExpr::Leaf(NetRef::Literal(bits)) => {
+            let mut out = Vec::with_capacity(lhs_width);
+            for bit_idx in 0..lhs_width {
+                out.push(bit_ref::NetBitRef::Literal(
+                    bits.get_bit(bit_idx).unwrap_or(false),
                 ));
             }
-        };
-        let net_idx = scalar_assign_lhs_net_index(&assign.lhs, nets, interner)?;
-        if sources[net_idx.0].is_some() {
-            return Err(anyhow!(
-                "net '{}' has multiple continuous assign drivers; wired multi-driver nets are unsupported in basic STA",
-                net_name_for_index(nets, interner, net_idx)
-            ));
+            Ok(Some(out))
         }
-        sources[net_idx.0] = Some(source);
+        AssignExpr::Leaf(net_ref) => {
+            let refs = bit_ref::net_ref_lsb_bit_refs(net_ref, nets, interner)?;
+            if refs.len() == lhs_width {
+                Ok(Some(refs))
+            } else {
+                Ok(None)
+            }
+        }
+        AssignExpr::Not(_)
+        | AssignExpr::And(_, _)
+        | AssignExpr::Or(_, _)
+        | AssignExpr::Xor(_, _) => Ok(None),
     }
-    Ok(sources)
 }
 
-/// Returns the scalar net targeted by a supported continuous assign lhs.
-fn scalar_assign_lhs_net_index(
-    lhs: &NetRef,
+/// Rejects unsupported continuous assigns only when they drive timing-live
+/// bits.
+fn reject_live_unsupported_assigns(
+    unsupported_sources: &[UnsupportedAssignSource],
+    assign_sources: &[Option<BitAssignSource>],
+    bit_loads: &[Vec<NetEndpoint>],
+    has_module_output: &[bool],
+    bit_index: &StaBitIndex,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
-) -> Result<NetIndex> {
-    let net_idx = match lhs {
-        NetRef::Simple(net_idx) => *net_idx,
-        NetRef::BitSelect(_, _)
-        | NetRef::PartSelect(_, _, _)
-        | NetRef::Literal(_)
-        | NetRef::Unconnected
-        | NetRef::Concat(_) => {
+) -> Result<()> {
+    if unsupported_sources.is_empty() {
+        return Ok(());
+    }
+    let mut live = vec![false; bit_index.bits.len()];
+    for bit_idx in 0..bit_index.bits.len() {
+        live[bit_idx] = !bit_loads[bit_idx].is_empty() || has_module_output[bit_idx];
+    }
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (bit_idx, source) in assign_sources.iter().enumerate() {
+            if !live[bit_idx] {
+                continue;
+            }
+            let Some(BitAssignSource::Alias(source_bit_idx)) = source else {
+                continue;
+            };
+            if !live[*source_bit_idx] {
+                live[*source_bit_idx] = true;
+                changed = true;
+            }
+        }
+    }
+    for unsupported in unsupported_sources {
+        if unsupported.lhs_bits.iter().any(|bit_idx| live[*bit_idx]) {
+            let live_names: Vec<String> = unsupported
+                .lhs_bits
+                .iter()
+                .filter(|bit_idx| live[**bit_idx])
+                .map(|bit_idx| bit_ref::render_net_bit(bit_index.bits[*bit_idx], nets, interner))
+                .collect();
             return Err(anyhow!(
-                "basic STA only supports scalar-net continuous assigns; unsupported assign lhs '{}'",
-                render_assign_lhs(lhs, nets, interner)
+                "basic STA only supports literal, alias, slice, or concat continuous assigns for live bits; unsupported assign to '{}' drives live bit(s): {}",
+                unsupported.rendered_lhs,
+                live_names.join(", ")
             ));
         }
-    };
-    if net_idx.0 >= nets.len() {
-        return Err(anyhow!(
-            "continuous assign references out-of-range lhs net index {}",
-            net_idx.0
-        ));
     }
-    if net_width_is_multibit(nets[net_idx.0].width) {
-        return Err(anyhow!(
-            "basic STA only supports scalar-net continuous assigns; net '{}' is multi-bit",
-            net_name_for_index(nets, interner, net_idx)
-        ));
-    }
-    Ok(net_idx)
-}
-
-/// Returns the scalar source net referenced by a supported alias RHS.
-fn scalar_assign_leaf_net_index(
-    rhs: &NetRef,
-    nets: &[Net],
-    interner: &StringInterner<StringBackend<SymbolU32>>,
-) -> Result<NetIndex> {
-    let net_idx = match rhs {
-        NetRef::Simple(net_idx) => *net_idx,
-        NetRef::BitSelect(_, _)
-        | NetRef::PartSelect(_, _, _)
-        | NetRef::Literal(_)
-        | NetRef::Unconnected
-        | NetRef::Concat(_) => {
-            return Err(anyhow!(
-                "basic STA only supports scalar-net alias continuous assigns; unsupported assign rhs '{}'",
-                render_assign_lhs(rhs, nets, interner)
-            ));
-        }
-    };
-    if net_idx.0 >= nets.len() {
-        return Err(anyhow!(
-            "alias continuous assign references out-of-range net index {}",
-            net_idx.0
-        ));
-    }
-    if net_width_is_multibit(nets[net_idx.0].width) {
-        return Err(anyhow!(
-            "basic STA only supports scalar-net alias continuous assigns; net '{}' is multi-bit",
-            net_name_for_index(nets, interner, net_idx)
-        ));
-    }
-    Ok(net_idx)
+    Ok(())
 }
 
 fn resolve_timing_source(
-    assign_sources: &[Option<ScalarAssignSource>],
-    start: NetIndex,
+    assign_sources: &[Option<BitAssignSource>],
+    start: usize,
+    bit_index: &StaBitIndex,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
 ) -> Result<ResolvedTimingSource> {
     let mut current = start;
     let mut seen = HashSet::new();
     loop {
-        if !seen.insert(current.0) {
+        if !seen.insert(current) {
             return Err(anyhow!(
-                "continuous assign aliases contain a cycle involving net '{}'",
-                net_name_for_index(nets, interner, current)
+                "continuous assign aliases contain a cycle involving net bit '{}'",
+                bit_ref::render_net_bit(bit_index.bits[current], nets, interner)
             ));
         }
-        let Some(source) = assign_sources.get(current.0).and_then(|source| *source) else {
-            return Ok(ResolvedTimingSource::Net(current));
+        let Some(source) = assign_sources.get(current).and_then(|source| *source) else {
+            return Ok(ResolvedTimingSource::Bit(current));
         };
         match source {
-            ScalarAssignSource::Literal(value) => return Ok(ResolvedTimingSource::Literal(value)),
-            ScalarAssignSource::Alias(next) => current = next,
+            BitAssignSource::Literal(value) => return Ok(ResolvedTimingSource::Literal(value)),
+            BitAssignSource::Alias(next) => current = next,
         }
     }
 }
 
 fn assign_known_values(
-    assign_sources: &[Option<ScalarAssignSource>],
+    assign_sources: &[Option<BitAssignSource>],
+    bit_index: &StaBitIndex,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
 ) -> Result<Vec<Option<bool>>> {
-    let mut values = vec![None; nets.len()];
-    for net_idx in 0..nets.len() {
+    let mut values = vec![None; bit_index.bits.len()];
+    for bit_idx in 0..bit_index.bits.len() {
         if let ResolvedTimingSource::Literal(value) =
-            resolve_timing_source(assign_sources, NetIndex(net_idx), nets, interner)?
+            resolve_timing_source(assign_sources, bit_idx, bit_index, nets, interner)?
         {
-            values[net_idx] = Some(value);
+            values[bit_idx] = Some(value);
         }
     }
     Ok(values)
 }
 
 fn propagate_alias_timings(
-    assign_sources: &[Option<ScalarAssignSource>],
-    net_timing_sets: &mut [Option<SignalTimingSet>],
+    assign_sources: &[Option<BitAssignSource>],
+    bit_timing_sets: &mut [Option<SignalTimingSet>],
+    bit_index: &StaBitIndex,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
 ) -> Result<()> {
     let mut changed = true;
     while changed {
         changed = false;
-        for net_idx in 0..assign_sources.len() {
-            let Some(ScalarAssignSource::Alias(source_net_idx)) = assign_sources[net_idx] else {
+        for bit_idx in 0..assign_sources.len() {
+            let Some(BitAssignSource::Alias(source_bit_idx)) = assign_sources[bit_idx] else {
                 continue;
             };
-            resolve_timing_source(assign_sources, NetIndex(net_idx), nets, interner)?;
-            let Some(source_timing) = net_timing_sets[source_net_idx.0].clone() else {
+            resolve_timing_source(assign_sources, bit_idx, bit_index, nets, interner)?;
+            let Some(source_timing) = bit_timing_sets[source_bit_idx].clone() else {
                 continue;
             };
-            if net_timing_sets[net_idx] != Some(source_timing.clone()) {
-                net_timing_sets[net_idx] = Some(source_timing);
+            if bit_timing_sets[bit_idx] != Some(source_timing.clone()) {
+                bit_timing_sets[bit_idx] = Some(source_timing);
                 changed = true;
             }
         }
@@ -1401,47 +1539,26 @@ fn propagate_alias_timings(
     Ok(())
 }
 
-fn render_assign_lhs(
-    lhs: &NetRef,
-    nets: &[Net],
-    interner: &StringInterner<StringBackend<SymbolU32>>,
-) -> String {
-    match lhs {
-        NetRef::Simple(net_idx) => net_name_for_index(nets, interner, *net_idx),
-        NetRef::BitSelect(net_idx, bit) => {
-            format!("{}[{}]", net_name_for_index(nets, interner, *net_idx), bit)
-        }
-        NetRef::PartSelect(net_idx, msb, lsb) => format!(
-            "{}[{}:{}]",
-            net_name_for_index(nets, interner, *net_idx),
-            msb,
-            lsb
-        ),
-        NetRef::Literal(bits) => bits.to_string(),
-        NetRef::Unconnected => "<unconnected>".to_string(),
-        NetRef::Concat(_) => "<concat>".to_string(),
+fn aggregate_bit_timing_by_net(
+    bit_timing_sets: &[Option<SignalTimingSet>],
+    bit_index: &StaBitIndex,
+    nets_len: usize,
+) -> Vec<Option<SignalTiming>> {
+    let mut aggregate_sets: Vec<Option<SignalTimingSet>> = vec![None; nets_len];
+    for (bit_idx, timing_set) in bit_timing_sets.iter().enumerate() {
+        let Some(timing_set) = timing_set else {
+            continue;
+        };
+        let net_idx = bit_index.bits[bit_idx].net.0;
+        aggregate_sets[net_idx] = Some(match aggregate_sets[net_idx].take() {
+            Some(prev) => prev.merge(timing_set),
+            None => timing_set.clone(),
+        });
     }
-}
-
-fn scalar_literal_bits_value(bits: &xlsynth::IrBits, context: &str) -> Result<bool> {
-    if bits.get_bit_count() != 1 {
-        return Err(anyhow!(
-            "{context}: basic STA only supports 1-bit scalar literals; got {} bits",
-            bits.get_bit_count()
-        ));
-    }
-    bits.get_bit(0)
-        .map_err(|e| anyhow!("{context}: could not read scalar literal bit: {e}"))
-}
-
-fn scalar_literal_netref_value(netref: &NetRef) -> Option<bool> {
-    let NetRef::Literal(bits) = netref else {
-        return None;
-    };
-    if bits.get_bit_count() != 1 {
-        return None;
-    }
-    bits.get_bit(0).ok()
+    aggregate_sets
+        .into_iter()
+        .map(|timing_set| timing_set.and_then(|set| set.as_report_signal_timing()))
+        .collect()
 }
 
 fn arc_when_may_apply(
@@ -2105,17 +2222,6 @@ fn resolve_symbol(
         .ok_or_else(|| anyhow!("could not resolve {} symbol {:?}", what, sym))
 }
 
-fn net_name_for_index(
-    nets: &[Net],
-    interner: &StringInterner<StringBackend<SymbolU32>>,
-    net_idx: NetIndex,
-) -> String {
-    nets.get(net_idx.0)
-        .and_then(|n| interner.resolve(n.name))
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| format!("<net:{}>", net_idx.0))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2353,8 +2459,90 @@ endmodule
         assert!(
             error
                 .to_string()
-                .contains("scalar literal or alias continuous assigns")
+                .contains("unsupported assign to 'y' drives live bit")
         );
+    }
+
+    #[test]
+    fn sta_ignores_unused_concat_continuous_assigns() {
+        let src = r#"
+module top (a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  wire n;
+  wire [1:0] unused;
+  INV u0 (.A(a), .Y(n));
+  INV u1 (.A(n), .Y(y));
+  assign unused = {1'b0, a};
+endmodule
+"#;
+        let (module, nets, interner) = parse_single_module(src);
+        let report = analyze_combinational_max_arrival_proto(
+            &module,
+            &nets,
+            &interner,
+            &scalar_inv_library(),
+            StaOptions::default(),
+        )
+        .expect("unused concat assign should not affect scalar STA");
+        assert_close(report.worst_output_arrival, 5.0);
+        assert_eq!(report.cell_levels, 2);
+    }
+
+    #[test]
+    fn sta_accepts_live_concat_continuous_assigns() {
+        let src = r#"
+module top (a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  wire live;
+  assign live = {a};
+  INV u0 (.A(live), .Y(y));
+endmodule
+"#;
+        let (module, nets, interner) = parse_single_module(src);
+        let report = analyze_combinational_max_arrival_proto(
+            &module,
+            &nets,
+            &interner,
+            &scalar_inv_library(),
+            StaOptions::default(),
+        )
+        .expect("live concat assign should be modeled as bit wiring");
+        assert_close(report.worst_output_arrival, 3.0);
+        assert_eq!(report.cell_levels, 1);
+    }
+
+    #[test]
+    fn sta_accepts_live_concat_through_alias_assigns() {
+        let src = r#"
+module top (a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  wire live_source;
+  wire live_alias;
+  assign live_source = {a};
+  assign live_alias = live_source;
+  INV u0 (.A(live_alias), .Y(y));
+endmodule
+"#;
+        let (module, nets, interner) = parse_single_module(src);
+        let report = analyze_combinational_max_arrival_proto(
+            &module,
+            &nets,
+            &interner,
+            &scalar_inv_library(),
+            StaOptions::default(),
+        )
+        .expect("live concat assign should be modeled through aliases");
+        assert_close(report.worst_output_arrival, 3.0);
+        assert_eq!(report.cell_levels, 1);
     }
 
     #[test]
@@ -2452,7 +2640,7 @@ endmodule
     }
 
     #[test]
-    fn sta_rejects_vector_pin_connectivity_until_bit_level_timing_is_supported() {
+    fn sta_accepts_vector_bit_select_connectivity() {
         let src = r#"
 module top (a, y);
   input [1:0] a;
@@ -2464,15 +2652,16 @@ module top (a, y);
 endmodule
 "#;
         let (module, nets, interner) = parse_single_module(src);
-        let error = analyze_combinational_max_arrival_proto(
+        let report = analyze_combinational_max_arrival_proto(
             &module,
             &nets,
             &interner,
             &scalar_inv_library(),
             StaOptions::default(),
         )
-        .expect_err("vector pin connectivity should be rejected");
-        assert!(error.to_string().contains("vector connectivity"));
+        .expect("bit-select connectivity should be accepted");
+        assert_close(report.worst_output_arrival, 3.0);
+        assert_eq!(report.cell_levels, 1);
     }
 
     #[test]
@@ -2495,7 +2684,7 @@ endmodule
             StaOptions::default(),
         )
         .expect_err("whole-vector simple connectivity should be rejected");
-        assert!(error.to_string().contains("vector connectivity"));
+        assert!(error.to_string().contains("connects 2 bits"));
     }
 
     #[test]
@@ -2623,7 +2812,7 @@ endmodule
     }
 
     #[test]
-    fn sta_rejects_literal_tied_timing_inputs() {
+    fn sta_accepts_literal_tied_timing_inputs() {
         let src = r#"
 module top (a, y);
   input a;
@@ -2685,19 +2874,15 @@ endmodule
             ..Default::default()
         };
 
-        let error = analyze_combinational_max_arrival_proto(
+        let report = analyze_combinational_max_arrival_proto(
             &module,
             &nets,
             &interner,
             &lib,
             StaOptions::default(),
         )
-        .expect_err("literal-tied timing inputs should be rejected");
-        assert!(
-            error
-                .to_string()
-                .contains("does not model constant-tied timing inputs")
-        );
+        .expect("literal-tied timing inputs should use a zero-transition literal source");
+        assert_close(report.worst_output_arrival, 5.0);
     }
 
     #[test]

--- a/xlsynth-g8r/src/netlist/sta.rs
+++ b/xlsynth-g8r/src/netlist/sta.rs
@@ -19,9 +19,10 @@
 //!   frontier reduction relies on larger transition/load queries not producing
 //!   smaller delay/slew values. Small decreases within the
 //!   characterization-noise tolerance are treated as effectively equal.
-//! - Accepts scalar bare-literal continuous assigns as zero-delay tie-offs so
-//!   mapped netlists emitted by tools such as ABC can preserve constant outputs
-//!   without needing synthetic tie cells.
+//! - Accepts scalar bare-literal and scalar alias continuous assigns as
+//!   zero-delay sources so mapped netlists emitted by tools such as ABC can
+//!   preserve constant outputs and wire aliases without needing synthetic
+//!   cells.
 //!
 //! At a high level, the analysis is:
 //! 1. Index each instance's cell/pin connectivity, recording one driver and all
@@ -296,6 +297,18 @@ struct NetEndpoint {
     pin_name: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScalarAssignSource {
+    Literal(bool),
+    Alias(NetIndex),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResolvedTimingSource {
+    Literal(bool),
+    Net(NetIndex),
+}
+
 pub fn analyze_combinational_max_arrival(
     module: &NetlistModule,
     nets: &[Net],
@@ -340,7 +353,8 @@ fn analyze_combinational_max_arrival_proto(
 
     let lib = StaLibraryIndex::new(library)?;
     let instance_count = module.instances.len();
-    let literal_source_values = scalar_literal_assign_sources(module, nets, interner)?;
+    let assign_sources = scalar_assign_sources(module, nets, interner)?;
+    let assign_known_values = assign_known_values(assign_sources.as_slice(), nets, interner)?;
 
     let mut instance_cell_indices: Vec<usize> = Vec::with_capacity(instance_count);
     let mut instance_cell_names: Vec<String> = Vec::with_capacity(instance_count);
@@ -502,7 +516,7 @@ fn analyze_combinational_max_arrival_proto(
                 }
             }
             if let Some(net_idx) = connected_nets.first()
-                && let Some(value) = literal_source_values[net_idx.0]
+                && let Some(value) = assign_known_values[net_idx.0]
             {
                 known_pin_values.insert(pin_name.clone(), value);
             }
@@ -547,27 +561,34 @@ fn analyze_combinational_max_arrival_proto(
     let mut indegree: Vec<usize> = vec![0; instance_count];
     let mut seen_edges: HashSet<(usize, usize)> = HashSet::new();
     for (net_idx, drivers) in net_drivers.iter().enumerate() {
-        if is_module_input[net_idx]
-            && (!drivers.is_empty() || literal_source_values[net_idx].is_some())
-        {
+        let has_assign_source = assign_sources[net_idx].is_some();
+        if is_module_input[net_idx] && (!drivers.is_empty() || has_assign_source) {
             let net_name = net_name_for_index(nets, interner, NetIndex(net_idx));
             return Err(anyhow!(
                 "module input net '{}' also has an internal driver; basic STA does not support multiply driven primary inputs",
                 net_name
             ));
         }
-        if drivers.len() > 1 || (!drivers.is_empty() && literal_source_values[net_idx].is_some()) {
+        if drivers.len() > 1 || (!drivers.is_empty() && has_assign_source) {
             let net_name = net_name_for_index(nets, interner, NetIndex(net_idx));
             return Err(anyhow!(
                 "net '{}' has {} drivers; wired multi-driver nets are unsupported in basic STA",
                 net_name,
-                drivers.len() + usize::from(literal_source_values[net_idx].is_some())
+                drivers.len() + usize::from(has_assign_source)
             ));
         }
-        let Some(driver) = drivers.first() else {
+    }
+
+    for (net_idx, loads) in net_loads.iter().enumerate() {
+        let ResolvedTimingSource::Net(source_net_idx) =
+            resolve_timing_source(assign_sources.as_slice(), NetIndex(net_idx), nets, interner)?
+        else {
             continue;
         };
-        for load in &net_loads[net_idx] {
+        let Some(driver) = net_drivers[source_net_idx.0].first() else {
+            continue;
+        };
+        for load in loads {
             if !instance_timing_related_input_pins[load.inst_idx].contains(&load.pin_name) {
                 continue;
             }
@@ -583,6 +604,11 @@ fn analyze_combinational_max_arrival_proto(
 
     let mut net_load_capacitance = vec![EdgeLoadCapacitance::default(); nets.len()];
     for (net_idx, loads) in net_loads.iter().enumerate() {
+        let ResolvedTimingSource::Net(load_source_net_idx) =
+            resolve_timing_source(assign_sources.as_slice(), NetIndex(net_idx), nets, interner)?
+        else {
+            continue;
+        };
         let mut cap = EdgeLoadCapacitance::default();
         for load in loads {
             let cell_idx = instance_cell_indices[load.inst_idx];
@@ -607,7 +633,8 @@ fn analyze_combinational_max_arrival_proto(
             cap.rise += options.module_output_load;
             cap.fall += options.module_output_load;
         }
-        net_load_capacitance[net_idx] = cap;
+        net_load_capacitance[load_source_net_idx.0].rise += cap.rise;
+        net_load_capacitance[load_source_net_idx.0].fall += cap.fall;
     }
 
     let source_timing = SignalTiming {
@@ -637,8 +664,14 @@ fn analyze_combinational_max_arrival_proto(
         if !drivers.is_empty() {
             continue;
         }
-        if literal_source_values[net_idx].is_some() {
+        if matches!(
+            assign_sources[net_idx],
+            Some(ScalarAssignSource::Literal(_))
+        ) {
             net_timing_sets[net_idx] = Some(literal_source_timing_set.clone());
+            continue;
+        }
+        if matches!(assign_sources[net_idx], Some(ScalarAssignSource::Alias(_))) {
             continue;
         }
         if is_module_input[net_idx] {
@@ -652,6 +685,12 @@ fn analyze_combinational_max_arrival_proto(
             ));
         }
     }
+    propagate_alias_timings(
+        assign_sources.as_slice(),
+        &mut net_timing_sets,
+        nets,
+        interner,
+    )?;
 
     let mut queue = VecDeque::new();
     let mut instance_levels = vec![1usize; instance_count];
@@ -848,6 +887,12 @@ fn analyze_combinational_max_arrival_proto(
                 queue.push_back(*succ);
             }
         }
+        propagate_alias_timings(
+            assign_sources.as_slice(),
+            &mut net_timing_sets,
+            nets,
+            interner,
+        )?;
     }
 
     if processed != instance_count {
@@ -878,8 +923,12 @@ fn analyze_combinational_max_arrival_proto(
                 .map(|current| current.max(output_arrival))
                 .unwrap_or(output_arrival),
         );
-        if let Some(driver) = net_drivers[net_idx.0].first() {
-            cell_levels = cell_levels.max(instance_levels[driver.inst_idx]);
+        if let ResolvedTimingSource::Net(source_net_idx) =
+            resolve_timing_source(assign_sources.as_slice(), *net_idx, nets, interner)?
+        {
+            if let Some(driver) = net_drivers[source_net_idx.0].first() {
+                cell_levels = cell_levels.max(instance_levels[driver.inst_idx]);
+            }
         }
     }
 
@@ -1174,39 +1223,50 @@ fn net_width_is_multibit(width: Option<(u32, u32)>) -> bool {
     matches!(width, Some((msb, lsb)) if msb != lsb)
 }
 
-/// Returns scalar nets driven by bare-literal continuous assigns.
-fn scalar_literal_assign_sources(
+/// Returns scalar nets driven by supported zero-delay continuous assigns.
+fn scalar_assign_sources(
     module: &NetlistModule,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
-) -> Result<Vec<Option<bool>>> {
-    let mut literal_source_values = vec![None; nets.len()];
+) -> Result<Vec<Option<ScalarAssignSource>>> {
+    let mut sources = vec![None; nets.len()];
     for assign in &module.assigns {
-        let AssignExpr::Leaf(NetRef::Literal(bits)) = &assign.rhs else {
-            return Err(anyhow!(
-                "basic STA only supports bare-literal continuous assigns; unsupported assign to '{}'",
-                render_assign_lhs(&assign.lhs, nets, interner)
-            ));
+        let source = match &assign.rhs {
+            AssignExpr::Leaf(NetRef::Literal(bits)) => {
+                ScalarAssignSource::Literal(scalar_literal_bits_value(
+                    bits,
+                    &format!(
+                        "assign to '{}'",
+                        render_assign_lhs(&assign.lhs, nets, interner)
+                    ),
+                )?)
+            }
+            AssignExpr::Leaf(rhs) => {
+                ScalarAssignSource::Alias(scalar_assign_leaf_net_index(rhs, nets, interner)?)
+            }
+            AssignExpr::Not(_)
+            | AssignExpr::And(_, _)
+            | AssignExpr::Or(_, _)
+            | AssignExpr::Xor(_, _) => {
+                return Err(anyhow!(
+                    "basic STA only supports scalar literal or alias continuous assigns; unsupported assign to '{}'",
+                    render_assign_lhs(&assign.lhs, nets, interner)
+                ));
+            }
         };
         let net_idx = scalar_assign_lhs_net_index(&assign.lhs, nets, interner)?;
-        if literal_source_values[net_idx.0].is_some() {
+        if sources[net_idx.0].is_some() {
             return Err(anyhow!(
-                "net '{}' has multiple bare-literal continuous assigns; wired multi-driver nets are unsupported in basic STA",
+                "net '{}' has multiple continuous assign drivers; wired multi-driver nets are unsupported in basic STA",
                 net_name_for_index(nets, interner, net_idx)
             ));
         }
-        literal_source_values[net_idx.0] = Some(scalar_literal_bits_value(
-            bits,
-            &format!(
-                "assign to '{}'",
-                net_name_for_index(nets, interner, net_idx)
-            ),
-        )?);
+        sources[net_idx.0] = Some(source);
     }
-    Ok(literal_source_values)
+    Ok(sources)
 }
 
-/// Returns the scalar net targeted by a supported bare-literal assign lhs.
+/// Returns the scalar net targeted by a supported continuous assign lhs.
 fn scalar_assign_lhs_net_index(
     lhs: &NetRef,
     nets: &[Net],
@@ -1220,24 +1280,125 @@ fn scalar_assign_lhs_net_index(
         | NetRef::Unconnected
         | NetRef::Concat(_) => {
             return Err(anyhow!(
-                "basic STA only supports scalar-net bare-literal continuous assigns; unsupported assign lhs '{}'",
+                "basic STA only supports scalar-net continuous assigns; unsupported assign lhs '{}'",
                 render_assign_lhs(lhs, nets, interner)
             ));
         }
     };
     if net_idx.0 >= nets.len() {
         return Err(anyhow!(
-            "bare-literal continuous assign references out-of-range net index {}",
+            "continuous assign references out-of-range lhs net index {}",
             net_idx.0
         ));
     }
     if net_width_is_multibit(nets[net_idx.0].width) {
         return Err(anyhow!(
-            "basic STA only supports scalar-net bare-literal continuous assigns; net '{}' is multi-bit",
+            "basic STA only supports scalar-net continuous assigns; net '{}' is multi-bit",
             net_name_for_index(nets, interner, net_idx)
         ));
     }
     Ok(net_idx)
+}
+
+/// Returns the scalar source net referenced by a supported alias RHS.
+fn scalar_assign_leaf_net_index(
+    rhs: &NetRef,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> Result<NetIndex> {
+    let net_idx = match rhs {
+        NetRef::Simple(net_idx) => *net_idx,
+        NetRef::BitSelect(_, _)
+        | NetRef::PartSelect(_, _, _)
+        | NetRef::Literal(_)
+        | NetRef::Unconnected
+        | NetRef::Concat(_) => {
+            return Err(anyhow!(
+                "basic STA only supports scalar-net alias continuous assigns; unsupported assign rhs '{}'",
+                render_assign_lhs(rhs, nets, interner)
+            ));
+        }
+    };
+    if net_idx.0 >= nets.len() {
+        return Err(anyhow!(
+            "alias continuous assign references out-of-range net index {}",
+            net_idx.0
+        ));
+    }
+    if net_width_is_multibit(nets[net_idx.0].width) {
+        return Err(anyhow!(
+            "basic STA only supports scalar-net alias continuous assigns; net '{}' is multi-bit",
+            net_name_for_index(nets, interner, net_idx)
+        ));
+    }
+    Ok(net_idx)
+}
+
+fn resolve_timing_source(
+    assign_sources: &[Option<ScalarAssignSource>],
+    start: NetIndex,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> Result<ResolvedTimingSource> {
+    let mut current = start;
+    let mut seen = HashSet::new();
+    loop {
+        if !seen.insert(current.0) {
+            return Err(anyhow!(
+                "continuous assign aliases contain a cycle involving net '{}'",
+                net_name_for_index(nets, interner, current)
+            ));
+        }
+        let Some(source) = assign_sources.get(current.0).and_then(|source| *source) else {
+            return Ok(ResolvedTimingSource::Net(current));
+        };
+        match source {
+            ScalarAssignSource::Literal(value) => return Ok(ResolvedTimingSource::Literal(value)),
+            ScalarAssignSource::Alias(next) => current = next,
+        }
+    }
+}
+
+fn assign_known_values(
+    assign_sources: &[Option<ScalarAssignSource>],
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> Result<Vec<Option<bool>>> {
+    let mut values = vec![None; nets.len()];
+    for net_idx in 0..nets.len() {
+        if let ResolvedTimingSource::Literal(value) =
+            resolve_timing_source(assign_sources, NetIndex(net_idx), nets, interner)?
+        {
+            values[net_idx] = Some(value);
+        }
+    }
+    Ok(values)
+}
+
+fn propagate_alias_timings(
+    assign_sources: &[Option<ScalarAssignSource>],
+    net_timing_sets: &mut [Option<SignalTimingSet>],
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+) -> Result<()> {
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for net_idx in 0..assign_sources.len() {
+            let Some(ScalarAssignSource::Alias(source_net_idx)) = assign_sources[net_idx] else {
+                continue;
+            };
+            resolve_timing_source(assign_sources, NetIndex(net_idx), nets, interner)?;
+            let Some(source_timing) = net_timing_sets[source_net_idx.0].clone() else {
+                continue;
+            };
+            if net_timing_sets[net_idx] != Some(source_timing.clone()) {
+                net_timing_sets[net_idx] = Some(source_timing);
+                changed = true;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn render_assign_lhs(
@@ -2111,7 +2272,7 @@ endmodule
     }
 
     #[test]
-    fn sta_rejects_non_literal_continuous_assigns() {
+    fn sta_accepts_scalar_alias_output_assigns() {
         let src = r#"
 module top (a, y);
   input a;
@@ -2124,6 +2285,63 @@ module top (a, y);
 endmodule
 "#;
         let (module, nets, interner) = parse_single_module(src);
+        let report = analyze_combinational_max_arrival_proto(
+            &module,
+            &nets,
+            &interner,
+            &scalar_inv_library(),
+            StaOptions::default(),
+        )
+        .expect("scalar alias output assign should be supported");
+        let n_idx = find_net_index(&nets, &interner, "n");
+        let y_idx = find_net_index(&nets, &interner, "y");
+        assert_eq!(report.timing_for_net(y_idx), report.timing_for_net(n_idx));
+        assert_close(report.worst_output_arrival, 3.0);
+        assert_eq!(report.cell_levels, 1);
+    }
+
+    #[test]
+    fn sta_accepts_scalar_alias_chains_to_instance_inputs() {
+        let src = r#"
+module top (a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  wire n0;
+  wire n1;
+  INV u0 (.A(a), .Y(n0));
+  assign n1 = n0;
+  INV u1 (.A(n1), .Y(y));
+endmodule
+"#;
+        let (module, nets, interner) = parse_single_module(src);
+        let report = analyze_combinational_max_arrival_proto(
+            &module,
+            &nets,
+            &interner,
+            &scalar_inv_library(),
+            StaOptions::default(),
+        )
+        .expect("scalar alias should carry timing into downstream instances");
+        assert_close(report.worst_output_arrival, 5.0);
+        assert_eq!(report.cell_levels, 2);
+    }
+
+    #[test]
+    fn sta_rejects_non_alias_continuous_assigns() {
+        let src = r#"
+module top (a, b, y);
+  input a;
+  input b;
+  output y;
+  wire a;
+  wire b;
+  wire y;
+  assign y = a & b;
+endmodule
+"#;
+        let (module, nets, interner) = parse_single_module(src);
         let error = analyze_combinational_max_arrival_proto(
             &module,
             &nets,
@@ -2131,11 +2349,11 @@ endmodule
             &scalar_inv_library(),
             StaOptions::default(),
         )
-        .expect_err("non-literal continuous assigns should be rejected");
+        .expect_err("non-alias continuous assigns should be rejected");
         assert!(
             error
                 .to_string()
-                .contains("bare-literal continuous assigns")
+                .contains("scalar literal or alias continuous assigns")
         );
     }
 

--- a/xlsynth-g8r/tests/gv2ir_test.rs
+++ b/xlsynth-g8r/tests/gv2ir_test.rs
@@ -2,7 +2,9 @@
 
 use std::io::Write;
 use tempfile::NamedTempFile;
-use xlsynth_g8r::netlist::gv2ir::convert_gv2ir_paths;
+use xlsynth_g8r::netlist::gv2ir::{
+    Gv2IrOptions, convert_gv2ir_paths, convert_gv2ir_paths_with_options,
+};
 
 const LIBERTY_TEXTPROTO: &str = r#"
 cells: {
@@ -14,12 +16,14 @@ cells: {
 "#;
 
 #[test]
-fn test_gv2ir_rejects_preserved_assigns() {
+fn test_gv2ir_rejects_default_top_function_name() {
     let netlist = r#"
 module top (a, y);
   input a;
   output y;
-  assign y = a & a;
+  wire a;
+  wire y;
+  BUF u0 (.A(a), .Y(y));
 endmodule
 "#;
     let mut liberty_file = NamedTempFile::new().unwrap();
@@ -28,9 +32,77 @@ endmodule
     write!(netlist_file, "{}", netlist).unwrap();
 
     let err = convert_gv2ir_paths(netlist_file.path(), liberty_file.path(), true)
-        .expect_err("expected preserved assigns to be rejected");
+        .expect_err("expected default top function name to be rejected");
     assert!(
         err.to_string()
-            .contains("gv2ir does not support preserved continuous assigns")
+            .contains("gv2ir would emit XLS IR function name 'top'")
+    );
+    assert!(err.to_string().contains("--output_function_name"));
+}
+
+#[test]
+fn test_gv2ir_output_function_name_override_supports_top_module_with_assigns() {
+    let netlist = r#"
+module top (a, y);
+  input [1:0] a;
+  output y;
+  wire [1:0] a;
+  wire y;
+  wire [1:0] tmp;
+  assign tmp = {a[0], a[1]};
+  BUF u0 (.A(tmp[1]), .Y(y));
+endmodule
+"#;
+    let mut liberty_file = NamedTempFile::new().unwrap();
+    write!(liberty_file, "{}", LIBERTY_TEXTPROTO).unwrap();
+    let mut netlist_file = NamedTempFile::new().unwrap();
+    write!(netlist_file, "{}", netlist).unwrap();
+
+    let ir = convert_gv2ir_paths_with_options(
+        netlist_file.path(),
+        liberty_file.path(),
+        &Gv2IrOptions {
+            module_name: None,
+            collapse_sequential: true,
+            output_function_name: Some("top_fn".to_string()),
+        },
+    )
+    .expect("override should allow a top-named netlist module");
+    assert!(
+        ir.contains("fn top_fn("),
+        "expected overridden function name in IR:\n{}",
+        ir
+    );
+}
+
+#[test]
+fn test_gv2ir_rejects_invalid_output_function_name_override() {
+    let netlist = r#"
+module not_top (a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  BUF u0 (.A(a), .Y(y));
+endmodule
+"#;
+    let mut liberty_file = NamedTempFile::new().unwrap();
+    write!(liberty_file, "{}", LIBERTY_TEXTPROTO).unwrap();
+    let mut netlist_file = NamedTempFile::new().unwrap();
+    write!(netlist_file, "{}", netlist).unwrap();
+
+    let err = convert_gv2ir_paths_with_options(
+        netlist_file.path(),
+        liberty_file.path(),
+        &Gv2IrOptions {
+            module_name: None,
+            collapse_sequential: true,
+            output_function_name: Some("bad-name".to_string()),
+        },
+    )
+    .expect_err("invalid function name override should be rejected");
+    assert!(
+        err.to_string()
+            .contains("invalid XLS IR function name 'bad-name'")
     );
 }


### PR DESCRIPTION
Changes:
* Unify all gv-* commands under the same netlist parser.
* support slices, concats, literals which (at least) yosys sometimes emits.
