### PR TITLE
Fix more netlist parsing issues.

### DIFF
--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -133,7 +133,7 @@ xlsynth-driver gv2ir \
 
 ### `gv2block`: gate-level netlist to Block IR
 
-Converts a gate-level netlist plus Liberty proto into an XLS block IR package. Cells are defined as separate blocks instantiated in the top block. The netlist must contain exactly one module.
+Converts a techmapped gate-level netlist plus Liberty proto into an XLS block IR package. Cells are defined as separate blocks instantiated in the top block. The netlist must contain exactly one module. Preserved `assign` / `tran` statements are accepted only when they are wiring artifacts such as aliases, slices, concats, or literal tieoffs; top-level combinational assign logic must be technology-mapped into cells first.
 
 ```shell
 xlsynth-driver gv2block \

--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -340,7 +340,7 @@ Additional flags:
 - `--module_name <MODULE>`: Optional module name to restrict the search; required when the netlist contains multiple modules.
 - `--start-pins <CSV>`: Optional comma-separated list of starting pins on the instance; defaults to all input pins for `--traverse=fanin` and all output pins for `--traverse=fanout`.
 - `--dff_cells <CSV>`: Comma-separated list of DFF cell names that should be treated as stop boundaries when using `--stop-at-dff` (required if `--stop-at-dff` is selected).
-- `gv-dump-cone` operates on instance-based structural connectivity; modules with preserved continuous `assign` statements are rejected rather than partially ignored.
+- `gv-dump-cone` operates on normalized bit-level connectivity, including preserved continuous `assign` dependencies that can be normalized by the frontend.
 
 Output format:
 

--- a/xlsynth-driver/src/gv_dump_cone.rs
+++ b/xlsynth-driver/src/gv_dump_cone.rs
@@ -61,15 +61,9 @@ fn stop_condition_from_matches(matches: &ArgMatches) -> Result<StopCondition, St
 
 fn cone_error_to_report_message(err: ConeError) -> (String, Vec<(&'static str, String)>) {
     match err {
-        ConeError::UnsupportedAssigns {
-            module,
-            assign_count,
-        } => (
-            "gv-dump-cone does not support preserved continuous assigns".to_string(),
-            vec![
-                ("module", module),
-                ("assign_count", format!("{}", assign_count)),
-            ],
+        ConeError::InvalidConnectivity { reason } => (
+            "gv-dump-cone could not normalize module connectivity".to_string(),
+            vec![("reason", reason)],
         ),
         ConeError::MissingInstance { name } => (
             "start instance not found in module".to_string(),

--- a/xlsynth-driver/tests/gv_dump_cone_test.rs
+++ b/xlsynth-driver/tests/gv_dump_cone_test.rs
@@ -78,7 +78,7 @@ INV,u2,A,1
 }
 
 #[test]
-fn gv_dump_cone_rejects_preserved_assigns() {
+fn gv_dump_cone_traverses_preserved_assigns() {
     let driver = env!("CARGO_BIN_EXE_xlsynth-driver");
 
     let liberty_text = r#"
@@ -98,13 +98,14 @@ cells: {
 "#;
 
     let netlist_text = r#"
-module top (a, b, y);
+module top (a, y);
   input a;
-  input b;
   output y;
-  wire n;
-  assign n = a & b;
-  BUF u1 (.A(n), .Y(y));
+  wire n0;
+  wire n1;
+  BUF u0 (.A(a), .Y(n0));
+  assign n1 = n0 & n0;
+  BUF u1 (.A(n1), .Y(y));
 endmodule
 "#;
 
@@ -122,26 +123,29 @@ endmodule
         .arg("--liberty_proto")
         .arg(liberty_file.path().as_os_str())
         .arg("--instance")
-        .arg("u1")
+        .arg("u0")
         .arg("--traverse")
-        .arg("fanin")
+        .arg("fanout")
         .arg("--stop-at-levels")
         .arg("1")
         .output()
         .expect("gv-dump-cone invocation should run");
 
     assert!(
-        !output.status.success(),
-        "gv-dump-cone should reject preserved assigns: status={:?}\nstdout={}\nstderr={}",
+        output.status.success(),
+        "gv-dump-cone failed: status={:?}\nstdout={}\nstderr={}",
         output.status,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("does not support preserved continuous assigns"),
-        "unexpected stderr: {}",
-        stderr,
-    );
+    let got = String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n");
+
+    let want = "\
+instance_type,instance_name,traversal_pin,levels
+BUF,u0,Y,0
+BUF,u1,A,1
+";
+
+    assert_eq!(got, want);
 }

--- a/xlsynth-g8r/src/netlist/cone.rs
+++ b/xlsynth-g8r/src/netlist/cone.rs
@@ -17,6 +17,7 @@
 use crate::liberty::IndexedLibrary;
 use crate::liberty_proto::PinDirection;
 use crate::netlist::connectivity::NetlistConnectivity;
+use crate::netlist::normalized::BitIndex;
 use crate::netlist::parse::{InstIndex, Net, NetlistModule, PortId};
 use std::collections::{HashMap, HashSet, VecDeque};
 use string_interner::symbol::SymbolU32;
@@ -62,9 +63,9 @@ pub struct ConeVisit {
 /// Error type for cone traversal.
 #[derive(Debug)]
 pub enum ConeError {
-    /// Given when the selected module contains preserved continuous assigns,
-    /// which this instance-connectivity traversal does not model.
-    UnsupportedAssigns { module: String, assign_count: usize },
+    /// Given when normalized connectivity could not be built for the selected
+    /// module.
+    InvalidConnectivity { reason: String },
     /// Given when the user supplies an instance name to start from that is not
     /// present in the module.
     MissingInstance { name: String },
@@ -91,14 +92,7 @@ pub enum ConeError {
 impl std::fmt::Display for ConeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ConeError::UnsupportedAssigns {
-                module,
-                assign_count,
-            } => write!(
-                f,
-                "module '{}' contains {} preserved continuous assign(s); cone traversal only supports instance-based structural netlists",
-                module, assign_count
-            ),
+            ConeError::InvalidConnectivity { reason } => write!(f, "{reason}"),
             ConeError::MissingInstance { name } => {
                 write!(f, "start instance '{}' was not found in the module", name)
             }
@@ -140,7 +134,6 @@ type ConeResult<T> = std::result::Result<T, ConeError>;
 struct ModuleConeContext<'a> {
     /// The module being traversed.
     module: &'a NetlistModule,
-    nets: &'a [Net],
     interner: &'a StringInterner<StringBackend<SymbolU32>>,
 
     /// Net-level connectivity (drivers and loads per net), plus cached
@@ -160,13 +153,6 @@ impl<'a> ModuleConeContext<'a> {
         dff_cell_names: &HashSet<String>,
         module_port_dirs: Option<&HashMap<PortId, HashMap<PortId, PinDirection>>>,
     ) -> ConeResult<Self> {
-        if !module.assigns.is_empty() {
-            return Err(ConeError::UnsupportedAssigns {
-                module: resolve_to_string(interner, module.name),
-                assign_count: module.assigns.len(),
-            });
-        }
-
         // Precompute dff_types as a set of type-name symbols used by instances.
         let mut dff_types: HashSet<PortId> = HashSet::new();
 
@@ -198,11 +184,13 @@ impl<'a> ModuleConeContext<'a> {
                 colno: inst.inst_colno,
             });
         }
-        let connectivity = NetlistConnectivity::new(module, nets, interner, lib, module_port_dirs);
+        let connectivity = NetlistConnectivity::new(module, nets, interner, lib, module_port_dirs)
+            .map_err(|e| ConeError::InvalidConnectivity {
+                reason: format!("could not normalize module connectivity: {e}"),
+            })?;
 
         Ok(ModuleConeContext {
             module,
-            nets,
             interner,
             connectivity,
             dff_types,
@@ -237,6 +225,38 @@ fn resolve_to_string(
         .resolve(sym)
         .expect("symbol should always resolve in interner")
         .to_string()
+}
+
+fn reachable_bits_for_traversal(
+    ctx: &ModuleConeContext<'_>,
+    start_bit: BitIndex,
+    direction: TraversalDirection,
+    stop: StopCondition,
+) -> Vec<BitIndex> {
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::new();
+    let mut reachable = Vec::new();
+    queue.push_back(start_bit);
+    while let Some(bit_idx) = queue.pop_front() {
+        if !visited.insert(bit_idx) {
+            continue;
+        }
+        reachable.push(bit_idx);
+        if matches!(stop, StopCondition::AtBlockPort) && ctx.connectivity.is_block_port_bit(bit_idx)
+        {
+            continue;
+        }
+        let next_bits = match direction {
+            TraversalDirection::Fanin => ctx.connectivity.assign_fanin_bits(bit_idx),
+            TraversalDirection::Fanout => ctx.connectivity.assign_fanout_bits(bit_idx),
+        };
+        for next_bit in next_bits {
+            if !visited.contains(next_bit) {
+                queue.push_back(*next_bit);
+            }
+        }
+    }
+    reachable
 }
 
 /// Traverse the cone around `start_instance` in `module`, calling `on_visit`
@@ -426,89 +446,82 @@ where
                 continue;
             }
 
-            for net_idx in &port.nets {
-                assert!(
-                    net_idx.0 < ctx.nets.len(),
-                    "NetIndex({}) out of bounds for nets (len={}) during traversal",
-                    net_idx.0,
-                    ctx.nets.len()
-                );
-
-                // If we are stopping at block ports, do not traverse across
-                // module boundary nets.
-                if matches!(stop, StopCondition::AtBlockPort)
-                    && ctx.connectivity.is_block_port_net(*net_idx)
-                {
-                    continue;
-                }
-
-                let neighbor_level = level + 1;
-                if let StopCondition::Levels(max) = stop {
-                    if neighbor_level > max {
-                        continue;
-                    }
-                }
-
-                let neighbors = match direction {
-                    TraversalDirection::Fanin => ctx.connectivity.drivers_for_net(*net_idx),
-                    TraversalDirection::Fanout => ctx.connectivity.loads_for_net(*net_idx),
-                };
-
-                for (nbr_inst_idx, nbr_port_sym) in neighbors {
-                    if is_clocking_pin_for_instance(&ctx, *nbr_inst_idx, *nbr_port_sym) {
-                        continue;
-                    }
-                    // Skip self-loops; the starting instance has already been emitted.
-                    if *nbr_inst_idx == inst_idx {
+            for start_bit in &port.bits {
+                for bit_idx in reachable_bits_for_traversal(&ctx, *start_bit, direction, stop) {
+                    if matches!(stop, StopCondition::AtBlockPort)
+                        && ctx.connectivity.is_block_port_bit(bit_idx)
+                    {
                         continue;
                     }
 
-                    let nbr_inst = &ctx.module.instances[nbr_inst_idx.0];
-                    let nbr_type_str = resolve_to_string(&ctx.interner, nbr_inst.type_name);
-                    let nbr_name_str = resolve_to_string(&ctx.interner, nbr_inst.instance_name);
-                    let nbr_port_name = resolve_to_string(&ctx.interner, *nbr_port_sym);
-
-                    if emitted_ports.insert((*nbr_inst_idx, *nbr_port_sym)) {
-                        let visit = ConeVisit {
-                            instance_type: nbr_type_str,
-                            instance_name: nbr_name_str,
-                            traversal_pin: nbr_port_name,
-                            level: neighbor_level,
-                        };
-                        on_visit(&visit)?;
-                    }
-
-                    // Decide whether to enqueue this neighbor for further
-                    // expansion.
-                    let is_dff = ctx.dff_types.contains(&nbr_inst.type_name);
-                    match stop {
-                        StopCondition::Levels(max) => {
-                            if neighbor_level < max && visited_instances.insert(*nbr_inst_idx) {
-                                queue.push_back(QueueEntry {
-                                    inst_idx: *nbr_inst_idx,
-                                    level: neighbor_level,
-                                });
-                            }
+                    let neighbor_level = level + 1;
+                    if let StopCondition::Levels(max) = stop {
+                        if neighbor_level > max {
+                            continue;
                         }
-                        StopCondition::AtDff => {
-                            if is_dff {
-                                // Include the DFF in the output but do not
-                                // traverse beyond it.
-                                continue;
-                            }
-                            if visited_instances.insert(*nbr_inst_idx) {
-                                queue.push_back(QueueEntry {
-                                    inst_idx: *nbr_inst_idx,
-                                    level: neighbor_level,
-                                });
-                            }
+                    }
+
+                    let neighbors = match direction {
+                        TraversalDirection::Fanin => ctx.connectivity.drivers_for_bit(bit_idx),
+                        TraversalDirection::Fanout => ctx.connectivity.loads_for_bit(bit_idx),
+                    };
+
+                    for (nbr_inst_idx, nbr_port_sym) in neighbors {
+                        if is_clocking_pin_for_instance(&ctx, *nbr_inst_idx, *nbr_port_sym) {
+                            continue;
                         }
-                        StopCondition::AtBlockPort => {
-                            if visited_instances.insert(*nbr_inst_idx) {
-                                queue.push_back(QueueEntry {
-                                    inst_idx: *nbr_inst_idx,
-                                    level: neighbor_level,
-                                });
+                        // Skip self-loops; the starting instance has already been emitted.
+                        if *nbr_inst_idx == inst_idx {
+                            continue;
+                        }
+
+                        let nbr_inst = &ctx.module.instances[nbr_inst_idx.0];
+                        let nbr_type_str = resolve_to_string(&ctx.interner, nbr_inst.type_name);
+                        let nbr_name_str = resolve_to_string(&ctx.interner, nbr_inst.instance_name);
+                        let nbr_port_name = resolve_to_string(&ctx.interner, *nbr_port_sym);
+
+                        if emitted_ports.insert((*nbr_inst_idx, *nbr_port_sym)) {
+                            let visit = ConeVisit {
+                                instance_type: nbr_type_str,
+                                instance_name: nbr_name_str,
+                                traversal_pin: nbr_port_name,
+                                level: neighbor_level,
+                            };
+                            on_visit(&visit)?;
+                        }
+
+                        // Decide whether to enqueue this neighbor for further
+                        // expansion.
+                        let is_dff = ctx.dff_types.contains(&nbr_inst.type_name);
+                        match stop {
+                            StopCondition::Levels(max) => {
+                                if neighbor_level < max && visited_instances.insert(*nbr_inst_idx) {
+                                    queue.push_back(QueueEntry {
+                                        inst_idx: *nbr_inst_idx,
+                                        level: neighbor_level,
+                                    });
+                                }
+                            }
+                            StopCondition::AtDff => {
+                                if is_dff {
+                                    // Include the DFF in the output but do not
+                                    // traverse beyond it.
+                                    continue;
+                                }
+                                if visited_instances.insert(*nbr_inst_idx) {
+                                    queue.push_back(QueueEntry {
+                                        inst_idx: *nbr_inst_idx,
+                                        level: neighbor_level,
+                                    });
+                                }
+                            }
+                            StopCondition::AtBlockPort => {
+                                if visited_instances.insert(*nbr_inst_idx) {
+                                    queue.push_back(QueueEntry {
+                                        inst_idx: *nbr_inst_idx,
+                                        level: neighbor_level,
+                                    });
+                                }
                             }
                         }
                     }
@@ -1005,12 +1018,14 @@ mod tests {
     }
 
     #[test]
-    fn visit_module_cone_rejects_preserved_assigns() {
+    fn visit_module_cone_traverses_preserved_assign_dependencies() {
         let mut interner: StringInterner<StringBackend<SymbolU32>> = StringInterner::new();
         let a = interner.get_or_intern("a");
-        let n = interner.get_or_intern("n");
+        let n0 = interner.get_or_intern("n0");
+        let n1 = interner.get_or_intern("n1");
         let y = interner.get_or_intern("y");
         let buf = interner.get_or_intern("BUF");
+        let u0 = interner.get_or_intern("u0");
         let u1 = interner.get_or_intern("u1");
         let top = interner.get_or_intern("top");
 
@@ -1020,7 +1035,11 @@ mod tests {
                 width: None,
             },
             Net {
-                name: n,
+                name: n0,
+                width: None,
+            },
+            Net {
+                name: n1,
                 width: None,
             },
             Net {
@@ -1046,15 +1065,16 @@ mod tests {
             name: top,
             net_index_range: 0..nets.len(),
             ports,
-            wires: vec![NetIndex(0), NetIndex(1), NetIndex(2)],
+            wires: vec![NetIndex(0), NetIndex(1), NetIndex(2), NetIndex(3)],
             assigns: vec![crate::netlist::parse::NetlistAssign {
-                lhs: NetRef::Simple(NetIndex(1)),
+                kind: crate::netlist::parse::NetlistAssignKind::Continuous,
+                lhs: NetRef::Simple(NetIndex(2)),
                 rhs: crate::netlist::parse::AssignExpr::And(
                     Box::new(crate::netlist::parse::AssignExpr::Leaf(NetRef::Simple(
-                        NetIndex(0),
+                        NetIndex(1),
                     ))),
                     Box::new(crate::netlist::parse::AssignExpr::Leaf(NetRef::Simple(
-                        NetIndex(0),
+                        NetIndex(1),
                     ))),
                 ),
                 span: crate::netlist::parse::Span {
@@ -1068,45 +1088,67 @@ mod tests {
                     },
                 },
             }],
-            instances: vec![NetlistInstance {
-                type_name: buf,
-                instance_name: u1,
-                connections: vec![
-                    (interner.get_or_intern("A"), NetRef::Simple(NetIndex(1))),
-                    (interner.get_or_intern("Y"), NetRef::Simple(NetIndex(2))),
-                ],
-                inst_lineno: 0,
-                inst_colno: 0,
-            }],
+            instances: vec![
+                NetlistInstance {
+                    type_name: buf,
+                    instance_name: u0,
+                    connections: vec![
+                        (interner.get_or_intern("I"), NetRef::Simple(NetIndex(0))),
+                        (interner.get_or_intern("O"), NetRef::Simple(NetIndex(1))),
+                    ],
+                    inst_lineno: 0,
+                    inst_colno: 0,
+                },
+                NetlistInstance {
+                    type_name: buf,
+                    instance_name: u1,
+                    connections: vec![
+                        (interner.get_or_intern("I"), NetRef::Simple(NetIndex(2))),
+                        (interner.get_or_intern("O"), NetRef::Simple(NetIndex(3))),
+                    ],
+                    inst_lineno: 0,
+                    inst_colno: 0,
+                },
+            ],
         };
 
         let lib: Library = make_test_library();
         let indexed = IndexedLibrary::new(lib);
         let dff_cells: HashSet<String> = HashSet::new();
-        let err = visit_module_cone(
+        let mut visits = Vec::new();
+        visit_module_cone(
             &module,
             &nets,
             &interner,
             &indexed,
             &dff_cells,
             None::<&HashMap<PortId, HashMap<PortId, PinDirection>>>,
-            "u1",
+            "u0",
             None,
             TraversalDirection::Fanout,
             StopCondition::Levels(1),
-            |_v: &ConeVisit| Ok(()),
+            |visit: &ConeVisit| {
+                visits.push(visit.clone());
+                Ok(())
+            },
         )
-        .expect_err("preserved assigns should be rejected");
-
-        match err {
-            ConeError::UnsupportedAssigns {
-                module,
-                assign_count,
-            } => {
-                assert_eq!(module, "top");
-                assert_eq!(assign_count, 1);
-            }
-            other => panic!("unexpected error: {}", other),
-        }
+        .expect("preserved assign dependencies should be traversed");
+        assert_eq!(
+            visits,
+            vec![
+                ConeVisit {
+                    instance_type: "BUF".to_string(),
+                    instance_name: "u0".to_string(),
+                    traversal_pin: "O".to_string(),
+                    level: 0,
+                },
+                ConeVisit {
+                    instance_type: "BUF".to_string(),
+                    instance_name: "u1".to_string(),
+                    traversal_pin: "I".to_string(),
+                    level: 1,
+                },
+            ]
+        );
     }
 }

--- a/xlsynth-g8r/src/netlist/connectivity.rs
+++ b/xlsynth-g8r/src/netlist/connectivity.rs
@@ -2,22 +2,25 @@
 
 //! Connectivity helpers for gate-level netlists.
 //!
-//! This module provides a small API for reasoning about which instances
-//! drive or load each net in a `NetlistModule`, combining information from
-//! the parsed netlist with Liberty pin directions via `IndexedLibrary`.
+//! This module derives per-bit instance and assign connectivity from the
+//! normalized netlist frontend. Parsed Verilog syntax such as concat, selects,
+//! continuous assigns, and plain `tran` aliases is lowered before cone-like
+//! consumers walk the graph.
 
 use crate::liberty::IndexedLibrary;
 use crate::liberty_proto::PinDirection;
+use crate::netlist::normalized::{BitIndex, BitSource, NormalizedNetlistModule};
 use crate::netlist::parse::{InstIndex, Net, NetIndex, NetlistModule, PortDirection, PortId};
+use anyhow::Result;
 use std::collections::HashMap;
 use string_interner::symbol::SymbolU32;
 use string_interner::{StringInterner, backend::StringBackend};
 
-/// Instances and ports that connect to a net.
-pub struct NetNeighbors {
-    /// Instances and ports that drive this net.
+/// Instances and ports that connect to one normalized net bit.
+pub struct BitNeighbors {
+    /// Instances and ports that drive this bit.
     pub drivers: Vec<(InstIndex, PortId)>,
-    /// Instances and ports that load this net.
+    /// Instances and ports that load this bit.
     pub loads: Vec<(InstIndex, PortId)>,
 }
 
@@ -30,98 +33,115 @@ pub struct InstancePortInfo {
     /// Direction of this pin on the cell (input/output), as derived from the
     /// Liberty library.
     pub dir: PinDirection,
-    /// All `NetIndex` values reachable from this port's connection expression.
-    ///
-    /// This may contain multiple nets when the Verilog connection is a concat
-    /// (e.g. `{a, b[5], c[7:0], 1'b0}`) or when a bus slice spans several
-    /// underlying nets.
-    pub nets: Vec<NetIndex>,
+    /// All normalized net bits reachable from this port's connection
+    /// expression. Literal, unknown, and unconnected sources are omitted.
+    pub bits: Vec<BitIndex>,
 }
 
-/// Block-level attachment for a net that touches one or more module ports.
-///
-/// This structure is stored sparsely: only nets that are attached to at least
-/// one module port get an entry in the `NetlistConnectivity` map.
+/// Block-level attachment for a normalized net bit that touches one or more
+/// module ports.
 pub struct BlockPortBoundary {
-    /// True if this net is attached to at least one module input port.
+    /// True if this bit is attached to at least one module input port.
     pub has_input: bool,
-    /// True if this net is attached to at least one module output port.
+    /// True if this bit is attached to at least one module output port.
     pub has_output: bool,
-    /// True if this net is attached to at least one module inout port.
+    /// True if this bit is attached to at least one module inout port.
     pub has_inout: bool,
 }
 
-/// Per-module connectivity derived from a `NetlistModule` and `IndexedLibrary`.
+/// Per-module connectivity derived from a normalized `NetlistModule` and
+/// `IndexedLibrary`.
 pub struct NetlistConnectivity<'a> {
     pub module: &'a NetlistModule,
     pub nets: &'a [Net],
     pub lib: &'a IndexedLibrary,
-    /// For each `NetIndex.0`, the instances and ports that drive/load it.
-    pub net_neighbors: Vec<NetNeighbors>,
-    /// Sparse map from nets that touch module ports to their block-port roles
-    /// (whether they are attached to input / output / inout ports).
-    pub block_port_nets: HashMap<NetIndex, BlockPortBoundary>,
+    normalized: NormalizedNetlistModule<'a>,
+    /// For each normalized bit index, the instances and ports that drive/load
+    /// it.
+    pub bit_neighbors: Vec<BitNeighbors>,
+    /// For each normalized bit index, assign-source bits that feed it.
+    pub assign_fanin_bits: Vec<Vec<BitIndex>>,
+    /// For each normalized bit index, assign-destination bits fed by it.
+    pub assign_fanout_bits: Vec<Vec<BitIndex>>,
+    /// Sparse map from normalized bits that touch module ports to their
+    /// block-port roles.
+    pub block_port_bits: HashMap<BitIndex, BlockPortBoundary>,
     /// For each instance index in `module.instances`, the list of its ports,
-    /// pin directions, and connected nets. Ports for each instance are stored
-    /// in a deterministic order by port name.
+    /// pin directions, and connected normalized bits. Ports for each instance
+    /// are stored in a deterministic order by port name.
     instance_ports: Vec<Vec<InstancePortInfo>>,
 }
 
 impl<'a> NetlistConnectivity<'a> {
     /// Builds connectivity information for `module` using the given Liberty
-    /// library. This constructor iterates all instances once and classifies
-    /// their connections as drivers or loads for each net.
+    /// library. This constructor classifies instance pin bindings and lowers
+    /// normalized assign dependencies onto the bit graph.
     pub fn new(
         module: &'a NetlistModule,
         nets: &'a [Net],
         interner: &StringInterner<StringBackend<SymbolU32>>,
         lib: &'a IndexedLibrary,
         module_port_dirs: Option<&HashMap<PortId, HashMap<PortId, PinDirection>>>,
-    ) -> Self {
-        let block_port_nets = build_block_port_nets(module, nets);
-        let mut net_neighbors = create_empty_net_neighbors(nets.len());
+    ) -> Result<Self> {
+        let normalized = NormalizedNetlistModule::new(module, nets, interner)?;
+        let block_port_bits = build_block_port_bits(&normalized);
+        let mut bit_neighbors = create_empty_bit_neighbors(normalized.bit_count());
+        let (assign_fanin_bits, assign_fanout_bits) = build_assign_connectivity(&normalized);
         let instance_ports = build_instance_connectivity(
-            module,
-            nets,
+            &normalized,
             interner,
             lib,
             module_port_dirs,
-            &mut net_neighbors,
+            bit_neighbors.as_mut_slice(),
         );
 
-        NetlistConnectivity {
+        Ok(Self {
             module,
             nets,
             lib,
-            net_neighbors,
-            block_port_nets,
+            normalized,
+            bit_neighbors,
+            assign_fanin_bits,
+            assign_fanout_bits,
+            block_port_bits,
             instance_ports,
-        }
+        })
     }
 
-    /// Returns the instances and ports that drive `net`.
-    pub fn drivers_for_net(&self, net: NetIndex) -> &[(InstIndex, PortId)] {
-        &self.net_neighbors[net.0].drivers
+    /// Returns the instances and ports that drive normalized `bit`.
+    pub fn drivers_for_bit(&self, bit: BitIndex) -> &[(InstIndex, PortId)] {
+        &self.bit_neighbors[bit].drivers
     }
 
-    /// Returns the instances and ports that load `net`.
-    pub fn loads_for_net(&self, net: NetIndex) -> &[(InstIndex, PortId)] {
-        &self.net_neighbors[net.0].loads
+    /// Returns the instances and ports that load normalized `bit`.
+    pub fn loads_for_bit(&self, bit: BitIndex) -> &[(InstIndex, PortId)] {
+        &self.bit_neighbors[bit].loads
     }
 
-    /// Returns true if `net` is attached to at least one module port (input,
-    /// output, or inout).
-    pub fn is_block_port_net(&self, net: NetIndex) -> bool {
-        self.block_port_nets.contains_key(&net)
+    /// Returns assign-source bits that feed normalized `bit`.
+    pub fn assign_fanin_bits(&self, bit: BitIndex) -> &[BitIndex] {
+        self.assign_fanin_bits[bit].as_slice()
     }
 
-    /// Returns the sparse block-port boundary metadata for `net`, if any.
-    pub fn net_block_port_boundary(&self, net: NetIndex) -> Option<&BlockPortBoundary> {
-        self.block_port_nets.get(&net)
+    /// Returns assign-destination bits fed by normalized `bit`.
+    pub fn assign_fanout_bits(&self, bit: BitIndex) -> &[BitIndex] {
+        self.assign_fanout_bits[bit].as_slice()
+    }
+
+    /// Returns true if normalized `bit` is attached to at least one module
+    /// port (input, output, or inout).
+    pub fn is_block_port_bit(&self, bit: BitIndex) -> bool {
+        self.block_port_bits.contains_key(&bit)
+    }
+
+    /// Returns the sparse block-port boundary metadata for normalized `bit`,
+    /// if any.
+    pub fn bit_block_port_boundary(&self, bit: BitIndex) -> Option<&BlockPortBoundary> {
+        self.block_port_bits.get(&bit)
     }
 
     /// Returns the per-port view for `inst_idx`, including pin direction and
-    /// connected nets.
+    /// connected normalized bits.
     pub fn instance_ports(
         &self,
         inst_idx: InstIndex,
@@ -129,66 +149,87 @@ impl<'a> NetlistConnectivity<'a> {
     ) -> &[InstancePortInfo] {
         &self.instance_ports[inst_idx.0]
     }
-}
 
-fn build_block_port_nets(
-    module: &NetlistModule,
-    nets: &[Net],
-) -> HashMap<NetIndex, BlockPortBoundary> {
-    // Map from module port net symbol -> PortDirection for sparse block-port
-    // attachment metadata.
-    let mut port_dir_by_sym: HashMap<SymbolU32, PortDirection> = HashMap::new();
-    for port in &module.ports {
-        port_dir_by_sym.insert(port.name, port.direction.clone());
+    /// Renders one normalized bit through the underlying parsed netlist names.
+    pub fn render_bit(
+        &self,
+        bit: BitIndex,
+        interner: &StringInterner<StringBackend<SymbolU32>>,
+    ) -> String {
+        self.normalized.render_bit(bit, self.nets, interner)
     }
 
-    // Sparse per-net module-port attachment (only nets that touch block ports
-    // get entries).
-    let mut block_port_nets: HashMap<NetIndex, BlockPortBoundary> = HashMap::new();
-    for (idx, net) in nets.iter().enumerate() {
-        if let Some(dir) = port_dir_by_sym.get(&net.name) {
-            let entry = block_port_nets
-                .entry(NetIndex(idx))
+    /// Returns the parsed net containing normalized `bit`.
+    pub fn net_for_bit(&self, bit: BitIndex) -> NetIndex {
+        self.normalized.bit(bit).net
+    }
+}
+
+fn build_block_port_bits(
+    normalized: &NormalizedNetlistModule<'_>,
+) -> HashMap<BitIndex, BlockPortBoundary> {
+    let mut block_port_bits = HashMap::new();
+    for port in &normalized.ports {
+        for bit in &port.bits {
+            let entry = block_port_bits
+                .entry(*bit)
                 .or_insert_with(|| BlockPortBoundary {
                     has_input: false,
                     has_output: false,
                     has_inout: false,
                 });
-            match dir {
+            match port.direction {
                 PortDirection::Input => entry.has_input = true,
                 PortDirection::Output => entry.has_output = true,
                 PortDirection::Inout => entry.has_inout = true,
             }
         }
     }
-
-    block_port_nets
+    block_port_bits
 }
 
-fn create_empty_net_neighbors(nets_len: usize) -> Vec<NetNeighbors> {
-    let mut net_neighbors: Vec<NetNeighbors> = Vec::with_capacity(nets_len);
-    net_neighbors.resize_with(nets_len, || NetNeighbors {
+fn create_empty_bit_neighbors(bits_len: usize) -> Vec<BitNeighbors> {
+    let mut bit_neighbors = Vec::with_capacity(bits_len);
+    bit_neighbors.resize_with(bits_len, || BitNeighbors {
         drivers: Vec::new(),
         loads: Vec::new(),
     });
-    net_neighbors
+    bit_neighbors
+}
+
+fn build_assign_connectivity(
+    normalized: &NormalizedNetlistModule<'_>,
+) -> (Vec<Vec<BitIndex>>, Vec<Vec<BitIndex>>) {
+    let mut assign_fanin_bits = vec![Vec::new(); normalized.bit_count()];
+    let mut assign_fanout_bits = vec![Vec::new(); normalized.bit_count()];
+    for assign in &normalized.assigns {
+        for (lhs_bit, rhs_expr) in assign.lhs_bits.iter().copied().zip(&assign.rhs_bits) {
+            let mut rhs_bits = Vec::new();
+            rhs_expr.collect_source_bits(&mut rhs_bits);
+            rhs_bits.sort_unstable();
+            rhs_bits.dedup();
+            for rhs_bit in rhs_bits {
+                extend_unique_bit(&mut assign_fanin_bits[lhs_bit], rhs_bit);
+                extend_unique_bit(&mut assign_fanout_bits[rhs_bit], lhs_bit);
+            }
+        }
+    }
+    (assign_fanin_bits, assign_fanout_bits)
 }
 
 fn build_instance_connectivity(
-    module: &NetlistModule,
-    nets: &[Net],
+    normalized: &NormalizedNetlistModule<'_>,
     interner: &StringInterner<StringBackend<SymbolU32>>,
     lib: &IndexedLibrary,
     module_port_dirs: Option<&HashMap<PortId, HashMap<PortId, PinDirection>>>,
-    net_neighbors: &mut [NetNeighbors],
+    bit_neighbors: &mut [BitNeighbors],
 ) -> Vec<Vec<InstancePortInfo>> {
-    let mut instance_ports: Vec<Vec<InstancePortInfo>> = Vec::with_capacity(module.instances.len());
-    instance_ports.resize_with(module.instances.len(), Vec::new);
+    let mut instance_ports: Vec<Vec<InstancePortInfo>> =
+        Vec::with_capacity(normalized.instances.len());
+    instance_ports.resize_with(normalized.instances.len(), Vec::new);
 
-    for (inst_idx_raw, inst) in module.instances.iter().enumerate() {
-        let inst_idx = InstIndex(inst_idx_raw);
-
-        // Resolve cell or module pin directions once per instance.
+    for inst in &normalized.instances {
+        let inst_idx = inst.raw_index;
         let type_sym = inst.type_name;
         let type_name = resolve_to_string(interner, type_sym);
 
@@ -200,47 +241,66 @@ fn build_instance_connectivity(
         };
 
         let mut ports_for_instance: HashMap<PortId, InstancePortInfo> = HashMap::new();
-
-        for (port_sym, netref) in &inst.connections {
-            let port_name = resolve_to_string(interner, *port_sym);
+        for connection in &inst.connections {
+            let port_name = resolve_to_string(interner, connection.port);
             let dir = *dir_by_pin
                 .get(port_name.as_str())
                 .unwrap_or(&PinDirection::Invalid);
-
             let entry = ports_for_instance
-                .entry(*port_sym)
+                .entry(connection.port)
                 .or_insert_with(|| InstancePortInfo {
-                    port: *port_sym,
+                    port: connection.port,
                     dir,
-                    nets: Vec::new(),
+                    bits: Vec::new(),
                 });
-
-            let mut net_indices: Vec<NetIndex> = Vec::new();
-            netref.collect_net_indices(&mut net_indices);
-
-            for idx in net_indices {
-                if idx.0 >= nets.len() {
-                    continue;
-                }
-                let nn_entry = &mut net_neighbors[idx.0];
+            let mut bit_indices = connection
+                .bits
+                .iter()
+                .filter_map(|source| match source {
+                    BitSource::Bit(bit_idx) => Some(*bit_idx),
+                    BitSource::Literal(_) | BitSource::Unknown => None,
+                })
+                .collect::<Vec<_>>();
+            bit_indices.sort_unstable();
+            bit_indices.dedup();
+            for bit_idx in bit_indices {
+                let neighbors = &mut bit_neighbors[bit_idx];
                 match dir {
-                    PinDirection::Output => nn_entry.drivers.push((inst_idx, *port_sym)),
-                    PinDirection::Input => nn_entry.loads.push((inst_idx, *port_sym)),
+                    PinDirection::Output => {
+                        extend_unique_endpoint(&mut neighbors.drivers, (inst_idx, connection.port))
+                    }
+                    PinDirection::Input => {
+                        extend_unique_endpoint(&mut neighbors.loads, (inst_idx, connection.port))
+                    }
                     PinDirection::Invalid => {
-                        nn_entry.drivers.push((inst_idx, *port_sym));
-                        nn_entry.loads.push((inst_idx, *port_sym));
+                        extend_unique_endpoint(&mut neighbors.drivers, (inst_idx, connection.port));
+                        extend_unique_endpoint(&mut neighbors.loads, (inst_idx, connection.port));
                     }
                 }
-                entry.nets.push(idx);
+                entry.bits.push(bit_idx);
             }
+            entry.bits.sort_unstable();
+            entry.bits.dedup();
         }
 
         let mut ports_vec: Vec<InstancePortInfo> = ports_for_instance.into_values().collect();
-        ports_vec.sort_by_key(|p| resolve_to_string(interner, p.port));
-        instance_ports[inst_idx_raw] = ports_vec;
+        ports_vec.sort_by_key(|port| resolve_to_string(interner, port.port));
+        instance_ports[inst_idx.0] = ports_vec;
     }
 
     instance_ports
+}
+
+fn extend_unique_endpoint(endpoints: &mut Vec<(InstIndex, PortId)>, endpoint: (InstIndex, PortId)) {
+    if !endpoints.contains(&endpoint) {
+        endpoints.push(endpoint);
+    }
+}
+
+fn extend_unique_bit(bits: &mut Vec<BitIndex>, bit: BitIndex) {
+    if !bits.contains(&bit) {
+        bits.push(bit);
+    }
 }
 
 fn build_dir_by_pin_for_instance(
@@ -442,95 +502,133 @@ mod tests {
     #[test]
     fn connectivity_identifies_simple_drivers_and_loads() {
         let (module, nets, interner, indexed) = make_simple_module_and_lib();
-        let conn = NetlistConnectivity::new(&module, &nets, &interner, &indexed, None);
+        let conn = NetlistConnectivity::new(&module, &nets, &interner, &indexed, None)
+            .expect("connectivity");
+        let bit_n0 = conn.normalized.net_bits(NetIndex(0))[0];
+        let bit_n1 = conn.normalized.net_bits(NetIndex(1))[0];
+        let bit_n2 = conn.normalized.net_bits(NetIndex(2))[0];
 
-        // Net 0: driven by no instance (primary input), loaded by u1.A.
-        let loads_n0 = conn.loads_for_net(NetIndex(0));
+        // Bit 0: driven by no instance (primary input), loaded by u1.A.
+        let loads_n0 = conn.loads_for_bit(bit_n0);
         assert_eq!(loads_n0.len(), 1);
 
-        // Net 1: driven by u1.Y, loaded by u2.A.
-        let drivers_n1 = conn.drivers_for_net(NetIndex(1));
-        let loads_n1 = conn.loads_for_net(NetIndex(1));
+        // Bit 1: driven by u1.Y, loaded by u2.A.
+        let drivers_n1 = conn.drivers_for_bit(bit_n1);
+        let loads_n1 = conn.loads_for_bit(bit_n1);
         assert_eq!(drivers_n1.len(), 1);
         assert_eq!(loads_n1.len(), 1);
 
-        // Net 2: driven by u2.Y, no loads.
-        let drivers_n2 = conn.drivers_for_net(NetIndex(2));
-        let loads_n2 = conn.loads_for_net(NetIndex(2));
+        // Bit 2: driven by u2.Y, no loads.
+        let drivers_n2 = conn.drivers_for_bit(bit_n2);
+        let loads_n2 = conn.loads_for_bit(bit_n2);
         assert_eq!(drivers_n2.len(), 1);
         assert!(loads_n2.is_empty());
     }
 
     #[test]
-    fn block_port_nets_match_module_ports() {
+    fn block_port_bits_match_module_ports() {
         let (module, nets, interner, indexed) = make_simple_module_and_lib();
-        let conn = NetlistConnectivity::new(&module, &nets, &interner, &indexed, None);
+        let conn = NetlistConnectivity::new(&module, &nets, &interner, &indexed, None)
+            .expect("connectivity");
+        let bit_n0 = conn.normalized.net_bits(NetIndex(0))[0];
+        let bit_n1 = conn.normalized.net_bits(NetIndex(1))[0];
+        let bit_n2 = conn.normalized.net_bits(NetIndex(2))[0];
 
-        // Net 0 corresponds to primary input "a".
-        assert!(conn.is_block_port_net(NetIndex(0)));
+        // Bit 0 corresponds to primary input "a".
+        assert!(conn.is_block_port_bit(bit_n0));
         let b0 = conn
-            .net_block_port_boundary(NetIndex(0))
-            .expect("net 0 should have block-port metadata");
+            .bit_block_port_boundary(bit_n0)
+            .expect("bit 0 should have block-port metadata");
         assert!(b0.has_input);
         assert!(!b0.has_output);
         assert!(!b0.has_inout);
 
-        // Net 1 is internal-only.
-        assert!(!conn.is_block_port_net(NetIndex(1)));
-        assert!(conn.net_block_port_boundary(NetIndex(1)).is_none());
+        // Bit 1 is internal-only.
+        assert!(!conn.is_block_port_bit(bit_n1));
+        assert!(conn.bit_block_port_boundary(bit_n1).is_none());
 
-        // Net 2 corresponds to primary output "y".
-        assert!(conn.is_block_port_net(NetIndex(2)));
+        // Bit 2 corresponds to primary output "y".
+        assert!(conn.is_block_port_bit(bit_n2));
         let b2 = conn
-            .net_block_port_boundary(NetIndex(2))
-            .expect("net 2 should have block-port metadata");
+            .bit_block_port_boundary(bit_n2)
+            .expect("bit 2 should have block-port metadata");
         assert!(!b2.has_input);
         assert!(b2.has_output);
         assert!(!b2.has_inout);
     }
 
     #[test]
-    fn instance_ports_reports_directions_and_nets() {
+    fn instance_ports_reports_directions_and_bits() {
         let (module, nets, interner, indexed) = make_simple_module_and_lib();
-        let conn = NetlistConnectivity::new(&module, &nets, &interner, &indexed, None);
+        let conn = NetlistConnectivity::new(&module, &nets, &interner, &indexed, None)
+            .expect("connectivity");
+        let bit_n0 = conn.normalized.net_bits(NetIndex(0))[0];
+        let bit_n1 = conn.normalized.net_bits(NetIndex(1))[0];
+        let bit_n2 = conn.normalized.net_bits(NetIndex(2))[0];
 
         // Instance 0: INVX1 u1
         let ports_u1 = conn.instance_ports(InstIndex(0), &interner);
-        let mut rendered_u1: Vec<(String, PinDirection, Vec<NetIndex>)> = Vec::new();
+        let mut rendered_u1: Vec<(String, PinDirection, Vec<BitIndex>)> = Vec::new();
         for p in ports_u1.iter() {
             let name = interner
                 .resolve(p.port)
                 .expect("port symbol should resolve")
                 .to_string();
-            rendered_u1.push((name, p.dir, p.nets.clone()));
+            rendered_u1.push((name, p.dir, p.bits.clone()));
         }
 
         // Expect a deterministic ordering by port name.
         assert_eq!(rendered_u1.len(), 2);
         assert_eq!(rendered_u1[0].0, "A");
         assert_eq!(rendered_u1[0].1, PinDirection::Input);
-        assert_eq!(rendered_u1[0].2, vec![NetIndex(0)]);
+        assert_eq!(rendered_u1[0].2, vec![bit_n0]);
         assert_eq!(rendered_u1[1].0, "Y");
         assert_eq!(rendered_u1[1].1, PinDirection::Output);
-        assert_eq!(rendered_u1[1].2, vec![NetIndex(1)]);
+        assert_eq!(rendered_u1[1].2, vec![bit_n1]);
 
         // Instance 1: INVX1 u2
         let ports_u2 = conn.instance_ports(InstIndex(1), &interner);
-        let mut rendered_u2: Vec<(String, PinDirection, Vec<NetIndex>)> = Vec::new();
+        let mut rendered_u2: Vec<(String, PinDirection, Vec<BitIndex>)> = Vec::new();
         for p in ports_u2.iter() {
             let name = interner
                 .resolve(p.port)
                 .expect("port symbol should resolve")
                 .to_string();
-            rendered_u2.push((name, p.dir, p.nets.clone()));
+            rendered_u2.push((name, p.dir, p.bits.clone()));
         }
 
         assert_eq!(rendered_u2.len(), 2);
         assert_eq!(rendered_u2[0].0, "A");
         assert_eq!(rendered_u2[0].1, PinDirection::Input);
-        assert_eq!(rendered_u2[0].2, vec![NetIndex(1)]);
+        assert_eq!(rendered_u2[0].2, vec![bit_n1]);
         assert_eq!(rendered_u2[1].0, "Y");
         assert_eq!(rendered_u2[1].1, PinDirection::Output);
-        assert_eq!(rendered_u2[1].2, vec![NetIndex(2)]);
+        assert_eq!(rendered_u2[1].2, vec![bit_n2]);
+    }
+
+    #[test]
+    fn connectivity_tracks_normalized_assign_dependencies() {
+        let (mut module, nets, interner, indexed) = make_simple_module_and_lib();
+        module.assigns.push(crate::netlist::parse::NetlistAssign {
+            kind: crate::netlist::parse::NetlistAssignKind::Continuous,
+            lhs: NetRef::Simple(NetIndex(2)),
+            rhs: crate::netlist::parse::AssignExpr::Leaf(NetRef::Simple(NetIndex(1))),
+            span: crate::netlist::parse::Span {
+                start: crate::netlist::parse::Pos {
+                    lineno: 1,
+                    colno: 1,
+                },
+                limit: crate::netlist::parse::Pos {
+                    lineno: 1,
+                    colno: 15,
+                },
+            },
+        });
+        let conn = NetlistConnectivity::new(&module, &nets, &interner, &indexed, None)
+            .expect("connectivity");
+        let bit_n1 = conn.normalized.net_bits(NetIndex(1))[0];
+        let bit_n2 = conn.normalized.net_bits(NetIndex(2))[0];
+        assert_eq!(conn.assign_fanout_bits(bit_n1), &[bit_n2]);
+        assert_eq!(conn.assign_fanin_bits(bit_n2), &[bit_n1]);
     }
 }

--- a/xlsynth-g8r/src/netlist/gatefn_from_netlist.rs
+++ b/xlsynth-g8r/src/netlist/gatefn_from_netlist.rs
@@ -6,8 +6,10 @@ use crate::aig::gate::{AigBitVector, AigOperand, GateFn};
 use crate::gate_builder::{GateBuilder, GateBuilderOptions};
 use crate::liberty::cell_formula::Term;
 use crate::liberty_proto::Library;
-use crate::netlist::bit_ref;
-use crate::netlist::parse::{AssignExpr, Net, NetIndex, NetRef, NetlistModule};
+use crate::netlist::normalized::{
+    BitExpr, BitIndex, BitSource, NormalizedConnection, NormalizedInstance, NormalizedNetlistModule,
+};
+use crate::netlist::parse::{Net, NetlistModule, PortDirection};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use string_interner::symbol::SymbolU32;
@@ -190,358 +192,220 @@ fn build_cell_formula_map(
     Ok(cell_formula_map)
 }
 
-fn check_undriven_nets(
-    used_as_input: &HashSet<SymbolU32>,
-    driven: &HashSet<SymbolU32>,
-    interner: &StringInterner<StringBackend<SymbolU32>>,
-) {
-    for net in used_as_input {
-        if !driven.contains(net) {
-            let net_name = interner.resolve(*net).unwrap_or("<unknown>");
-            panic!(
-                "Net '{}' is used as an input but is never driven by any instance or module input!",
-                net_name
-            );
-        }
-    }
-}
-
-fn net_name(
-    idx: NetIndex,
+fn check_undriven_bits(
+    used_as_input: &HashSet<BitIndex>,
+    driven: &HashSet<BitIndex>,
+    normalized: &NormalizedNetlistModule<'_>,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
-) -> String {
-    interner
-        .resolve(nets[idx.0].name)
-        .unwrap_or("<unknown>")
-        .to_string()
-}
-
-fn select_width_bits(msb: u32, lsb: u32) -> usize {
-    (u32::abs_diff(msb, lsb) as usize) + 1
-}
-
-fn select_bit_number(msb: u32, lsb: u32, bit_offset: usize) -> Option<u32> {
-    if bit_offset >= select_width_bits(msb, lsb) {
-        return None;
+) -> Result<(), String> {
+    for bit_idx in used_as_input {
+        if !driven.contains(bit_idx) {
+            return Err(format!(
+                "net bit '{}' is used as an input but is never driven by any instance, continuous assign, or module input",
+                normalized.render_bit(*bit_idx, nets, interner)
+            ));
+        }
     }
-    let offset = bit_offset as u32;
-    if msb >= lsb {
-        Some(lsb + offset)
-    } else {
-        Some(lsb - offset)
-    }
+    Ok(())
 }
 
-struct ResolvedNetValues {
-    values: HashMap<NetIndex, Vec<Option<AigOperand>>>,
+struct ResolvedBitValues {
+    values: Vec<Option<AigOperand>>,
 }
 
 #[derive(Clone, Copy, Debug)]
 struct PendingAssignBit {
     assign_index: usize,
     rhs_bit_index: usize,
-    target: bit_ref::NetBit,
+    target: BitIndex,
 }
 
-impl ResolvedNetValues {
-    fn new() -> Self {
+impl ResolvedBitValues {
+    fn new(bit_count: usize) -> Self {
         Self {
-            values: HashMap::new(),
+            values: vec![None; bit_count],
         }
     }
 
-    fn seed_input(&mut self, idx: NetIndex, bv: &AigBitVector) {
-        self.values.insert(
-            idx,
-            bv.iter_lsb_to_msb()
-                .map(|bit| Some(*bit))
-                .collect::<Vec<_>>(),
-        );
+    fn resolve_bit(&self, bit_idx: BitIndex) -> Option<AigOperand> {
+        self.values[bit_idx]
     }
 
-    fn ensure_entry(&mut self, idx: NetIndex, width: usize) -> &mut Vec<Option<AigOperand>> {
-        self.values.entry(idx).or_insert_with(|| vec![None; width])
-    }
-
-    fn resolve_bit(
+    fn resolve_source(
         &self,
-        idx: NetIndex,
-        bit_number: u32,
-        nets: &[Net],
-        interner: &StringInterner<StringBackend<SymbolU32>>,
+        source: BitSource,
+        gb: &mut GateBuilder,
     ) -> Result<Option<AigOperand>, String> {
-        let Some(offset) = nets[idx.0].bit_offset(bit_number) else {
-            return Err(format!(
-                "bit {} out of range for net '{}'",
-                bit_number,
-                net_name(idx, nets, interner)
-            ));
-        };
-        Ok(self
-            .values
-            .get(&idx)
-            .and_then(|bits| bits.get(offset))
-            .copied()
-            .flatten())
+        match source {
+            BitSource::Bit(bit_idx) => Ok(self.resolve_bit(bit_idx)),
+            BitSource::Literal(value) => {
+                Ok(Some(if value { gb.get_true() } else { gb.get_false() }))
+            }
+            BitSource::Unknown => Err("unknown literal net reference is not supported".to_string()),
+        }
     }
 
-    fn materialize_ref(
+    fn materialize_sources(
         &self,
-        net_ref: &NetRef,
-        nets: &[Net],
-        interner: &StringInterner<StringBackend<SymbolU32>>,
+        sources: &[BitSource],
         gb: &mut GateBuilder,
     ) -> Result<Option<AigBitVector>, String> {
-        match net_ref {
-            NetRef::Simple(idx) => {
-                let net = &nets[idx.0];
-                let mut bits = Vec::with_capacity(net.width_bits());
-                for offset in 0..net.width_bits() {
-                    let bit_number = net.bit_number(offset).ok_or_else(|| {
-                        format!(
-                            "internal error computing bit {} for net '{}'",
-                            offset,
-                            net_name(*idx, nets, interner)
-                        )
-                    })?;
-                    let Some(bit) = self.resolve_bit(*idx, bit_number, nets, interner)? else {
-                        return Ok(None);
-                    };
-                    bits.push(bit);
-                }
-                Ok(Some(AigBitVector::from_lsb_is_index_0(&bits)))
-            }
-            NetRef::BitSelect(idx, bit) => {
-                let Some(bit) = self.resolve_bit(*idx, *bit, nets, interner)? else {
-                    return Ok(None);
-                };
-                Ok(Some(AigBitVector::from_bit(bit)))
-            }
-            NetRef::PartSelect(idx, msb, lsb) => {
-                let width = select_width_bits(*msb, *lsb);
-                let mut bits = Vec::with_capacity(width);
-                for offset in 0..width {
-                    let bit_number = select_bit_number(*msb, *lsb, offset).ok_or_else(|| {
-                        format!(
-                            "invalid part-select [{}:{}] on net '{}'",
-                            msb,
-                            lsb,
-                            net_name(*idx, nets, interner)
-                        )
-                    })?;
-                    let Some(bit) = self.resolve_bit(*idx, bit_number, nets, interner)? else {
-                        return Ok(None);
-                    };
-                    bits.push(bit);
-                }
-                Ok(Some(AigBitVector::from_lsb_is_index_0(&bits)))
-            }
-            NetRef::Literal(bits) => {
-                let mut ops = Vec::with_capacity(bits.get_bit_count());
-                for i in 0..bits.get_bit_count() {
-                    let bit_is_one = bits.get_bit(i).unwrap_or(false);
-                    ops.push(if bit_is_one {
-                        gb.get_true()
-                    } else {
-                        gb.get_false()
-                    });
-                }
-                Ok(Some(AigBitVector::from_lsb_is_index_0(&ops)))
-            }
-            NetRef::UnknownLiteral(_) => {
-                Err("unknown literal net reference is not supported".to_string())
-            }
-            NetRef::Unconnected => Ok(None),
-            NetRef::Concat(_) => {
-                let bit_refs = bit_ref::net_ref_lsb_bit_refs(net_ref, nets, interner)
-                    .map_err(|e| e.to_string())?;
-                let mut bits = Vec::with_capacity(bit_refs.len());
-                for bit_ref in bit_refs {
-                    match bit_ref {
-                        bit_ref::NetBitRef::Net(bit) => {
-                            let Some(op) =
-                                self.resolve_bit(bit.net, bit.bit_number, nets, interner)?
-                            else {
-                                return Ok(None);
-                            };
-                            bits.push(op);
-                        }
-                        bit_ref::NetBitRef::Literal(value) => {
-                            bits.push(if value { gb.get_true() } else { gb.get_false() })
-                        }
-                        bit_ref::NetBitRef::Unknown => {
-                            return Err(
-                                "unknown literal net reference is not supported".to_string()
-                            );
-                        }
-                    }
-                }
-                Ok(Some(AigBitVector::from_lsb_is_index_0(&bits)))
-            }
+        if sources.is_empty() {
+            return Ok(None);
         }
+        let mut bits = Vec::with_capacity(sources.len());
+        for source in sources {
+            let Some(bit) = self.resolve_source(*source, gb)? else {
+                return Ok(None);
+            };
+            bits.push(bit);
+        }
+        Ok(Some(AigBitVector::from_lsb_is_index_0(&bits)))
     }
 
     fn write_bit(
         &mut self,
-        idx: NetIndex,
-        bit_number: u32,
+        bit_idx: BitIndex,
         value: AigOperand,
+        normalized: &NormalizedNetlistModule<'_>,
         nets: &[Net],
         interner: &StringInterner<StringBackend<SymbolU32>>,
     ) -> Result<(), String> {
-        let net = &nets[idx.0];
-        let width = net.width_bits();
-        let Some(offset) = net.bit_offset(bit_number) else {
-            return Err(format!(
-                "bit {} out of range for net '{}'",
-                bit_number,
-                net_name(idx, nets, interner)
-            ));
-        };
-        let entry = self.ensure_entry(idx, width);
-        if entry[offset].is_some() {
+        if self.values[bit_idx].is_some() {
+            let bit = normalized.bit(bit_idx);
             return Err(format!(
                 "net '{}' bit {} was assigned more than once during projection",
-                net_name(idx, nets, interner),
-                bit_number
+                crate::netlist::bit_ref::net_name(bit.net, nets, interner),
+                bit.bit_number
             ));
         }
-        entry[offset] = Some(value);
+        self.values[bit_idx] = Some(value);
         Ok(())
     }
 
-    fn write_ref(
+    fn write_bits(
         &mut self,
-        dst_ref: &NetRef,
+        targets: &[BitIndex],
         src_bv: &AigBitVector,
+        normalized: &NormalizedNetlistModule<'_>,
         nets: &[Net],
         interner: &StringInterner<StringBackend<SymbolU32>>,
     ) -> Result<(), String> {
-        match dst_ref {
-            NetRef::Simple(idx) => {
-                let net = &nets[idx.0];
-                let width = net.width_bits();
-                if src_bv.get_bit_count() != width {
-                    return Err(format!(
-                        "width mismatch assigning to net '{}': expected {} bits but got {}",
-                        net_name(*idx, nets, interner),
-                        width,
-                        src_bv.get_bit_count()
-                    ));
-                }
-                for offset in 0..width {
-                    let bit_number = net.bit_number(offset).ok_or_else(|| {
-                        format!(
-                            "internal error computing bit {} for net '{}'",
-                            offset,
-                            net_name(*idx, nets, interner)
-                        )
-                    })?;
-                    self.write_bit(*idx, bit_number, *src_bv.get_lsb(offset), nets, interner)?;
-                }
-                Ok(())
-            }
-            NetRef::BitSelect(idx, bit) => {
-                if src_bv.get_bit_count() != 1 {
-                    return Err(format!(
-                        "width mismatch assigning to net '{}[{}]': expected 1 bit but got {}",
-                        net_name(*idx, nets, interner),
-                        bit,
-                        src_bv.get_bit_count()
-                    ));
-                }
-                self.write_bit(*idx, *bit, *src_bv.get_lsb(0), nets, interner)
-            }
-            NetRef::PartSelect(idx, msb, lsb) => {
-                let width = select_width_bits(*msb, *lsb);
-                if src_bv.get_bit_count() != width {
-                    return Err(format!(
-                        "width mismatch assigning to net '{}[{}:{}]': expected {} bits but got {}",
-                        net_name(*idx, nets, interner),
-                        msb,
-                        lsb,
-                        width,
-                        src_bv.get_bit_count()
-                    ));
-                }
-                for offset in 0..width {
-                    let bit_number = select_bit_number(*msb, *lsb, offset).ok_or_else(|| {
-                        format!(
-                            "invalid part-select [{}:{}] on net '{}'",
-                            msb,
-                            lsb,
-                            net_name(*idx, nets, interner)
-                        )
-                    })?;
-                    self.write_bit(*idx, bit_number, *src_bv.get_lsb(offset), nets, interner)?;
-                }
-                Ok(())
-            }
-            NetRef::Literal(_) | NetRef::UnknownLiteral(_) => {
-                Err("output destination cannot be a literal".to_string())
-            }
-            NetRef::Unconnected => Ok(()),
-            NetRef::Concat(_) => {
-                let targets = bit_ref::net_ref_lsb_targets(dst_ref, nets, interner)
-                    .map_err(|e| e.to_string())?;
-                if src_bv.get_bit_count() != targets.len() {
-                    return Err(format!(
-                        "width mismatch assigning to '{}': expected {} bits but got {}",
-                        bit_ref::render_net_ref(dst_ref, nets, interner),
-                        targets.len(),
-                        src_bv.get_bit_count()
-                    ));
-                }
-                for (offset, target) in targets.iter().copied().enumerate() {
-                    self.write_bit(
-                        target.net,
-                        target.bit_number,
-                        *src_bv.get_lsb(offset),
-                        nets,
-                        interner,
-                    )?;
-                }
-                Ok(())
-            }
+        if targets.is_empty() {
+            return Ok(());
         }
+        if src_bv.get_bit_count() != targets.len() {
+            return Err(format!(
+                "width mismatch assigning to '{}': expected {} bits but got {}",
+                normalized.render_bit(targets[0], nets, interner),
+                targets.len(),
+                src_bv.get_bit_count()
+            ));
+        }
+        for (offset, target) in targets.iter().copied().enumerate() {
+            self.write_bit(target, *src_bv.get_lsb(offset), normalized, nets, interner)?;
+        }
+        Ok(())
     }
 
     fn materialize_output_or_false(
         &self,
-        idx: NetIndex,
-        nets: &[Net],
-        interner: &StringInterner<StringBackend<SymbolU32>>,
+        output_bits: &[BitIndex],
         gb: &mut GateBuilder,
-    ) -> Result<AigBitVector, String> {
-        let net = &nets[idx.0];
-        let mut bits = Vec::with_capacity(net.width_bits());
-        for offset in 0..net.width_bits() {
-            let bit_number = net.bit_number(offset).ok_or_else(|| {
-                format!(
-                    "internal error computing bit {} for net '{}'",
-                    offset,
-                    net_name(idx, nets, interner)
-                )
-            })?;
-            bits.push(
-                self.resolve_bit(idx, bit_number, nets, interner)?
-                    .unwrap_or_else(|| gb.get_false()),
-            );
+    ) -> AigBitVector {
+        let bits = output_bits
+            .iter()
+            .map(|bit_idx| self.resolve_bit(*bit_idx).unwrap_or_else(|| gb.get_false()))
+            .collect::<Vec<_>>();
+        AigBitVector::from_lsb_is_index_0(&bits)
+    }
+}
+
+fn collect_expr_source_bits(expr: &BitExpr, out: &mut HashSet<BitIndex>) {
+    let mut bits = Vec::new();
+    expr.collect_source_bits(&mut bits);
+    out.extend(bits);
+}
+
+fn output_target_bits(connection: &NormalizedConnection) -> Result<Vec<BitIndex>, String> {
+    connection
+        .bits
+        .iter()
+        .map(|source| match source {
+            BitSource::Bit(bit_idx) => Ok(*bit_idx),
+            BitSource::Literal(_) | BitSource::Unknown => {
+                Err("output destination cannot be a literal or unknown".to_string())
+            }
+        })
+        .collect()
+}
+
+fn eval_bit_expr(
+    expr: &BitExpr,
+    resolved: &ResolvedBitValues,
+    gb: &mut GateBuilder,
+) -> Result<Option<AigOperand>, String> {
+    match expr {
+        BitExpr::Source(source) => resolved.resolve_source(*source, gb),
+        BitExpr::Not(inner) => {
+            let Some(value) = eval_bit_expr(inner, resolved, gb)? else {
+                return Ok(None);
+            };
+            Ok(Some(gb.add_not(value)))
         }
-        Ok(AigBitVector::from_lsb_is_index_0(&bits))
+        BitExpr::And(lhs, rhs) | BitExpr::Or(lhs, rhs) | BitExpr::Xor(lhs, rhs) => {
+            let Some(lhs_value) = eval_bit_expr(lhs, resolved, gb)? else {
+                return Ok(None);
+            };
+            let Some(rhs_value) = eval_bit_expr(rhs, resolved, gb)? else {
+                return Ok(None);
+            };
+            Ok(Some(match expr {
+                BitExpr::And(_, _) => gb.add_and_binary(lhs_value, rhs_value),
+                BitExpr::Or(_, _) => gb.add_or_binary(lhs_value, rhs_value),
+                BitExpr::Xor(_, _) => gb.add_xor_binary(lhs_value, rhs_value),
+                BitExpr::Source(_) | BitExpr::Not(_) => unreachable!(),
+            }))
+        }
+    }
+}
+
+fn collect_missing_expr_sources(
+    expr: &BitExpr,
+    resolved: &ResolvedBitValues,
+    normalized: &NormalizedNetlistModule<'_>,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    out: &mut Vec<String>,
+) {
+    match expr {
+        BitExpr::Source(BitSource::Bit(bit_idx)) => {
+            if resolved.resolve_bit(*bit_idx).is_none() {
+                out.push(normalized.render_bit(*bit_idx, nets, interner));
+            }
+        }
+        BitExpr::Source(BitSource::Literal(_) | BitSource::Unknown) => {}
+        BitExpr::Not(inner) => {
+            collect_missing_expr_sources(inner, resolved, normalized, nets, interner, out)
+        }
+        BitExpr::And(lhs, rhs) | BitExpr::Or(lhs, rhs) | BitExpr::Xor(lhs, rhs) => {
+            collect_missing_expr_sources(lhs, resolved, normalized, nets, interner, out);
+            collect_missing_expr_sources(rhs, resolved, normalized, nets, interner, out);
+        }
     }
 }
 
 fn process_instance_outputs(
-    inst: &crate::netlist::parse::NetlistInstance,
+    inst: &NormalizedInstance,
     type_name: &str,
     inst_name: &str,
     pin_directions: &HashMap<&str, i32>,
     interner: &StringInterner<StringBackend<SymbolU32>>,
     nets: &[Net],
     gb: &mut GateBuilder,
-    resolved: &mut ResolvedNetValues,
+    resolved: &mut ResolvedBitValues,
+    normalized: &NormalizedNetlistModule<'_>,
     dff_cells_identity: &std::collections::HashSet<String>,
     dff_cells_inverted: &std::collections::HashSet<String>,
     cell_formula_map: &HashMap<(String, String), (crate::liberty::cell_formula::Term, String)>,
@@ -549,8 +413,8 @@ fn process_instance_outputs(
     port_map: &HashMap<String, String>,
 ) -> Result<bool, String> {
     let mut processed_any_output = false;
-    for (port, netref) in &inst.connections {
-        let port_name = interner.resolve(*port).unwrap();
+    for connection in &inst.connections {
+        let port_name = interner.resolve(connection.port).unwrap();
         let pin_dir = *pin_directions.get(port_name).unwrap_or(&0); // 1=OUTPUT, 2=INPUT
         if pin_dir == 1 {
             if handle_dff_identity_override(
@@ -561,6 +425,7 @@ fn process_instance_outputs(
                 interner,
                 gb,
                 resolved,
+                normalized,
                 dff_cells_identity,
                 dff_cells_inverted,
                 nets,
@@ -588,7 +453,8 @@ fn process_instance_outputs(
                     )
                 })?;
             let src_bv = AigBitVector::from_bit(out_op);
-            resolved.write_ref(netref, &src_bv, nets, interner)?;
+            let output_bits = output_target_bits(connection)?;
+            resolved.write_bits(output_bits.as_slice(), &src_bv, normalized, nets, interner)?;
             processed_any_output = true;
         }
     }
@@ -632,6 +498,8 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
     dff_cells_inverted: &std::collections::HashSet<String>,
     options: &GateFnProjectOptions,
 ) -> Result<GateFn, String> {
+    let normalized =
+        NormalizedNetlistModule::new(module, nets, interner).map_err(|e| e.to_string())?;
     let used_cell_names: HashSet<String> = module
         .instances
         .iter()
@@ -646,30 +514,24 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
     )?;
     let module_name = interner.resolve(module.name).unwrap();
     let mut gb = GateBuilder::new(module_name.to_string(), GateBuilderOptions::no_opt());
-    let mut resolved = ResolvedNetValues::new();
-    collect_module_io_nets(module, nets, interner, &mut gb, &mut resolved);
-    let module_output_bits = collect_module_output_bits(module, nets)?;
-    let mut pending_assigns = build_pending_assign_bits(module, nets, interner)?;
+    let mut resolved = ResolvedBitValues::new(normalized.bit_count());
+    collect_module_io_bits(&normalized, nets, interner, &mut gb, &mut resolved)?;
+    let module_output_bits = collect_module_output_bits(&normalized);
+    let mut pending_assigns = build_pending_assign_bits(&normalized);
     let mut used_as_input = HashSet::new();
     let mut driven = HashSet::new();
-    for port in &module.ports {
-        if port.direction == crate::netlist::parse::PortDirection::Input {
-            driven.insert(port.name);
+    for port in &normalized.ports {
+        if port.direction == PortDirection::Input {
+            driven.extend(port.bits.iter().copied());
         }
     }
-    for assign in &module.assigns {
-        let mut lhs_nets = Vec::new();
-        assign.lhs.collect_net_indices(&mut lhs_nets);
-        for net_idx in lhs_nets {
-            driven.insert(nets[net_idx.0].name);
-        }
-        let mut rhs_nets = Vec::new();
-        assign.rhs.collect_net_indices(&mut rhs_nets);
-        for net_idx in rhs_nets {
-            used_as_input.insert(nets[net_idx.0].name);
+    for assign in &normalized.assigns {
+        driven.extend(assign.lhs_bits.iter().copied());
+        for rhs in &assign.rhs_bits {
+            collect_expr_source_bits(rhs, &mut used_as_input);
         }
     }
-    for inst in &module.instances {
+    for inst in &normalized.instances {
         let type_name = interner.resolve(inst.type_name).unwrap();
         let cell = liberty_lib
             .cells
@@ -680,34 +542,27 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
         for pin in &cell.pins {
             pin_directions.insert(pin.name.as_str(), pin.direction);
         }
-        for (port, netref) in &inst.connections {
-            let port_name = interner.resolve(*port).unwrap();
+        for connection in &inst.connections {
+            let port_name = interner.resolve(connection.port).unwrap();
             let pin_dir = *pin_directions.get(port_name).unwrap_or(&0); // 1=OUTPUT, 2=INPUT
-            match netref {
-                crate::netlist::parse::NetRef::Simple(net_idx)
-                | crate::netlist::parse::NetRef::BitSelect(net_idx, _)
-                | crate::netlist::parse::NetRef::PartSelect(net_idx, _, _) => {
-                    if pin_dir == 1 {
-                        driven.insert(nets[net_idx.0].name);
-                    } else if pin_dir == 2 {
-                        used_as_input.insert(nets[net_idx.0].name);
-                    }
-                }
-                crate::netlist::parse::NetRef::Unconnected => {
-                    // Do not count as driven/used.
-                }
-                _ => {}
+            if pin_dir == 1 {
+                driven.extend(output_target_bits(connection)?);
+            } else if pin_dir == 2 {
+                used_as_input.extend(connection.bits.iter().filter_map(|source| match source {
+                    BitSource::Bit(bit_idx) => Some(*bit_idx),
+                    BitSource::Literal(_) | BitSource::Unknown => None,
+                }));
             }
         }
     }
-    check_undriven_nets(&used_as_input, &driven, interner);
-    let mut unprocessed: Vec<_> = module.instances.iter().collect();
+    check_undriven_bits(&used_as_input, &driven, &normalized, nets, interner)?;
+    let mut unprocessed: Vec<_> = normalized.instances.iter().collect();
     let mut processed_any = true;
     while (!unprocessed.is_empty() || !pending_assigns.is_empty()) && processed_any {
         processed_any = false;
         let (next_pending_assigns, processed_assign) = process_pending_assign_bits(
             pending_assigns,
-            module,
+            &normalized,
             &mut resolved,
             nets,
             interner,
@@ -729,8 +584,15 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
             for pin in &cell.pins {
                 pin_directions.insert(pin.name.as_str(), pin.direction);
             }
-            let (input_map, missing_inputs, port_map) =
-                build_instance_input_map(inst, &pin_directions, interner, nets, &resolved, &mut gb);
+            let (input_map, missing_inputs, port_map) = build_instance_input_map(
+                inst,
+                &pin_directions,
+                interner,
+                nets,
+                &resolved,
+                &mut gb,
+                &normalized,
+            );
             if !missing_inputs.is_empty() {
                 log::trace!(
                     "Skipping instance '{}' (cell '{}') due to missing input nets: {:?}",
@@ -750,6 +612,7 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
                 nets,
                 &mut gb,
                 &mut resolved,
+                &normalized,
                 dff_cells_identity,
                 dff_cells_inverted,
                 &cell_formula_map,
@@ -795,6 +658,7 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
                     nets,
                     &resolved,
                     &mut gb,
+                    &normalized,
                 );
                 if missing_inputs.is_empty() {
                     diag_lines.push(format!(
@@ -832,97 +696,92 @@ pub fn project_gatefn_from_netlist_and_liberty_with_options(
                     pending_assigns.len()
                 ));
                 for pending_bit in pending_assigns.iter().take(10) {
-                    let assign = &module.assigns[pending_bit.assign_index];
-                    msg.push_str(&format!(
-                        "- assign to '{}' at {} remains unresolved\n",
-                        bit_ref::render_net_bit(pending_bit.target, nets, interner),
-                        assign.span.to_human_string()
-                    ));
+                    let assign = &normalized.assigns[pending_bit.assign_index];
+                    let mut missing = Vec::new();
+                    collect_missing_expr_sources(
+                        &assign.rhs_bits[pending_bit.rhs_bit_index],
+                        &resolved,
+                        &normalized,
+                        nets,
+                        interner,
+                        &mut missing,
+                    );
+                    missing.sort();
+                    missing.dedup();
+                    if missing.is_empty() {
+                        msg.push_str(&format!(
+                            "- assign to '{}' at {} remains unresolved\n",
+                            normalized.render_bit(pending_bit.target, nets, interner),
+                            assign.span.to_human_string()
+                        ));
+                    } else {
+                        msg.push_str(&format!(
+                            "- assign to '{}' at {} is waiting on [{}]\n",
+                            normalized.render_bit(pending_bit.target, nets, interner),
+                            assign.span.to_human_string(),
+                            missing.join(", ")
+                        ));
+                    }
                 }
             }
             msg.push_str(r#"Hint: re-run with RUST_LOG=trace to log skipped instances and their missing nets during processing."#);
             return Err(msg);
         }
     }
-    for port in &module.ports {
-        if port.direction == crate::netlist::parse::PortDirection::Output {
-            let net_idx = nets
-                .iter()
-                .position(|n| n.name == port.name)
-                .map(NetIndex)
-                .ok_or("output port net not found")?;
-            let net = &nets[net_idx.0];
-            let net_name = interner.resolve(net.name).unwrap();
-            let width = net.width_bits();
-            let bv = resolved.materialize_output_or_false(net_idx, nets, interner, &mut gb)?;
+    for port in &normalized.ports {
+        if port.direction == PortDirection::Output {
+            let net_name = interner.resolve(port.name).unwrap();
+            let bv = resolved.materialize_output_or_false(port.bits.as_slice(), &mut gb);
             assert_eq!(
                 bv.get_bit_count(),
-                width,
+                port.bits.len(),
                 "Output net '{}' width mismatch",
                 net_name
             );
-            gb.add_output(net_name.to_string(), bv.clone());
+            gb.add_output(net_name.to_string(), bv);
         }
     }
     Ok(gb.build())
 }
 
-fn collect_module_io_nets(
-    module: &NetlistModule,
+fn collect_module_io_bits(
+    normalized: &NormalizedNetlistModule<'_>,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
     gb: &mut GateBuilder,
-    resolved: &mut ResolvedNetValues,
-) {
-    for port in &module.ports {
-        if port.direction == crate::netlist::parse::PortDirection::Input {
-            let net_idx = nets
-                .iter()
-                .position(|n| n.name == port.name)
-                .map(NetIndex)
-                .expect("input port net not found");
-            let net = &nets[net_idx.0];
-            let net_name = interner.resolve(net.name).unwrap();
-            let width = net.width_bits();
-            let bv = gb.add_input(net_name.to_string(), width);
-            resolved.seed_input(net_idx, &bv);
+    resolved: &mut ResolvedBitValues,
+) -> Result<(), String> {
+    for port in &normalized.ports {
+        if port.direction == PortDirection::Input {
+            let port_name = interner.resolve(port.name).unwrap();
+            let bv = gb.add_input(port_name.to_string(), port.bits.len());
+            for (bit_idx, bit) in port.bits.iter().copied().zip(bv.iter_lsb_to_msb()) {
+                resolved.write_bit(bit_idx, *bit, normalized, nets, interner)?;
+            }
         }
     }
+    Ok(())
 }
 
-fn collect_module_output_bits(
-    module: &NetlistModule,
-    nets: &[Net],
-) -> Result<HashSet<bit_ref::NetBit>, String> {
+fn collect_module_output_bits(normalized: &NormalizedNetlistModule<'_>) -> HashSet<BitIndex> {
     let mut output_bits = HashSet::new();
-    for port in &module.ports {
-        if port.direction != crate::netlist::parse::PortDirection::Output {
+    for port in &normalized.ports {
+        if port.direction != PortDirection::Output {
             continue;
         }
-        let net_idx = module
-            .find_net_index(port.name, nets)
-            .ok_or_else(|| "output port net not found".to_string())?;
-        let net = &nets[net_idx.0];
-        for offset in 0..net.width_bits() {
-            let bit_number = net
-                .bit_number(offset)
-                .ok_or_else(|| "internal error computing output bit number".to_string())?;
-            output_bits.insert(bit_ref::NetBit {
-                net: net_idx,
-                bit_number,
-            });
-        }
+        output_bits.extend(port.bits.iter().copied());
     }
-    Ok(output_bits)
+    output_bits
 }
 
 fn build_instance_input_map(
-    inst: &crate::netlist::parse::NetlistInstance,
+    inst: &NormalizedInstance,
     pin_directions: &HashMap<&str, i32>,
     interner: &StringInterner<StringBackend<SymbolU32>>,
     nets: &[Net],
-    resolved: &ResolvedNetValues,
+    resolved: &ResolvedBitValues,
     gb: &mut GateBuilder,
+    normalized: &NormalizedNetlistModule<'_>,
 ) -> (
     HashMap<String, AigOperand>,
     Vec<String>,
@@ -931,115 +790,30 @@ fn build_instance_input_map(
     let mut input_map = HashMap::new();
     let mut missing_inputs = Vec::new();
     let mut port_map = HashMap::new();
-    for (port, netref) in &inst.connections {
-        let port_name = interner.resolve(*port).unwrap();
+    for connection in &inst.connections {
+        let port_name = interner.resolve(connection.port).unwrap();
         let pin_dir = *pin_directions.get(port_name).unwrap_or(&0); // 1=OUTPUT, 2=INPUT
-        let net_name_str = match netref {
-            crate::netlist::parse::NetRef::Simple(net_idx) => interner
-                .resolve(nets[net_idx.0].name)
-                .unwrap_or("<unknown>")
-                .to_string(),
-            crate::netlist::parse::NetRef::BitSelect(net_idx, bit) => format!(
-                "{}[{}]",
-                interner
-                    .resolve(nets[net_idx.0].name)
-                    .unwrap_or("<unknown>"),
-                bit
-            ),
-            crate::netlist::parse::NetRef::PartSelect(net_idx, msb, lsb) => format!(
-                "{}[{}:{}]",
-                interner
-                    .resolve(nets[net_idx.0].name)
-                    .unwrap_or("<unknown>"),
-                msb,
-                lsb
-            ),
-            crate::netlist::parse::NetRef::Literal(bits) => format!("{}", bits),
-            crate::netlist::parse::NetRef::UnknownLiteral(width) => format!("{}'hx", width),
-            crate::netlist::parse::NetRef::Unconnected => "<unconnected>".to_string(),
-            crate::netlist::parse::NetRef::Concat(_) => "<concat>".to_string(),
-        };
-        port_map.insert(port_name.to_string(), net_name_str);
+        port_map.insert(
+            port_name.to_string(),
+            normalized.render_sources(connection.bits.as_slice(), nets, interner),
+        );
         if pin_dir == 2 {
-            match netref {
-                NetRef::Simple(net_idx) => {
-                    let materialized = resolved.materialize_ref(netref, nets, interner, gb);
-                    match materialized {
-                        Ok(Some(bv)) => {
-                            if bv.get_bit_count() == 1 {
-                                input_map.insert(port_name.to_string(), *bv.get_lsb(0));
-                            }
-                        }
-                        Ok(None) => {
-                            missing_inputs.push(format!(
-                                "{} (NetIndex({}), name='{}')",
-                                port_name,
-                                net_idx.0,
-                                net_name(*net_idx, nets, interner)
-                            ));
-                        }
-                        Err(e) => missing_inputs.push(format!("{} ({})", port_name, e)),
+            if connection.bits.is_empty() {
+                missing_inputs.push(format!("{} (<unconnected>)", port_name));
+                continue;
+            }
+            match resolved.materialize_sources(connection.bits.as_slice(), gb) {
+                Ok(Some(bv)) => {
+                    if bv.get_bit_count() == 1 {
+                        input_map.insert(port_name.to_string(), *bv.get_lsb(0));
                     }
                 }
-                NetRef::BitSelect(net_idx, bit) => {
-                    match resolved.materialize_ref(netref, nets, interner, gb) {
-                        Ok(Some(bv)) => {
-                            input_map.insert(port_name.to_string(), *bv.get_lsb(0));
-                        }
-                        Ok(None) => {
-                            missing_inputs.push(format!(
-                                "{} (NetIndex({}), name='{}', bit={})",
-                                port_name,
-                                net_idx.0,
-                                net_name(*net_idx, nets, interner),
-                                bit
-                            ));
-                        }
-                        Err(e) => missing_inputs.push(format!("{} ({})", port_name, e)),
-                    }
-                }
-                NetRef::PartSelect(net_idx, msb, lsb) => {
-                    match resolved.materialize_ref(netref, nets, interner, gb) {
-                        Ok(Some(bv)) => {
-                            if bv.get_bit_count() == 1 {
-                                input_map.insert(port_name.to_string(), *bv.get_lsb(0));
-                            }
-                        }
-                        Ok(None) => {
-                            missing_inputs.push(format!(
-                                "{} (NetIndex({}), name='{}', part-select=[{}:{}])",
-                                port_name,
-                                net_idx.0,
-                                net_name(*net_idx, nets, interner),
-                                msb,
-                                lsb
-                            ));
-                        }
-                        Err(e) => missing_inputs.push(format!("{} ({})", port_name, e)),
-                    }
-                }
-                NetRef::Literal(bits) => {
-                    let bit_count = bits.get_bit_count();
-                    assert_eq!(bit_count, 1);
-                    let is_one = bits.get_bit(0).unwrap();
-                    let val = if is_one {
-                        gb.get_true()
-                    } else {
-                        gb.get_false()
-                    };
-                    input_map.insert(port_name.to_string(), val);
-                }
-                NetRef::UnknownLiteral(_) => {
-                    missing_inputs.push(format!("{} (<unknown-literal-unsupported>)", port_name));
-                }
-                NetRef::Unconnected => {
-                    // Treat as a hard missing input and surface clearly.
-                    missing_inputs.push(format!("{} (<unconnected>)", port_name));
-                }
-                NetRef::Concat(_) => {
-                    // Currently unsupported for cell inputs; surface clearly.
-                    missing_inputs.push(format!("{} (<concat-unsupported>)", port_name));
-                }
+                Ok(None) => missing_inputs.push(format!(
+                    "{} ({})",
+                    port_name,
+                    normalized.render_sources(connection.bits.as_slice(), nets, interner)
+                )),
+                Err(e) => missing_inputs.push(format!("{} ({})", port_name, e)),
             }
         }
     }
@@ -1056,182 +830,41 @@ fn invert_bv(gb: &mut GateBuilder, src: &AigBitVector) -> AigBitVector {
 }
 
 fn build_d_bv(
-    d_netref: &NetRef,
+    d_connection: &NormalizedConnection,
     gb: &mut GateBuilder,
-    resolved: &ResolvedNetValues,
-    nets: &[Net],
-    interner: &StringInterner<StringBackend<SymbolU32>>,
+    resolved: &ResolvedBitValues,
     invert: bool,
 ) -> Result<Option<AigBitVector>, String> {
-    let Some(bv) = resolved.materialize_ref(d_netref, nets, interner, gb)? else {
+    let Some(bv) = resolved.materialize_sources(d_connection.bits.as_slice(), gb)? else {
         return Ok(None);
     };
     Ok(Some(if invert { invert_bv(gb, &bv) } else { bv }))
 }
 
 fn write_bv_to_port_destination(
-    inst: &crate::netlist::parse::NetlistInstance,
+    inst: &NormalizedInstance,
     interner: &StringInterner<StringBackend<SymbolU32>>,
-    resolved: &mut ResolvedNetValues,
+    resolved: &mut ResolvedBitValues,
+    normalized: &NormalizedNetlistModule<'_>,
     nets: &[Net],
     target_port_ci: &str,
     src_bv: &AigBitVector,
 ) -> Result<(), String> {
-    for (p, dst_ref) in &inst.connections {
-        let pname = interner.resolve(*p).unwrap();
+    for connection in &inst.connections {
+        let pname = interner.resolve(connection.port).unwrap();
         if !pname.eq_ignore_ascii_case(target_port_ci) {
             continue;
         }
-        match dst_ref {
-            NetRef::Simple(_)
-            | NetRef::BitSelect(_, _)
-            | NetRef::PartSelect(_, _, _)
-            | NetRef::Concat(_) => {
-                resolved.write_ref(dst_ref, src_bv, nets, interner)?;
-            }
-            NetRef::Literal(_) | NetRef::UnknownLiteral(_) => {
-                log::warn!(
-                    "DFF override: destination output as literal not supported for port '{}'",
-                    pname
-                );
-            }
-            NetRef::Unconnected => {
-                // Nothing to write.
-            }
-        }
+        let output_bits = output_target_bits(connection)?;
+        resolved.write_bits(output_bits.as_slice(), src_bv, normalized, nets, interner)?;
     }
     Ok(())
 }
 
-fn is_bare_literal_assign_expr(expr: &AssignExpr) -> bool {
-    matches!(expr, AssignExpr::Leaf(NetRef::Literal(_)))
-}
-
-fn eval_assign_net_ref_bit(
-    net_ref: &NetRef,
-    rhs_bit_index: usize,
-    allow_literal_zero_extend: bool,
-    resolved: &ResolvedNetValues,
-    nets: &[Net],
-    interner: &StringInterner<StringBackend<SymbolU32>>,
-    gb: &mut GateBuilder,
-) -> Result<Option<AigOperand>, String> {
-    let bit_refs =
-        bit_ref::net_ref_lsb_bit_refs(net_ref, nets, interner).map_err(|e| e.to_string())?;
-    if rhs_bit_index >= bit_refs.len() {
-        if allow_literal_zero_extend && matches!(net_ref, NetRef::Literal(_)) {
-            return Ok(Some(gb.get_false()));
-        }
-        return Err(format!(
-            "bit {} out of range for {}-bit expression '{}'",
-            rhs_bit_index,
-            bit_refs.len(),
-            bit_ref::render_net_ref(net_ref, nets, interner)
-        ));
-    }
-    match bit_refs[rhs_bit_index] {
-        bit_ref::NetBitRef::Net(bit) => {
-            resolved.resolve_bit(bit.net, bit.bit_number, nets, interner)
-        }
-        bit_ref::NetBitRef::Literal(value) => {
-            Ok(Some(if value { gb.get_true() } else { gb.get_false() }))
-        }
-        bit_ref::NetBitRef::Unknown => {
-            Err("unknown literal net reference is not supported".to_string())
-        }
-    }
-}
-
-fn eval_assign_expr_bit(
-    expr: &AssignExpr,
-    rhs_bit_index: usize,
-    allow_literal_zero_extend: bool,
-    resolved: &ResolvedNetValues,
-    nets: &[Net],
-    interner: &StringInterner<StringBackend<SymbolU32>>,
-    gb: &mut GateBuilder,
-) -> Result<Option<AigOperand>, String> {
-    match expr {
-        AssignExpr::Leaf(net_ref) => eval_assign_net_ref_bit(
-            net_ref,
-            rhs_bit_index,
-            allow_literal_zero_extend,
-            resolved,
-            nets,
-            interner,
-            gb,
-        ),
-        AssignExpr::Not(inner) => {
-            let Some(value) = eval_assign_expr_bit(
-                inner,
-                rhs_bit_index,
-                allow_literal_zero_extend,
-                resolved,
-                nets,
-                interner,
-                gb,
-            )?
-            else {
-                return Ok(None);
-            };
-            Ok(Some(gb.add_not(value)))
-        }
-        AssignExpr::And(lhs, rhs) | AssignExpr::Or(lhs, rhs) | AssignExpr::Xor(lhs, rhs) => {
-            let Some(lhs_value) = eval_assign_expr_bit(
-                lhs,
-                rhs_bit_index,
-                allow_literal_zero_extend,
-                resolved,
-                nets,
-                interner,
-                gb,
-            )?
-            else {
-                return Ok(None);
-            };
-            let Some(rhs_value) = eval_assign_expr_bit(
-                rhs,
-                rhs_bit_index,
-                allow_literal_zero_extend,
-                resolved,
-                nets,
-                interner,
-                gb,
-            )?
-            else {
-                return Ok(None);
-            };
-            Ok(Some(match expr {
-                AssignExpr::And(_, _) => gb.add_and_binary(lhs_value, rhs_value),
-                AssignExpr::Or(_, _) => gb.add_or_binary(lhs_value, rhs_value),
-                AssignExpr::Xor(_, _) => gb.add_xor_binary(lhs_value, rhs_value),
-                _ => unreachable!(),
-            }))
-        }
-    }
-}
-
-fn build_pending_assign_bits(
-    module: &NetlistModule,
-    nets: &[Net],
-    interner: &StringInterner<StringBackend<SymbolU32>>,
-) -> Result<Vec<PendingAssignBit>, String> {
+fn build_pending_assign_bits(normalized: &NormalizedNetlistModule<'_>) -> Vec<PendingAssignBit> {
     let mut pending = Vec::new();
-    for (assign_index, assign) in module.assigns.iter().enumerate() {
-        let lhs_bits =
-            bit_ref::net_ref_lsb_targets(&assign.lhs, nets, interner).map_err(|e| e.to_string())?;
-        let rhs_width = bit_ref::assign_expr_width_bits(&assign.rhs, nets, interner)
-            .map_err(|e| e.to_string())?;
-        let allow_literal_zero_extend = is_bare_literal_assign_expr(&assign.rhs);
-        if lhs_bits.len() != rhs_width && !allow_literal_zero_extend {
-            return Err(format!(
-                "assign to '{}' has lhs width {} but rhs width {}; Liberty-backed projection requires exact-width assigns except for bare literal tie-offs",
-                bit_ref::render_net_ref(&assign.lhs, nets, interner),
-                lhs_bits.len(),
-                rhs_width
-            ));
-        }
-        for (rhs_bit_index, target) in lhs_bits.into_iter().enumerate() {
+    for (assign_index, assign) in normalized.assigns.iter().enumerate() {
+        for (rhs_bit_index, target) in assign.lhs_bits.iter().copied().enumerate() {
             pending.push(PendingAssignBit {
                 assign_index,
                 rhs_bit_index,
@@ -1239,13 +872,13 @@ fn build_pending_assign_bits(
             });
         }
     }
-    Ok(pending)
+    pending
 }
 
 fn process_pending_assign_bits(
     pending: Vec<PendingAssignBit>,
-    module: &NetlistModule,
-    resolved: &mut ResolvedNetValues,
+    normalized: &NormalizedNetlistModule<'_>,
+    resolved: &mut ResolvedBitValues,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
     gb: &mut GateBuilder,
@@ -1253,27 +886,13 @@ fn process_pending_assign_bits(
     let mut next_pending = Vec::new();
     let mut processed_any = false;
     for pending_bit in pending {
-        let assign = &module.assigns[pending_bit.assign_index];
-        let Some(value) = eval_assign_expr_bit(
-            &assign.rhs,
-            pending_bit.rhs_bit_index,
-            is_bare_literal_assign_expr(&assign.rhs),
-            resolved,
-            nets,
-            interner,
-            gb,
-        )?
+        let assign = &normalized.assigns[pending_bit.assign_index];
+        let Some(value) = eval_bit_expr(&assign.rhs_bits[pending_bit.rhs_bit_index], resolved, gb)?
         else {
             next_pending.push(pending_bit);
             continue;
         };
-        resolved.write_bit(
-            pending_bit.target.net,
-            pending_bit.target.bit_number,
-            value,
-            nets,
-            interner,
-        )?;
+        resolved.write_bit(pending_bit.target, value, normalized, nets, interner)?;
         processed_any = true;
     }
     Ok((next_pending, processed_any))
@@ -1282,10 +901,7 @@ fn process_pending_assign_bits(
 /// Implements DFF output overrides for identity (Q=D) and inverted (QN=NOT(D)).
 ///
 /// This bypasses formula emission by directly wiring from the connected `D`
-/// netref into the `Q`/`QN` destination, supporting Simple, BitSelect, and
-/// PartSelect on the destination side. Destination bitvectors are sized to the
-/// full declared width of the destination net, and part-selects are written at
-/// the correct least-significant-bit offset.
+/// bits into the `Q`/`QN` destination bits after normalized bit expansion.
 ///
 /// Returns `true` when this function fully handled this output port; `false`
 /// when the instance is not a recognized DFF and normal handling should
@@ -1294,10 +910,11 @@ fn handle_dff_identity_override(
     type_name: &str,
     inst_name: &str,
     port_name: &str,
-    inst: &crate::netlist::parse::NetlistInstance,
+    inst: &NormalizedInstance,
     interner: &StringInterner<StringBackend<SymbolU32>>,
     gb: &mut GateBuilder,
-    resolved: &mut ResolvedNetValues,
+    resolved: &mut ResolvedBitValues,
+    normalized: &NormalizedNetlistModule<'_>,
     dff_cells_identity: &std::collections::HashSet<String>,
     dff_cells_inverted: &std::collections::HashSet<String>,
     nets: &[Net],
@@ -1323,12 +940,12 @@ fn handle_dff_identity_override(
         return Ok(true);
     };
     // Resolve D input
-    let d_input = inst.connections.iter().find_map(|(p, nref)| {
-        let pname = interner.resolve(*p).unwrap();
+    let d_input = inst.connections.iter().find(|connection| {
+        let pname = interner.resolve(connection.port).unwrap();
         if pname.eq_ignore_ascii_case("d") {
-            Some(nref)
+            true
         } else {
-            None
+            false
         }
     });
     if d_input.is_none() {
@@ -1340,8 +957,16 @@ Ensure the cell exposes a 'd' pin or do not classify it as DFF-like.",
         ));
     }
     // Build D (optionally inverted) and write to destination port.
-    if let Some(d_bv) = build_d_bv(d_input.unwrap(), gb, resolved, nets, interner, invert)? {
-        write_bv_to_port_destination(inst, interner, resolved, nets, target_port, &d_bv)?;
+    if let Some(d_bv) = build_d_bv(d_input.unwrap(), gb, resolved, invert)? {
+        write_bv_to_port_destination(
+            inst,
+            interner,
+            resolved,
+            normalized,
+            nets,
+            target_port,
+            &d_bv,
+        )?;
     } else {
         return Err(format!(
             "DFF override: D net not available for cell '{}' instance '{}' (output '{}'). \
@@ -1358,7 +983,7 @@ mod tests {
     use crate::aig_sim::gate_sim::{self, Collect};
     use crate::liberty_proto::{Cell, Library, Pin, PinDirection};
     use crate::netlist::parse::{
-        Net, NetRef, NetlistInstance, NetlistModule, NetlistPort, Parser, PortDirection,
+        Net, NetIndex, NetRef, NetlistInstance, NetlistModule, NetlistPort, Parser, PortDirection,
         TokenScanner,
     };
     use string_interner::{StringInterner, backend::StringBackend};
@@ -1522,6 +1147,26 @@ endmodule
         let y_from_bit0_zero =
             eval_output_by_name(&gate_fn, vec![IrBits::make_ubits(2, 0b10).unwrap()], "y");
         assert_bits(&y_from_bit0_zero, &[false]);
+    }
+
+    #[test]
+    fn test_liberty_projection_supports_preserved_tran_aliases() {
+        let gate_fn = project_parsed_netlist(
+            r#"
+module top (a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  wire y_alias;
+  tran(y, y_alias);
+  BUF u0 (.A(a), .Y(y_alias));
+endmodule
+"#,
+        );
+
+        assert!(eval_single_output_bit(&gate_fn, &[true]));
+        assert!(!eval_single_output_bit(&gate_fn, &[false]));
     }
 
     fn assert_bits(bits: &IrBits, expected_lsb_to_msb: &[bool]) {

--- a/xlsynth-g8r/src/netlist/gv2block.rs
+++ b/xlsynth-g8r/src/netlist/gv2block.rs
@@ -6,7 +6,10 @@ use crate::liberty::cell_formula::{EmitContext as FormulaEmitContext, Term, pars
 use crate::liberty::indexed::IndexedLibrary;
 use crate::liberty_proto::{Cell, PinDirection, SequentialKind};
 use crate::netlist::io::{ParsedNetlist, load_liberty_from_path, parse_netlist_from_path};
-use crate::netlist::parse::{Net, NetIndex, NetRef, NetlistInstance, NetlistModule};
+use crate::netlist::normalized::{
+    BitExpr, BitIndex, BitSource, NormalizedInstance, NormalizedNetlistModule,
+};
+use crate::netlist::parse::NetlistModule;
 use anyhow::{Result, anyhow};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -25,14 +28,10 @@ pub fn convert_gv2block_paths(netlist_path: &Path, liberty_proto_path: &Path) ->
         )));
     }
     let module = &parsed.modules[0];
-    if !module.assigns.is_empty() {
-        return Err(anyhow!(
-            "gv2block does not support preserved continuous assigns"
-        ));
-    }
     let liberty_lib = load_liberty_from_path(liberty_proto_path)?;
     let lib_indexed = IndexedLibrary::new(liberty_lib);
-    build_package_from_netlist(module, &parsed, &lib_indexed)
+    let normalized = NormalizedNetlistModule::new(module, &parsed.nets, &parsed.interner)?;
+    build_package_from_normalized_netlist(module, &parsed, &lib_indexed, &normalized)
 }
 
 pub fn convert_gv2block_paths_to_string(
@@ -99,23 +98,209 @@ struct ClockGatePassthroughSpec {
     output_pin: String,
 }
 
-/// Net connections for one elided clock-gate instance in the netlist.
 #[derive(Clone)]
 struct ClockGatePassthroughInstance {
     instance_name: String,
-    clock_ref: NetRef,
-    output_ref: NetRef,
+    clock_source: BitSource,
+    output_bit: BitIndex,
 }
 
-/// Aggregated clock-gate passthrough data used while building the top block.
 struct ClockGatePassthroughAnalysis {
-    /// Per-instance clock->output passthrough wiring for elided clock gates.
     passthroughs: Vec<ClockGatePassthroughInstance>,
-    /// Clock gaten istance names that should be skipped from normal block
-    /// instantiation.
     elided_instance_names: HashSet<String>,
-    /// Alias map from clock-gate output net to its source clock net.
-    net_aliases: HashMap<NetIndex, NetIndex>,
+    bit_aliases: HashMap<BitIndex, BitIndex>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResolvedWiringSource {
+    Bit(BitIndex),
+    Literal(bool),
+}
+
+struct WiringAssignResolver {
+    source_by_lhs: HashMap<BitIndex, BitSource>,
+}
+
+impl WiringAssignResolver {
+    fn new(normalized: &NormalizedNetlistModule<'_>, parsed: &ParsedNetlist) -> Result<Self> {
+        let mut source_by_lhs = HashMap::new();
+        for assign in &normalized.assigns {
+            for (lhs_bit, rhs_expr) in assign.lhs_bits.iter().copied().zip(&assign.rhs_bits) {
+                let source = match rhs_expr {
+                    BitExpr::Source(source) => *source,
+                    BitExpr::Not(_)
+                    | BitExpr::And(_, _)
+                    | BitExpr::Or(_, _)
+                    | BitExpr::Xor(_, _) => {
+                        return Err(anyhow!(format!(
+                            "gv2block only supports techmapped netlists; preserved combinational assign to '{}' at {} contains top-level logic; run technology mapping first",
+                            normalized.render_bit(lhs_bit, &parsed.nets, &parsed.interner),
+                            assign.span.to_human_string()
+                        )));
+                    }
+                };
+                if source_by_lhs.insert(lhs_bit, source).is_some() {
+                    return Err(anyhow!(format!(
+                        "gv2block found multiple preserved wiring assigns for '{}'",
+                        normalized.render_bit(lhs_bit, &parsed.nets, &parsed.interner)
+                    )));
+                }
+            }
+        }
+        let resolver = Self { source_by_lhs };
+        for lhs_bit in resolver.source_by_lhs.keys().copied() {
+            resolver.resolve_source(BitSource::Bit(lhs_bit), normalized, parsed)?;
+        }
+        Ok(resolver)
+    }
+
+    fn has_lhs(&self, bit_idx: BitIndex) -> bool {
+        self.source_by_lhs.contains_key(&bit_idx)
+    }
+
+    fn resolve_source(
+        &self,
+        source: BitSource,
+        normalized: &NormalizedNetlistModule<'_>,
+        parsed: &ParsedNetlist,
+    ) -> Result<ResolvedWiringSource> {
+        let mut seen_bits = HashSet::new();
+        let mut current = source;
+        loop {
+            match current {
+                BitSource::Bit(bit_idx) => {
+                    if !seen_bits.insert(bit_idx) {
+                        return Err(anyhow!(format!(
+                            "gv2block found a preserved wiring-assign cycle at '{}'",
+                            normalized.render_bit(bit_idx, &parsed.nets, &parsed.interner)
+                        )));
+                    }
+                    let Some(next_source) = self.source_by_lhs.get(&bit_idx).copied() else {
+                        return Ok(ResolvedWiringSource::Bit(bit_idx));
+                    };
+                    current = next_source;
+                }
+                BitSource::Literal(value) => return Ok(ResolvedWiringSource::Literal(value)),
+                BitSource::Unknown => {
+                    return Err(anyhow!(
+                        "gv2block does not support unknown literal preserved wiring"
+                    ));
+                }
+            }
+        }
+    }
+}
+
+struct BitDrivers {
+    drivers: Vec<Option<BitDriver>>,
+}
+
+/// One normalized bit driver; vector input bits stay lazy until consumed.
+#[derive(Clone, Copy)]
+enum BitDriver {
+    Node(NodeRef),
+    InputPortBit {
+        port_node: NodeRef,
+        bit_offset: usize,
+        port_width: usize,
+    },
+}
+
+impl BitDrivers {
+    fn new(bit_count: usize) -> Self {
+        Self {
+            drivers: vec![None; bit_count],
+        }
+    }
+
+    fn set_node_bit(
+        &mut self,
+        bit_idx: BitIndex,
+        node: NodeRef,
+        wiring: &WiringAssignResolver,
+        normalized: &NormalizedNetlistModule<'_>,
+        parsed: &ParsedNetlist,
+    ) -> Result<()> {
+        self.set_driver(bit_idx, BitDriver::Node(node), wiring, normalized, parsed)
+    }
+
+    fn set_input_bit(
+        &mut self,
+        bit_idx: BitIndex,
+        port_node: NodeRef,
+        bit_offset: usize,
+        port_width: usize,
+        wiring: &WiringAssignResolver,
+        normalized: &NormalizedNetlistModule<'_>,
+        parsed: &ParsedNetlist,
+    ) -> Result<()> {
+        self.set_driver(
+            bit_idx,
+            BitDriver::InputPortBit {
+                port_node,
+                bit_offset,
+                port_width,
+            },
+            wiring,
+            normalized,
+            parsed,
+        )
+    }
+
+    fn set_driver(
+        &mut self,
+        bit_idx: BitIndex,
+        driver: BitDriver,
+        wiring: &WiringAssignResolver,
+        normalized: &NormalizedNetlistModule<'_>,
+        parsed: &ParsedNetlist,
+    ) -> Result<()> {
+        if wiring.has_lhs(bit_idx) {
+            return Err(anyhow!(format!(
+                "multiple drivers for '{}': preserved wiring assign and explicit driver",
+                normalized.render_bit(bit_idx, &parsed.nets, &parsed.interner)
+            )));
+        }
+        let entry = self.drivers.get_mut(bit_idx).ok_or_else(|| {
+            anyhow!(format!(
+                "normalized bit index {} is out of range for gv2block driver table",
+                bit_idx
+            ))
+        })?;
+        if entry.replace(driver).is_some() {
+            return Err(anyhow!(format!(
+                "multiple drivers for '{}'",
+                normalized.render_bit(bit_idx, &parsed.nets, &parsed.interner)
+            )));
+        }
+        Ok(())
+    }
+
+    fn materialize_bit(&self, bit_idx: BitIndex, b: &mut PirFnBuilder) -> Option<NodeRef> {
+        let driver = self.drivers.get(bit_idx).copied().flatten()?;
+        Some(match driver {
+            BitDriver::Node(node) => node,
+            BitDriver::InputPortBit {
+                port_node,
+                bit_offset,
+                port_width,
+            } => {
+                if port_width == 1 {
+                    port_node
+                } else {
+                    b.add_node(
+                        NodePayload::BitSlice {
+                            arg: port_node,
+                            start: bit_offset,
+                            width: 1,
+                        },
+                        Type::Bits(1),
+                        None,
+                    )
+                }
+            }
+        })
+    }
 }
 
 fn get_clock_gate_passthrough_spec(cell: &Cell) -> Result<Option<ClockGatePassthroughSpec>> {
@@ -203,54 +388,109 @@ fn get_clock_gate_passthrough_spec(cell: &Cell) -> Result<Option<ClockGatePassth
     }))
 }
 
-fn instance_connection_for_port(
-    inst: &NetlistInstance,
+fn normalized_connection_for_port<'a>(
+    inst: &'a NormalizedInstance,
     parsed: &ParsedNetlist,
     port_name: &str,
-) -> Option<NetRef> {
-    inst.connections.iter().find_map(|(port_id, net_ref)| {
-        let Some(name) = parsed.interner.resolve(*port_id) else {
+) -> Option<&'a [BitSource]> {
+    inst.connections.iter().find_map(|connection| {
+        let Some(name) = parsed.interner.resolve(connection.port) else {
             return None;
         };
         if name == port_name {
-            return Some(net_ref.clone());
+            return Some(connection.bits.as_slice());
         }
         None
     })
 }
 
-fn resolve_net_alias(idx: NetIndex, aliases: &HashMap<NetIndex, NetIndex>) -> Result<NetIndex> {
-    let mut visited: HashSet<NetIndex> = HashSet::new();
-    let mut cur = idx;
-    while let Some(next) = aliases.get(&cur).copied() {
-        if !visited.insert(cur) {
-            return Err(anyhow!(format!(
-                "clock-gate net alias cycle detected at {:?}",
-                cur
-            )));
-        }
-        cur = next;
+fn source_bit_only(
+    sources: &[BitSource],
+    what: &str,
+    wiring: &WiringAssignResolver,
+    normalized: &NormalizedNetlistModule<'_>,
+    parsed: &ParsedNetlist,
+) -> Result<BitIndex> {
+    let [source] = sources else {
+        return Err(anyhow!(format!(
+            "{} must connect exactly one bit in gv2block",
+            what
+        )));
+    };
+    match wiring.resolve_source(*source, normalized, parsed)? {
+        ResolvedWiringSource::Bit(bit_idx) => Ok(bit_idx),
+        ResolvedWiringSource::Literal(_) => Err(anyhow!(format!(
+            "{} must be driven by a net bit in gv2block",
+            what
+        ))),
     }
-    Ok(cur)
 }
 
-fn net_ref_to_simple_index(net_ref: &NetRef) -> Option<NetIndex> {
-    match net_ref {
-        NetRef::Simple(idx) => Some(*idx),
-        _ => None,
+fn target_bit_only(
+    sources: &[BitSource],
+    what: &str,
+    normalized: &NormalizedNetlistModule<'_>,
+    parsed: &ParsedNetlist,
+) -> Result<BitIndex> {
+    let [BitSource::Bit(bit_idx)] = sources else {
+        return Err(anyhow!(format!(
+            "{} must connect exactly one net bit in gv2block; got {}",
+            what,
+            normalized.render_sources(sources, &parsed.nets, &parsed.interner)
+        )));
+    };
+    Ok(*bit_idx)
+}
+
+fn resolve_clock_bit(
+    bit_idx: BitIndex,
+    wiring: &WiringAssignResolver,
+    clock_gate_bit_aliases: &HashMap<BitIndex, BitIndex>,
+    normalized: &NormalizedNetlistModule<'_>,
+    parsed: &ParsedNetlist,
+) -> Result<BitIndex> {
+    let mut seen_bits = HashSet::new();
+    let mut current_bit = bit_idx;
+    loop {
+        if !seen_bits.insert(current_bit) {
+            return Err(anyhow!(format!(
+                "gv2block found a clock wiring cycle at '{}'",
+                normalized.render_bit(current_bit, &parsed.nets, &parsed.interner)
+            )));
+        }
+        current_bit =
+            match wiring.resolve_source(BitSource::Bit(current_bit), normalized, parsed)? {
+                ResolvedWiringSource::Bit(bit_idx) => bit_idx,
+                ResolvedWiringSource::Literal(_) => {
+                    return Err(anyhow!("gv2block clock pin is driven by a literal"));
+                }
+            };
+        let Some(next_bit) = clock_gate_bit_aliases.get(&current_bit).copied() else {
+            return Ok(current_bit);
+        };
+        current_bit = next_bit;
     }
+}
+
+fn render_clock_bit(
+    bit_idx: BitIndex,
+    normalized: &NormalizedNetlistModule<'_>,
+    parsed: &ParsedNetlist,
+) -> String {
+    normalized.render_bit(bit_idx, &parsed.nets, &parsed.interner)
 }
 
 fn collect_clock_gate_passthroughs(
-    module: &NetlistModule,
+    normalized: &NormalizedNetlistModule<'_>,
     parsed: &ParsedNetlist,
     lib_indexed: &IndexedLibrary,
+    wiring: &WiringAssignResolver,
 ) -> Result<ClockGatePassthroughAnalysis> {
-    let mut passthroughs: Vec<ClockGatePassthroughInstance> = Vec::new();
-    let mut elided_instance_names: HashSet<String> = HashSet::new();
-    let mut net_aliases: HashMap<NetIndex, NetIndex> = HashMap::new();
+    let mut passthroughs = Vec::new();
+    let mut elided_instance_names = HashSet::new();
+    let mut bit_aliases = HashMap::new();
 
-    for inst in &module.instances {
+    for inst in &normalized.instances {
         let inst_name = parsed
             .interner
             .resolve(inst.instance_name)
@@ -264,39 +504,52 @@ fn collect_clock_gate_passthroughs(
             continue;
         };
 
-        let clock_ref =
-            instance_connection_for_port(inst, parsed, &spec.clock_pin).ok_or_else(|| {
+        let clock_sources = normalized_connection_for_port(inst, parsed, &spec.clock_pin)
+            .ok_or_else(|| {
                 anyhow!(format!(
                     "clock-gate instance '{}' missing connection for clock pin '{}'",
                     inst_name, spec.clock_pin
                 ))
             })?;
-        let output_ref =
-            instance_connection_for_port(inst, parsed, &spec.output_pin).ok_or_else(|| {
+        let output_sources = normalized_connection_for_port(inst, parsed, &spec.output_pin)
+            .ok_or_else(|| {
                 anyhow!(format!(
                     "clock-gate instance '{}' missing connection for output pin '{}'",
                     inst_name, spec.output_pin
                 ))
             })?;
 
-        let clock_idx = net_ref_to_simple_index(&clock_ref).ok_or_else(|| {
-            anyhow!(format!(
-                "clock-gate instance '{}' clock pin '{}' is not connected to a simple net",
+        let [clock_source] = clock_sources else {
+            return Err(anyhow!(format!(
+                "clock-gate instance '{}' clock pin '{}' must connect exactly one bit",
                 inst_name, spec.clock_pin
-            ))
-        })?;
-        let output_idx = net_ref_to_simple_index(&output_ref).ok_or_else(|| {
-            anyhow!(format!(
-                "clock-gate instance '{}' output pin '{}' is not connected to a simple net",
+            )));
+        };
+        let output_bit = target_bit_only(
+            output_sources,
+            &format!(
+                "clock-gate instance '{}' output pin '{}'",
                 inst_name, spec.output_pin
-            ))
-        })?;
+            ),
+            normalized,
+            parsed,
+        )?;
+        let clock_bit = source_bit_only(
+            clock_sources,
+            &format!(
+                "clock-gate instance '{}' clock pin '{}'",
+                inst_name, spec.clock_pin
+            ),
+            wiring,
+            normalized,
+            parsed,
+        )?;
 
-        if let Some(existing) = net_aliases.insert(output_idx, clock_idx) {
-            if existing != clock_idx {
+        if let Some(existing) = bit_aliases.insert(output_bit, clock_bit) {
+            if existing != clock_bit {
                 return Err(anyhow!(format!(
-                    "clock-gate output net '{}' is aliased to multiple clock nets",
-                    net_name_by_index(output_idx, parsed)
+                    "clock-gate output bit '{}' is aliased to multiple clock bits",
+                    render_clock_bit(output_bit, normalized, parsed)
                 )));
             }
         }
@@ -304,103 +557,73 @@ fn collect_clock_gate_passthroughs(
         elided_instance_names.insert(inst_name.clone());
         passthroughs.push(ClockGatePassthroughInstance {
             instance_name: inst_name,
-            clock_ref,
-            output_ref,
+            clock_source: *clock_source,
+            output_bit,
         });
     }
 
     Ok(ClockGatePassthroughAnalysis {
         passthroughs,
         elided_instance_names,
-        net_aliases,
+        bit_aliases,
     })
 }
 
 fn apply_clock_gate_passthroughs(
     passthroughs: &[ClockGatePassthroughInstance],
+    wiring: &WiringAssignResolver,
+    normalized: &NormalizedNetlistModule<'_>,
     parsed: &ParsedNetlist,
-    net_drivers: &mut NetDrivers,
-    net_widths: &HashMap<NetIndex, (usize, i64)>,
+    bit_drivers: &mut BitDrivers,
     b: &mut PirFnBuilder,
-) -> Result<HashSet<NetIndex>> {
+) -> Result<HashSet<BitIndex>> {
     let mut pending_passthroughs = passthroughs.to_vec();
-    let mut unresolved_passthrough_output_nets: HashSet<NetIndex> = HashSet::new();
+    let mut unresolved_passthrough_output_bits = HashSet::new();
 
     while !pending_passthroughs.is_empty() {
         let mut progressed = false;
-        let mut next_pending: Vec<ClockGatePassthroughInstance> = Vec::new();
+        let mut next_pending = Vec::new();
         for passthrough in pending_passthroughs {
-            if !net_ref_is_resolved(&passthrough.clock_ref, net_drivers, net_widths) {
+            let ResolvedWiringSource::Bit(clock_bit) =
+                wiring.resolve_source(passthrough.clock_source, normalized, parsed)?
+            else {
+                return Err(anyhow!(format!(
+                    "clock-gate instance '{}' clock pin is driven by a literal",
+                    passthrough.instance_name
+                )));
+            };
+            let Some(source_node) = bit_drivers.materialize_bit(clock_bit, b) else {
                 next_pending.push(passthrough);
                 continue;
-            }
-
-            let source_node = net_ref_to_node(
-                &passthrough.clock_ref,
+            };
+            bit_drivers.set_node_bit(
+                passthrough.output_bit,
+                source_node,
+                wiring,
+                normalized,
                 parsed,
-                net_drivers,
-                net_widths,
-                b,
-                1,
             )?;
-            match &passthrough.output_ref {
-                NetRef::Simple(net_idx) => {
-                    net_drivers.set_whole(*net_idx, source_node, net_widths, parsed)?;
-                }
-                NetRef::BitSelect(net_idx, bit) => {
-                    net_drivers.set_bit(
-                        *net_idx,
-                        i64::from(*bit),
-                        source_node,
-                        net_widths,
-                        parsed,
-                    )?;
-                }
-                NetRef::PartSelect(net_idx, msb, lsb) => {
-                    if msb != lsb {
-                        return Err(anyhow!(format!(
-                            "clock-gate instance '{}' output connection is unsupported multi-bit part-select on net '{}'",
-                            passthrough.instance_name,
-                            net_name_by_index(*net_idx, parsed)
-                        )));
-                    }
-                    net_drivers.set_bit(
-                        *net_idx,
-                        i64::from(*lsb),
-                        source_node,
-                        net_widths,
-                        parsed,
-                    )?;
-                }
-                NetRef::Unconnected => {}
-                _ => {
-                    return Err(anyhow!(format!(
-                        "clock-gate instance '{}' output connection is unsupported net reference",
-                        passthrough.instance_name
-                    )));
-                }
-            }
             progressed = true;
         }
         if !progressed {
             for passthrough in &next_pending {
-                if let Some(output_idx) = net_ref_to_simple_index(&passthrough.output_ref) {
-                    unresolved_passthrough_output_nets.insert(output_idx);
-                }
+                unresolved_passthrough_output_bits.insert(passthrough.output_bit);
             }
             break;
         }
         pending_passthroughs = next_pending;
     }
 
-    Ok(unresolved_passthrough_output_nets)
+    Ok(unresolved_passthrough_output_bits)
 }
 
-fn build_package_from_netlist(
+fn build_package_from_normalized_netlist(
     module: &NetlistModule,
     parsed: &ParsedNetlist,
     lib_indexed: &IndexedLibrary,
+    normalized: &NormalizedNetlistModule<'_>,
 ) -> Result<Package> {
+    let wiring = WiringAssignResolver::new(normalized, parsed)?;
     let module_name =
         sanitize_to_xls_identifier(parsed.interner.resolve(module.name).unwrap_or("top"));
 
@@ -438,7 +661,7 @@ fn build_package_from_netlist(
         });
     }
 
-    let (top_fn, top_meta) = build_top_block(module, parsed, lib_indexed)?;
+    let (top_fn, top_meta) = build_top_block(module, parsed, lib_indexed, normalized, &wiring)?;
     pkg.members.push(PackageMember::Block {
         func: top_fn.clone(),
         metadata: top_meta,
@@ -733,114 +956,180 @@ fn build_cell_block(cell: &Cell, lib_indexed: &IndexedLibrary) -> Result<(PirFn,
     Ok((b.finish(ret_ty, ret_node_ref), meta))
 }
 
-struct NetDrivers {
-    whole: HashMap<NetIndex, NodeRef>,
-    bits: HashMap<NetIndex, Vec<Option<NodeRef>>>,
+fn add_input_bit_driver(
+    bit_idx: BitIndex,
+    bit_offset: usize,
+    port_width: usize,
+    port_node: NodeRef,
+    bit_drivers: &mut BitDrivers,
+    wiring: &WiringAssignResolver,
+    normalized: &NormalizedNetlistModule<'_>,
+    parsed: &ParsedNetlist,
+) -> Result<()> {
+    bit_drivers.set_input_bit(
+        bit_idx, port_node, bit_offset, port_width, wiring, normalized, parsed,
+    )
 }
 
-impl NetDrivers {
-    fn new() -> Self {
-        Self {
-            whole: HashMap::new(),
-            bits: HashMap::new(),
+fn add_literal_bit(b: &mut PirFnBuilder, value: bool) -> NodeRef {
+    b.add_literal_bits(1, if value { 1 } else { 0 })
+}
+
+fn resolved_wiring_source_to_node(
+    source: ResolvedWiringSource,
+    bit_drivers: &BitDrivers,
+    unresolved_passthrough_output_bits: &HashSet<BitIndex>,
+    normalized: &NormalizedNetlistModule<'_>,
+    parsed: &ParsedNetlist,
+    b: &mut PirFnBuilder,
+    allow_undriven_zero: bool,
+) -> Result<NodeRef> {
+    match source {
+        ResolvedWiringSource::Bit(bit_idx) => {
+            if let Some(node) = bit_drivers.materialize_bit(bit_idx, b) {
+                return Ok(node);
+            }
+            if unresolved_passthrough_output_bits.contains(&bit_idx) {
+                return Err(anyhow!(format!(
+                    "clock-gate output bit '{}' is unresolved as data (clock-only passthrough)",
+                    normalized.render_bit(bit_idx, &parsed.nets, &parsed.interner)
+                )));
+            }
+            if allow_undriven_zero {
+                return Ok(add_literal_bit(b, false));
+            }
+            Err(anyhow!(format!(
+                "net bit '{}' has no driver",
+                normalized.render_bit(bit_idx, &parsed.nets, &parsed.interner)
+            )))
         }
+        ResolvedWiringSource::Literal(value) => Ok(add_literal_bit(b, value)),
+    }
+}
+
+fn materialize_sources_to_node(
+    sources: &[BitSource],
+    empty_width: usize,
+    wiring: &WiringAssignResolver,
+    bit_drivers: &BitDrivers,
+    unresolved_passthrough_output_bits: &HashSet<BitIndex>,
+    normalized: &NormalizedNetlistModule<'_>,
+    parsed: &ParsedNetlist,
+    b: &mut PirFnBuilder,
+    allow_undriven_zero: bool,
+) -> Result<NodeRef> {
+    if sources.is_empty() {
+        return Ok(b.add_literal_bits(empty_width, 0));
     }
 
-    fn set_whole(
-        &mut self,
-        idx: NetIndex,
-        node: NodeRef,
-        net_widths: &HashMap<NetIndex, (usize, i64)>,
-        parsed: &ParsedNetlist,
-    ) -> Result<()> {
-        if self.bits.contains_key(&idx) {
-            let net_name = net_name_by_index(idx, parsed);
-            return Err(anyhow!(format!(
-                "multiple drivers for net '{}' (bit-level and whole-net)",
-                net_name
-            )));
-        }
-        if self.whole.insert(idx, node).is_some() {
-            let net_name = net_name_by_index(idx, parsed);
-            return Err(anyhow!(format!("multiple drivers for net '{}'", net_name)));
-        }
-        // Ensure widths map entry exists for later slices.
-        let _ = net_widths.get(&idx).copied().unwrap_or((1, 0));
-        Ok(())
+    let mut parts = Vec::with_capacity(sources.len());
+    for source in sources.iter().rev().copied() {
+        let resolved = wiring.resolve_source(source, normalized, parsed)?;
+        parts.push(resolved_wiring_source_to_node(
+            resolved,
+            bit_drivers,
+            unresolved_passthrough_output_bits,
+            normalized,
+            parsed,
+            b,
+            allow_undriven_zero,
+        )?);
     }
+    if parts.len() == 1 {
+        Ok(parts[0])
+    } else {
+        Ok(b.add_node(
+            NodePayload::Nary(NaryOp::Concat, parts),
+            Type::Bits(sources.len()),
+            None,
+        ))
+    }
+}
 
-    fn set_bit(
-        &mut self,
-        idx: NetIndex,
-        bit: i64,
-        node: NodeRef,
-        net_widths: &HashMap<NetIndex, (usize, i64)>,
-        parsed: &ParsedNetlist,
-    ) -> Result<()> {
-        if self.whole.contains_key(&idx) {
-            let net_name = net_name_by_index(idx, parsed);
-            return Err(anyhow!(format!(
-                "multiple drivers for net '{}' (whole-net and bit-level)",
-                net_name
-            )));
-        }
-        let (width, lsb) = net_widths.get(&idx).copied().unwrap_or((1, 0));
-        let offset = (bit - lsb) as usize;
-        if offset >= width {
-            let net_name = net_name_by_index(idx, parsed);
-            return Err(anyhow!(format!(
-                "bit {} out of range for net '{}' (width {}, lsb {})",
-                bit, net_name, width, lsb
-            )));
-        }
-        let entry = self.bits.entry(idx).or_insert_with(|| vec![None; width]);
-        if entry[offset].is_some() {
-            let net_name = net_name_by_index(idx, parsed);
-            return Err(anyhow!(format!("multiple drivers for net '{}'", net_name)));
-        }
-        entry[offset] = Some(node);
-        Ok(())
-    }
+fn materialize_bits_to_node(
+    bits: &[BitIndex],
+    wiring: &WiringAssignResolver,
+    bit_drivers: &BitDrivers,
+    unresolved_passthrough_output_bits: &HashSet<BitIndex>,
+    normalized: &NormalizedNetlistModule<'_>,
+    parsed: &ParsedNetlist,
+    b: &mut PirFnBuilder,
+    allow_undriven_zero: bool,
+) -> Result<NodeRef> {
+    let sources: Vec<BitSource> = bits.iter().copied().map(BitSource::Bit).collect();
+    materialize_sources_to_node(
+        sources.as_slice(),
+        bits.len(),
+        wiring,
+        bit_drivers,
+        unresolved_passthrough_output_bits,
+        normalized,
+        parsed,
+        b,
+        allow_undriven_zero,
+    )
+}
 
-    fn get_whole(&self, idx: NetIndex) -> Option<NodeRef> {
-        self.whole.get(&idx).copied()
-    }
+fn source_resolves_to_clock(
+    source: BitSource,
+    selected_clock_bit: BitIndex,
+    wiring: &WiringAssignResolver,
+    clock_gate_bit_aliases: &HashMap<BitIndex, BitIndex>,
+    normalized: &NormalizedNetlistModule<'_>,
+    parsed: &ParsedNetlist,
+) -> Result<bool> {
+    let ResolvedWiringSource::Bit(bit_idx) = wiring.resolve_source(source, normalized, parsed)?
+    else {
+        return Ok(false);
+    };
+    Ok(
+        resolve_clock_bit(bit_idx, wiring, clock_gate_bit_aliases, normalized, parsed)?
+            == selected_clock_bit,
+    )
+}
 
-    fn get_bits(&self, idx: NetIndex) -> Option<&Vec<Option<NodeRef>>> {
-        self.bits.get(&idx)
-    }
+fn top_input_port_name_for_bit(
+    bit_idx: BitIndex,
+    normalized: &NormalizedNetlistModule<'_>,
+    parsed: &ParsedNetlist,
+) -> Option<String> {
+    normalized
+        .ports
+        .iter()
+        .find(|port| {
+            port.direction == crate::netlist::parse::PortDirection::Input
+                && port.bits.contains(&bit_idx)
+        })
+        .and_then(|port| parsed.interner.resolve(port.name))
+        .map(|name| name.to_string())
 }
 
 fn build_top_block(
     module: &NetlistModule,
     parsed: &ParsedNetlist,
     lib_indexed: &IndexedLibrary,
+    normalized: &NormalizedNetlistModule<'_>,
+    wiring: &WiringAssignResolver,
 ) -> Result<(PirFn, BlockMetadata)> {
     let module_name_raw = parsed.interner.resolve(module.name).unwrap_or("top");
     let module_name = sanitize_to_xls_identifier(module_name_raw);
     let mut b = PirFnBuilder::new(&module_name);
 
-    let mut net_drivers = NetDrivers::new();
-    let mut net_widths: HashMap<NetIndex, (usize, i64)> = HashMap::new();
+    let mut bit_drivers = BitDrivers::new(normalized.bit_count());
     let mut top_port_name_legalizer = IdentifierLegalizer::default();
     let mut instance_name_legalizer = IdentifierLegalizer::default();
-
-    for (i, net) in parsed.nets.iter().enumerate() {
-        let idx = NetIndex(i);
-        net_widths.insert(idx, net_width_bits(net));
-    }
 
     let ClockGatePassthroughAnalysis {
         passthroughs: clock_gate_passthroughs,
         elided_instance_names: elided_clock_gate_instances,
-        net_aliases: clock_gate_net_aliases,
-    } = collect_clock_gate_passthroughs(module, parsed, lib_indexed)?;
+        bit_aliases: clock_gate_bit_aliases,
+    } = collect_clock_gate_passthroughs(normalized, parsed, lib_indexed, wiring)?;
 
-    // Identify a shared clock net name for DFFs (if any).
-    let mut clock_net_name: Option<String> = None;
-    let mut dff_clock_pins: Vec<String> = Vec::new();
+    let mut selected_clock_bit: Option<BitIndex> = None;
+    let mut selected_clock_port_name_raw: Option<String> = None;
+    let mut dff_clock_pins = Vec::new();
 
-    for inst in &module.instances {
+    for inst in &normalized.instances {
         let cell_name = parsed.interner.resolve(inst.type_name).unwrap_or("");
         let cell = lib_indexed
             .get_cell(cell_name)
@@ -860,7 +1149,7 @@ fn build_top_block(
         }
     }
 
-    for inst in &module.instances {
+    for inst in &normalized.instances {
         let cell_name = parsed.interner.resolve(inst.type_name).unwrap_or("");
         let cell = lib_indexed
             .get_cell(cell_name)
@@ -870,79 +1159,89 @@ fn build_top_block(
             .first()
             .is_some_and(|s| s.kind == SequentialKind::Ff as i32)
         {
-            for (port_name, net_ref) in &inst.connections {
-                let port = parsed.interner.resolve(*port_name).unwrap_or("");
-                if dff_clock_pins.iter().any(|p| p == port) {
-                    let net_idx = net_ref_to_simple_index(net_ref).ok_or_else(|| {
-                        anyhow!(format!(
-                            "clock pin '{}' on instance '{}' is not driven by a simple net",
-                            port,
-                            parsed
-                                .interner
-                                .resolve(inst.instance_name)
-                                .unwrap_or("<unknown>")
-                        ))
-                    })?;
-                    let resolved_net_idx = resolve_net_alias(net_idx, &clock_gate_net_aliases)?;
-                    let net_name = net_name_by_index(resolved_net_idx, parsed);
-                    match &clock_net_name {
-                        None => clock_net_name = Some(net_name),
-                        Some(existing) if existing != &net_name => {
-                            return Err(anyhow!(format!(
-                                "multiple clock nets detected: '{}' vs '{}'",
-                                existing, net_name
-                            )));
-                        }
-                        _ => {}
+            for connection in &inst.connections {
+                let port = parsed.interner.resolve(connection.port).unwrap_or("");
+                if !dff_clock_pins.iter().any(|clock_pin| clock_pin == port) {
+                    continue;
+                }
+                let raw_clock_bit = source_bit_only(
+                    connection.bits.as_slice(),
+                    &format!(
+                        "clock pin '{}' on instance '{}'",
+                        port,
+                        parsed
+                            .interner
+                            .resolve(inst.instance_name)
+                            .unwrap_or("<unknown>")
+                    ),
+                    wiring,
+                    normalized,
+                    parsed,
+                )?;
+                let clock_bit = resolve_clock_bit(
+                    raw_clock_bit,
+                    wiring,
+                    &clock_gate_bit_aliases,
+                    normalized,
+                    parsed,
+                )?;
+                match selected_clock_bit {
+                    None => selected_clock_bit = Some(clock_bit),
+                    Some(existing) if existing != clock_bit => {
+                        return Err(anyhow!(format!(
+                            "multiple clock nets detected: '{}' vs '{}'",
+                            render_clock_bit(existing, normalized, parsed),
+                            render_clock_bit(clock_bit, normalized, parsed)
+                        )));
                     }
+                    _ => {}
                 }
             }
         }
     }
 
-    if let Some(ref clk_net) = clock_net_name {
-        let is_top_input = module.ports.iter().any(|p| {
-            p.direction == crate::netlist::parse::PortDirection::Input
-                && parsed
-                    .interner
-                    .resolve(p.name)
-                    .is_some_and(|name| name == clk_net)
-        });
-        if !is_top_input {
+    if let Some(clock_bit) = selected_clock_bit {
+        selected_clock_port_name_raw = top_input_port_name_for_bit(clock_bit, normalized, parsed);
+        if selected_clock_port_name_raw.is_none() {
             return Err(anyhow!(format!(
                 "derived clock '{}' is not a top-level input port",
-                clk_net
+                render_clock_bit(clock_bit, normalized, parsed)
             )));
         }
     }
 
-    for port in &module.ports {
+    for port in &normalized.ports {
         if port.direction != crate::netlist::parse::PortDirection::Input {
             continue;
         }
         let name_raw = parsed.interner.resolve(port.name).unwrap_or("").to_string();
-        if clock_net_name.as_ref().is_some_and(|clk| clk == &name_raw) {
+        if selected_clock_port_name_raw
+            .as_ref()
+            .is_some_and(|clock_name| clock_name == &name_raw)
+        {
             continue;
         }
         let name = top_port_name_legalizer.legalize(&name_raw);
-        let width = port
-            .width
-            .map(|(msb, lsb)| (msb as i64 - lsb as i64).abs() as usize + 1)
-            .unwrap_or(1);
-        let nr = b.add_param(&name, Type::Bits(width));
-        let net_idx = parsed
-            .nets
-            .iter()
-            .position(|n| n.name == port.name)
-            .map(NetIndex)
-            .ok_or_else(|| anyhow!(format!("input port net '{}' not found", name)))?;
-        net_drivers.set_whole(net_idx, nr, &net_widths, parsed)?;
+        let width = port.bits.len();
+        let port_node = b.add_param(&name, Type::Bits(width));
+        for (bit_offset, bit_idx) in port.bits.iter().copied().enumerate() {
+            add_input_bit_driver(
+                bit_idx,
+                bit_offset,
+                width,
+                port_node,
+                &mut bit_drivers,
+                wiring,
+                normalized,
+                parsed,
+            )?;
+        }
     }
 
-    let mut instantiations: Vec<Instantiation> = Vec::new();
+    let mut instantiations = Vec::new();
     let mut instance_outputs: Vec<(String, String, Vec<(String, NodeRef)>)> = Vec::new();
 
-    for inst in &module.instances {
+    for inst in &normalized.instances {
         let inst_name_raw = parsed
             .interner
             .resolve(inst.instance_name)
@@ -965,7 +1264,7 @@ fn build_top_block(
         let outputs = lib_indexed
             .pins_for_dir(&cell_name, PinDirection::Output)
             .unwrap_or_default();
-        let mut output_refs: Vec<(String, NodeRef)> = Vec::new();
+        let mut output_refs = Vec::new();
         for pin in outputs {
             let output_node_name = format!("{}_{}", inst_name, pin.name);
             let nr = b.add_node(
@@ -981,53 +1280,48 @@ fn build_top_block(
         instance_outputs.push((inst_name_raw, inst_name, output_refs));
     }
 
-    // Map instance outputs to nets.
     for (inst_name_raw, _inst_name_legal, output_refs) in &instance_outputs {
-        let inst = module
+        let inst = normalized
             .instances
             .iter()
-            .find(|i| parsed.interner.resolve(i.instance_name).unwrap_or("") == inst_name_raw)
+            .find(|inst| parsed.interner.resolve(inst.instance_name).unwrap_or("") == inst_name_raw)
             .ok_or_else(|| anyhow!(format!("instance '{}' not found", inst_name_raw)))?;
-        for (port_id, net_ref) in &inst.connections {
-            let port_name = parsed.interner.resolve(*port_id).unwrap_or("").to_string();
+        for connection in &inst.connections {
+            let port_name = parsed
+                .interner
+                .resolve(connection.port)
+                .unwrap_or("")
+                .to_string();
             let Some(node_ref) = output_refs
                 .iter()
-                .find(|(n, _)| n == &port_name)
-                .map(|(_, r)| *r)
+                .find(|(name, _)| name == &port_name)
+                .map(|(_, node_ref)| *node_ref)
             else {
                 continue;
             };
-            match net_ref {
-                NetRef::Simple(net_idx) => {
-                    net_drivers.set_whole(*net_idx, node_ref, &net_widths, parsed)?;
-                }
-                NetRef::BitSelect(net_idx, bit) => {
-                    net_drivers.set_bit(*net_idx, *bit as i64, node_ref, &net_widths, parsed)?;
-                }
-                NetRef::PartSelect(net_idx, msb, lsb) => {
-                    if msb != lsb {
-                        return Err(anyhow!(format!(
-                            "unsupported multi-bit part-select output for net '{}'",
-                            net_name_by_index(*net_idx, parsed)
-                        )));
-                    }
-                    net_drivers.set_bit(*net_idx, *lsb as i64, node_ref, &net_widths, parsed)?;
-                }
-                _ => {}
+            if connection.bits.is_empty() {
+                continue;
             }
+            let output_bit = target_bit_only(
+                connection.bits.as_slice(),
+                &format!("instance output '{}.{}'", inst_name_raw, port_name),
+                normalized,
+                parsed,
+            )?;
+            bit_drivers.set_node_bit(output_bit, node_ref, wiring, normalized, parsed)?;
         }
     }
 
-    let unresolved_passthrough_output_nets = apply_clock_gate_passthroughs(
+    let unresolved_passthrough_output_bits = apply_clock_gate_passthroughs(
         &clock_gate_passthroughs,
+        wiring,
+        normalized,
         parsed,
-        &mut net_drivers,
-        &net_widths,
+        &mut bit_drivers,
         &mut b,
     )?;
 
-    // Emit instantiation inputs.
-    for inst in &module.instances {
+    for inst in &normalized.instances {
         let inst_name_raw = parsed
             .interner
             .resolve(inst.instance_name)
@@ -1048,12 +1342,12 @@ fn build_top_block(
         let inputs = lib_indexed
             .pins_for_dir(&cell_name, PinDirection::Input)
             .unwrap_or_default();
-        let input_pin_names: HashSet<String> = inputs.iter().map(|p| p.name.clone()).collect();
+        let input_pin_names: HashSet<String> = inputs.iter().map(|pin| pin.name.clone()).collect();
 
         let mut clock_pin_names: HashSet<String> = inputs
             .iter()
-            .filter(|p| p.is_clocking_pin)
-            .map(|p| p.name.clone())
+            .filter(|pin| pin.is_clocking_pin)
+            .map(|pin| pin.name.clone())
             .collect();
         if let Some(seq) = cell.sequential.first() {
             if !seq.clock_expr.is_empty() {
@@ -1062,29 +1356,52 @@ fn build_top_block(
             }
         }
 
-        for (port_id, net_ref) in &inst.connections {
-            let port_name = parsed.interner.resolve(*port_id).unwrap_or("").to_string();
+        for connection in &inst.connections {
+            let port_name = parsed
+                .interner
+                .resolve(connection.port)
+                .unwrap_or("")
+                .to_string();
             if !input_pin_names.contains(&port_name) || clock_pin_names.contains(&port_name) {
                 continue;
             }
-            if let (Some(clock_net), Some(net_idx)) =
-                (clock_net_name.as_ref(), net_ref_to_simple_index(net_ref))
-            {
-                let resolved_net_idx = resolve_net_alias(net_idx, &clock_gate_net_aliases)?;
-                if net_name_by_index(resolved_net_idx, parsed) == *clock_net {
-                    return Err(anyhow!(format!(
-                        "clock net '{}' is connected to non-clock input '{}.{}' (cell '{}'); gv2block does not support feeding the selected clock into ordinary logic",
-                        clock_net, inst_name, port_name, cell_name
-                    )));
+            if let Some(clock_bit) = selected_clock_bit {
+                for source in connection.bits.iter().copied() {
+                    if source_resolves_to_clock(
+                        source,
+                        clock_bit,
+                        wiring,
+                        &clock_gate_bit_aliases,
+                        normalized,
+                        parsed,
+                    )? {
+                        return Err(anyhow!(format!(
+                            "clock net '{}' is connected to non-clock input '{}.{}' (cell '{}'); gv2block does not support feeding the selected clock into ordinary logic",
+                            render_clock_bit(clock_bit, normalized, parsed),
+                            inst_name,
+                            port_name,
+                            cell_name
+                        )));
+                    }
                 }
             }
-            let val = net_ref_to_node(net_ref, parsed, &net_drivers, &net_widths, &mut b, 1)?;
+            let value = materialize_sources_to_node(
+                connection.bits.as_slice(),
+                1,
+                wiring,
+                &bit_drivers,
+                &unresolved_passthrough_output_bits,
+                normalized,
+                parsed,
+                &mut b,
+                false,
+            )?;
             let input_node_name = format!("{}_{}", inst_name, port_name);
             b.add_node(
                 NodePayload::InstantiationInput {
                     instantiation: inst_name.clone(),
                     port_name: port_name.clone(),
-                    arg: val,
+                    arg: value,
                 },
                 Type::Tuple(vec![]),
                 Some(&input_node_name),
@@ -1092,63 +1409,36 @@ fn build_top_block(
         }
     }
 
-    // Collect module outputs.
-    let mut output_names: Vec<String> = Vec::new();
-    let mut output_nodes: Vec<NodeRef> = Vec::new();
-    for port in &module.ports {
+    let mut output_names = Vec::new();
+    let mut output_nodes = Vec::new();
+    for port in &normalized.ports {
         if port.direction != crate::netlist::parse::PortDirection::Output {
             continue;
         }
         let name_raw = parsed.interner.resolve(port.name).unwrap_or("").to_string();
         let name = top_port_name_legalizer.legalize(&name_raw);
-        let net_idx = parsed
-            .nets
-            .iter()
-            .position(|n| n.name == port.name)
-            .map(NetIndex)
-            .ok_or_else(|| anyhow!(format!("output port net '{}' not found", name_raw)))?;
-        let (width, _) = net_widths.get(&net_idx).copied().unwrap_or((1, 0));
-        let node = if let Some(nr) = net_drivers.get_whole(net_idx) {
-            nr
-        } else if let Some(bits) = net_drivers.get_bits(net_idx) {
-            let mut parts: Vec<NodeRef> = Vec::new();
-            for bit in bits.iter().rev() {
-                let nr = match bit {
-                    Some(n) => *n,
-                    None => b.add_literal_bits(1, 0),
-                };
-                parts.push(nr);
-            }
-            if parts.len() == 1 {
-                parts[0]
-            } else {
-                b.add_node(
-                    NodePayload::Nary(NaryOp::Concat, parts),
-                    Type::Bits(width),
-                    None,
-                )
-            }
-        } else {
-            if unresolved_passthrough_output_nets.contains(&net_idx) {
-                return Err(anyhow!(format!(
-                    "clock-gate output net '{}' is unresolved as data (clock-only passthrough)",
-                    name
-                )));
-            }
-            b.add_literal_bits(width, 0)
-        };
+        let node = materialize_bits_to_node(
+            port.bits.as_slice(),
+            wiring,
+            &bit_drivers,
+            &unresolved_passthrough_output_bits,
+            normalized,
+            parsed,
+            &mut b,
+            true,
+        )?;
         output_names.push(name);
         output_nodes.push(node);
     }
 
     let (ret_ty, ret_node_ref) = build_return_node(&mut b, &output_nodes);
 
-    let mut input_port_ids: HashMap<String, usize> = HashMap::new();
-    for p in &b.params {
-        input_port_ids.insert(p.name.clone(), p.id.get_wrapped_id());
+    let mut input_port_ids = HashMap::new();
+    for param in &b.params {
+        input_port_ids.insert(param.name.clone(), param.id.get_wrapped_id());
     }
 
-    let clock_port_name = clock_net_name
+    let clock_port_name = selected_clock_port_name_raw
         .as_ref()
         .map(|name| top_port_name_legalizer.legalize(name));
 
@@ -1181,241 +1471,6 @@ fn build_return_node(b: &mut PirFnBuilder, outputs: &[NodeRef]) -> (Type, Option
     let tuple_ty = Type::Tuple(tys);
     let tuple_node = b.add_node(NodePayload::Tuple(outputs.to_vec()), tuple_ty.clone(), None);
     (tuple_ty, Some(tuple_node))
-}
-
-fn net_width_bits(net: &Net) -> (usize, i64) {
-    if let Some((msb, lsb)) = net.width {
-        let width = (msb as i64 - lsb as i64).abs() as usize + 1;
-        (width, lsb as i64)
-    } else {
-        (1, 0)
-    }
-}
-
-fn net_name_by_index(idx: NetIndex, parsed: &ParsedNetlist) -> String {
-    parsed
-        .interner
-        .resolve(parsed.nets[idx.0].name)
-        .unwrap_or("<unknown>")
-        .to_string()
-}
-
-fn net_ref_is_resolved(
-    net_ref: &NetRef,
-    net_drivers: &NetDrivers,
-    net_widths: &HashMap<NetIndex, (usize, i64)>,
-) -> bool {
-    match net_ref {
-        NetRef::Simple(idx) => {
-            if net_drivers.get_whole(*idx).is_some() {
-                return true;
-            }
-            net_drivers
-                .get_bits(*idx)
-                .is_some_and(|bits| bits.iter().all(|b| b.is_some()))
-        }
-        NetRef::BitSelect(idx, bit) => {
-            if net_drivers.get_whole(*idx).is_some() {
-                return true;
-            }
-            let Some(bits) = net_drivers.get_bits(*idx) else {
-                return false;
-            };
-            let (_, lsb) = net_widths.get(idx).copied().unwrap_or((1, 0));
-            let offset_i64 = i64::from(*bit) - lsb;
-            if offset_i64 < 0 {
-                return false;
-            }
-            bits.get(offset_i64 as usize).is_some_and(|n| n.is_some())
-        }
-        NetRef::PartSelect(idx, msb, lsb_select) => {
-            if msb < lsb_select {
-                return false;
-            }
-            if net_drivers.get_whole(*idx).is_some() {
-                return true;
-            }
-            let Some(bits) = net_drivers.get_bits(*idx) else {
-                return false;
-            };
-            let (_, net_lsb) = net_widths.get(idx).copied().unwrap_or((1, 0));
-            for bit in *lsb_select..=*msb {
-                let offset_i64 = i64::from(bit) - net_lsb;
-                if offset_i64 < 0 {
-                    return false;
-                }
-                let Some(nr_opt) = bits.get(offset_i64 as usize) else {
-                    return false;
-                };
-                if nr_opt.is_none() {
-                    return false;
-                }
-            }
-            true
-        }
-        NetRef::Literal(_) | NetRef::UnknownLiteral(_) | NetRef::Unconnected => true,
-        NetRef::Concat(elems) => elems
-            .iter()
-            .all(|e| net_ref_is_resolved(e, net_drivers, net_widths)),
-    }
-}
-
-fn net_ref_to_node(
-    net_ref: &NetRef,
-    parsed: &ParsedNetlist,
-    net_drivers: &NetDrivers,
-    net_widths: &HashMap<NetIndex, (usize, i64)>,
-    b: &mut PirFnBuilder,
-    expected_width: usize,
-) -> Result<NodeRef> {
-    match net_ref {
-        NetRef::Simple(idx) => {
-            if let Some(nr) = net_drivers.get_whole(*idx) {
-                return Ok(nr);
-            }
-            if let Some(bits) = net_drivers.get_bits(*idx) {
-                let (width, _lsb) = net_widths.get(idx).copied().unwrap_or((1, 0));
-                let mut parts: Vec<NodeRef> = Vec::new();
-                for bit in bits.iter().rev() {
-                    let nr = match bit {
-                        Some(n) => *n,
-                        None => b.add_literal_bits(1, 0),
-                    };
-                    parts.push(nr);
-                }
-                if width == 1 {
-                    return Ok(parts[0]);
-                }
-                return Ok(b.add_node(
-                    NodePayload::Nary(NaryOp::Concat, parts),
-                    Type::Bits(width),
-                    None,
-                ));
-            }
-            Err(anyhow!(format!(
-                "net '{}' has no driver",
-                net_name_by_index(*idx, parsed)
-            )))
-        }
-        NetRef::BitSelect(idx, bit) => {
-            if let Some(nr) = net_drivers.get_whole(*idx) {
-                let (_, lsb) = net_widths.get(idx).copied().unwrap_or((1, 0));
-                let start = (*bit as i64 - lsb) as usize;
-                return Ok(b.add_node(
-                    NodePayload::BitSlice {
-                        arg: nr,
-                        start,
-                        width: 1,
-                    },
-                    Type::Bits(1),
-                    None,
-                ));
-            }
-            if let Some(bits) = net_drivers.get_bits(*idx) {
-                let (_, lsb) = net_widths.get(idx).copied().unwrap_or((1, 0));
-                let start = (*bit as i64 - lsb) as usize;
-                if start >= bits.len() {
-                    return Err(anyhow!(format!(
-                        "net '{}' has no driver",
-                        net_name_by_index(*idx, parsed)
-                    )));
-                }
-                return bits[start].ok_or_else(|| {
-                    anyhow!(format!(
-                        "net '{}' has no driver",
-                        net_name_by_index(*idx, parsed)
-                    ))
-                });
-            }
-            Err(anyhow!(format!(
-                "net '{}' has no driver",
-                net_name_by_index(*idx, parsed)
-            )))
-        }
-        NetRef::PartSelect(idx, msb, lsb) => {
-            if let Some(nr) = net_drivers.get_whole(*idx) {
-                let (_, net_lsb) = net_widths.get(idx).copied().unwrap_or((1, 0));
-                let (hi, lo) = (*msb as i64, *lsb as i64);
-                if hi < lo {
-                    return Err(anyhow!(format!(
-                        "unsupported part-select with msb<lsb for net '{}'",
-                        net_name_by_index(*idx, parsed)
-                    )));
-                }
-                let width = (hi - lo + 1) as usize;
-                let start = (lo - net_lsb) as usize;
-                return Ok(b.add_node(
-                    NodePayload::BitSlice {
-                        arg: nr,
-                        start,
-                        width,
-                    },
-                    Type::Bits(width),
-                    None,
-                ));
-            }
-            if let Some(bits) = net_drivers.get_bits(*idx) {
-                let (_, net_lsb) = net_widths.get(idx).copied().unwrap_or((1, 0));
-                let (hi, lo) = (*msb as i64, *lsb as i64);
-                if hi < lo {
-                    return Err(anyhow!(format!(
-                        "unsupported part-select with msb<lsb for net '{}'",
-                        net_name_by_index(*idx, parsed)
-                    )));
-                }
-                let mut parts: Vec<NodeRef> = Vec::new();
-                for bit in (lo..=hi).rev() {
-                    let offset = (bit - net_lsb) as usize;
-                    let nr = bits.get(offset).and_then(|n| *n).ok_or_else(|| {
-                        anyhow!(format!(
-                            "net '{}' has no driver",
-                            net_name_by_index(*idx, parsed)
-                        ))
-                    })?;
-                    parts.push(nr);
-                }
-                let width = (hi - lo + 1) as usize;
-                if width == 1 {
-                    return Ok(parts[0]);
-                }
-                return Ok(b.add_node(
-                    NodePayload::Nary(NaryOp::Concat, parts),
-                    Type::Bits(width),
-                    None,
-                ));
-            }
-            Err(anyhow!(format!(
-                "net '{}' has no driver",
-                net_name_by_index(*idx, parsed)
-            )))
-        }
-        NetRef::Literal(bits) => {
-            let lit = IrValue::from_bits(bits);
-            let width = bits.get_bit_count();
-            Ok(b.add_node(NodePayload::Literal(lit), Type::Bits(width), None))
-        }
-        NetRef::UnknownLiteral(_) => Err(anyhow!("unknown literal is unsupported in gv2block")),
-        NetRef::Unconnected => Ok(b.add_literal_bits(expected_width, 0)),
-        NetRef::Concat(elems) => {
-            let mut parts: Vec<NodeRef> = Vec::new();
-            let mut total_width = 0usize;
-            for e in elems {
-                let nr = net_ref_to_node(e, parsed, net_drivers, net_widths, b, 1)?;
-                let ty = b.nodes[nr.index].ty.clone();
-                let width = match ty {
-                    Type::Bits(w) => w,
-                    _ => return Err(anyhow!("concat element must be bits, got {:?}", ty)),
-                };
-                total_width += width;
-                parts.push(nr);
-            }
-            Ok(b.add_node(
-                NodePayload::Nary(NaryOp::Concat, parts),
-                Type::Bits(total_width),
-                None,
-            ))
-        }
-    }
 }
 
 fn emit_term_as_pir(

--- a/xlsynth-g8r/src/netlist/mod.rs
+++ b/xlsynth-g8r/src/netlist/mod.rs
@@ -12,6 +12,7 @@ pub mod gv2block;
 pub mod gv2ir;
 pub mod integrity;
 pub mod io;
+pub mod normalized;
 pub mod parse;
 pub mod report;
 pub mod sta;

--- a/xlsynth-g8r/src/netlist/normalized.rs
+++ b/xlsynth-g8r/src/netlist/normalized.rs
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Normalized per-bit connectivity for parsed gate-level netlists.
+//!
+//! The raw parser preserves Verilog syntax such as concat, selects, continuous
+//! assigns, and plain `tran` primitives. This module lowers those syntax forms
+//! once into canonical per-bit connectivity so downstream consumers do not each
+//! need to rediscover Verilog wiring semantics.
+
+use crate::netlist::bit_ref;
+use crate::netlist::parse::{
+    AssignExpr, InstIndex, Net, NetIndex, NetRef, NetlistAssignKind, NetlistModule, PortDirection,
+    PortId, Span,
+};
+use anyhow::{Result, anyhow};
+use std::collections::HashMap;
+use string_interner::symbol::SymbolU32;
+use string_interner::{StringInterner, backend::StringBackend};
+
+pub type BitIndex = usize;
+
+/// One normalized bit source used by pin bindings and assign leaves.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BitSource {
+    Bit(BitIndex),
+    Literal(bool),
+    Unknown,
+}
+
+/// One normalized per-bit assign expression.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BitExpr {
+    Source(BitSource),
+    Not(Box<BitExpr>),
+    And(Box<BitExpr>, Box<BitExpr>),
+    Or(Box<BitExpr>, Box<BitExpr>),
+    Xor(Box<BitExpr>, Box<BitExpr>),
+}
+
+impl BitExpr {
+    /// Appends every normalized net bit referenced by this expression.
+    pub fn collect_source_bits(&self, out: &mut Vec<BitIndex>) {
+        match self {
+            Self::Source(BitSource::Bit(bit_idx)) => out.push(*bit_idx),
+            Self::Source(BitSource::Literal(_) | BitSource::Unknown) => {}
+            Self::Not(inner) => inner.collect_source_bits(out),
+            Self::And(lhs, rhs) | Self::Or(lhs, rhs) | Self::Xor(lhs, rhs) => {
+                lhs.collect_source_bits(out);
+                rhs.collect_source_bits(out);
+            }
+        }
+    }
+}
+
+/// One normalized continuous assign statement.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NormalizedAssign {
+    pub lhs_bits: Vec<BitIndex>,
+    pub rhs_bits: Vec<BitExpr>,
+    pub rendered_lhs: String,
+    pub span: Span,
+}
+
+/// One normalized instance pin binding.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NormalizedConnection {
+    pub port: PortId,
+    pub bits: Vec<BitSource>,
+}
+
+/// One normalized instance view.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NormalizedInstance {
+    pub raw_index: InstIndex,
+    pub type_name: PortId,
+    pub instance_name: PortId,
+    pub connections: Vec<NormalizedConnection>,
+    pub inst_lineno: u32,
+    pub inst_colno: u32,
+}
+
+/// One normalized module port view.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NormalizedPort {
+    pub direction: PortDirection,
+    pub width: Option<(u32, u32)>,
+    pub name: PortId,
+    pub bits: Vec<BitIndex>,
+}
+
+/// Canonical per-bit connectivity for one parsed module.
+pub struct NormalizedNetlistModule<'a> {
+    pub raw: &'a NetlistModule,
+    bits: Vec<bit_ref::NetBit>,
+    index_by_bit: HashMap<bit_ref::NetBit, BitIndex>,
+    bits_by_net: Vec<Vec<BitIndex>>,
+    canonical_bits: Vec<BitIndex>,
+    pub ports: Vec<NormalizedPort>,
+    pub instances: Vec<NormalizedInstance>,
+    pub assigns: Vec<NormalizedAssign>,
+}
+
+impl<'a> NormalizedNetlistModule<'a> {
+    /// Builds canonical per-bit connectivity for one parsed module.
+    pub fn new(
+        module: &'a NetlistModule,
+        nets: &[Net],
+        interner: &StringInterner<StringBackend<SymbolU32>>,
+    ) -> Result<Self> {
+        let (bits, index_by_bit, bits_by_net) = build_bit_index(nets)?;
+        let canonical_bits =
+            build_tran_aliases(module, nets, interner, bits.as_slice(), &index_by_bit)?;
+        let ports = normalize_ports(module, nets, &bits_by_net, canonical_bits.as_slice())?;
+        let instances = normalize_instances(
+            module,
+            nets,
+            interner,
+            &index_by_bit,
+            canonical_bits.as_slice(),
+        )?;
+        let assigns = normalize_assigns(
+            module,
+            nets,
+            interner,
+            &index_by_bit,
+            canonical_bits.as_slice(),
+        )?;
+        Ok(Self {
+            raw: module,
+            bits,
+            index_by_bit,
+            bits_by_net,
+            canonical_bits,
+            ports,
+            instances,
+            assigns,
+        })
+    }
+
+    pub fn bit_count(&self) -> usize {
+        self.bits.len()
+    }
+
+    pub fn bit(&self, bit_idx: BitIndex) -> bit_ref::NetBit {
+        self.bits[bit_idx]
+    }
+
+    pub fn bit_index(&self, bit: bit_ref::NetBit) -> Result<BitIndex> {
+        self.index_by_bit.get(&bit).copied().ok_or_else(|| {
+            anyhow!(
+                "net bit NetIndex({})[{}] is not present in normalized bit index",
+                bit.net.0,
+                bit.bit_number
+            )
+        })
+    }
+
+    pub fn net_bits(&self, net: NetIndex) -> &[BitIndex] {
+        &self.bits_by_net[net.0]
+    }
+
+    pub fn canonical_bit(&self, bit_idx: BitIndex) -> BitIndex {
+        self.canonical_bits[bit_idx]
+    }
+
+    pub fn canonical_bits(&self) -> &[BitIndex] {
+        self.canonical_bits.as_slice()
+    }
+
+    pub fn render_bit(
+        &self,
+        bit_idx: BitIndex,
+        nets: &[Net],
+        interner: &StringInterner<StringBackend<SymbolU32>>,
+    ) -> String {
+        bit_ref::render_net_bit(self.bits[bit_idx], nets, interner)
+    }
+
+    pub fn render_source(
+        &self,
+        source: BitSource,
+        nets: &[Net],
+        interner: &StringInterner<StringBackend<SymbolU32>>,
+    ) -> String {
+        match source {
+            BitSource::Bit(bit_idx) => self.render_bit(bit_idx, nets, interner),
+            BitSource::Literal(false) => "1'b0".to_string(),
+            BitSource::Literal(true) => "1'b1".to_string(),
+            BitSource::Unknown => "1'bx".to_string(),
+        }
+    }
+
+    pub fn render_sources(
+        &self,
+        sources: &[BitSource],
+        nets: &[Net],
+        interner: &StringInterner<StringBackend<SymbolU32>>,
+    ) -> String {
+        match sources {
+            [] => "<unconnected>".to_string(),
+            [source] => self.render_source(*source, nets, interner),
+            _ => {
+                let mut parts: Vec<String> = sources
+                    .iter()
+                    .rev()
+                    .copied()
+                    .map(|source| self.render_source(source, nets, interner))
+                    .collect();
+                parts.shrink_to_fit();
+                format!("{{{}}}", parts.join(", "))
+            }
+        }
+    }
+}
+
+fn build_bit_index(
+    nets: &[Net],
+) -> Result<(
+    Vec<bit_ref::NetBit>,
+    HashMap<bit_ref::NetBit, BitIndex>,
+    Vec<Vec<BitIndex>>,
+)> {
+    let mut bits = Vec::new();
+    let mut index_by_bit = HashMap::new();
+    let mut bits_by_net = vec![Vec::new(); nets.len()];
+    for (net_raw_idx, net) in nets.iter().enumerate() {
+        let net_idx = NetIndex(net_raw_idx);
+        for offset in 0..net.width_bits() {
+            let bit_number = net.bit_number(offset).ok_or_else(|| {
+                anyhow!(
+                    "internal error computing bit {} for net index {}",
+                    offset,
+                    net_raw_idx
+                )
+            })?;
+            let bit = bit_ref::NetBit {
+                net: net_idx,
+                bit_number,
+            };
+            let bit_idx = bits.len();
+            bits.push(bit);
+            index_by_bit.insert(bit, bit_idx);
+            bits_by_net[net_raw_idx].push(bit_idx);
+        }
+    }
+    Ok((bits, index_by_bit, bits_by_net))
+}
+
+fn build_tran_aliases(
+    module: &NetlistModule,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    bits: &[bit_ref::NetBit],
+    index_by_bit: &HashMap<bit_ref::NetBit, BitIndex>,
+) -> Result<Vec<BitIndex>> {
+    let mut parents: Vec<BitIndex> = (0..bits.len()).collect();
+    for tran in module
+        .assigns
+        .iter()
+        .filter(|assign| assign.kind == NetlistAssignKind::Tran)
+    {
+        let AssignExpr::Leaf(rhs) = &tran.rhs else {
+            unreachable!("tran parser only constructs leaf net refs")
+        };
+        let lhs_bits = bit_ref::net_ref_lsb_targets(&tran.lhs, nets, interner)?;
+        let rhs_bits = bit_ref::net_ref_lsb_targets(rhs, nets, interner)?;
+        if lhs_bits.len() != rhs_bits.len() {
+            return Err(anyhow!(
+                "plain tran terminals must have equal widths; '{}' has {} bit(s) and '{}' has {} bit(s)",
+                bit_ref::render_net_ref(&tran.lhs, nets, interner),
+                lhs_bits.len(),
+                bit_ref::render_net_ref(rhs, nets, interner),
+                rhs_bits.len()
+            ));
+        }
+        for (lhs_bit, rhs_bit) in lhs_bits.into_iter().zip(rhs_bits) {
+            let lhs_bit_idx = bit_index(index_by_bit, lhs_bit)?;
+            let rhs_bit_idx = bit_index(index_by_bit, rhs_bit)?;
+            union_aliases(parents.as_mut_slice(), lhs_bit_idx, rhs_bit_idx);
+        }
+    }
+    Ok((0..bits.len())
+        .map(|bit_idx| find_alias_root(parents.as_mut_slice(), bit_idx))
+        .collect())
+}
+
+fn bit_index(
+    index_by_bit: &HashMap<bit_ref::NetBit, BitIndex>,
+    bit: bit_ref::NetBit,
+) -> Result<BitIndex> {
+    index_by_bit.get(&bit).copied().ok_or_else(|| {
+        anyhow!(
+            "net bit NetIndex({})[{}] is not present in normalized bit index",
+            bit.net.0,
+            bit.bit_number
+        )
+    })
+}
+
+fn find_alias_root(parents: &mut [BitIndex], bit_idx: BitIndex) -> BitIndex {
+    let parent = parents[bit_idx];
+    if parent == bit_idx {
+        bit_idx
+    } else {
+        let root = find_alias_root(parents, parent);
+        parents[bit_idx] = root;
+        root
+    }
+}
+
+fn union_aliases(parents: &mut [BitIndex], lhs_bit_idx: BitIndex, rhs_bit_idx: BitIndex) {
+    let lhs_root = find_alias_root(parents, lhs_bit_idx);
+    let rhs_root = find_alias_root(parents, rhs_bit_idx);
+    if lhs_root == rhs_root {
+        return;
+    }
+    let (root, child) = if lhs_root < rhs_root {
+        (lhs_root, rhs_root)
+    } else {
+        (rhs_root, lhs_root)
+    };
+    parents[child] = root;
+}
+
+fn normalize_ports(
+    module: &NetlistModule,
+    nets: &[Net],
+    bits_by_net: &[Vec<BitIndex>],
+    canonical_bits: &[BitIndex],
+) -> Result<Vec<NormalizedPort>> {
+    module
+        .ports
+        .iter()
+        .map(|port| {
+            let net_idx = module.find_net_index(port.name, nets).ok_or_else(|| {
+                anyhow!("module port net for symbol {:?} was not found", port.name)
+            })?;
+            Ok(NormalizedPort {
+                direction: port.direction.clone(),
+                width: port.width,
+                name: port.name,
+                bits: bits_by_net[net_idx.0]
+                    .iter()
+                    .map(|bit_idx| canonical_bits[*bit_idx])
+                    .collect(),
+            })
+        })
+        .collect()
+}
+
+fn normalize_instances(
+    module: &NetlistModule,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    index_by_bit: &HashMap<bit_ref::NetBit, BitIndex>,
+    canonical_bits: &[BitIndex],
+) -> Result<Vec<NormalizedInstance>> {
+    module
+        .instances
+        .iter()
+        .enumerate()
+        .map(|(inst_idx, inst)| {
+            let connections = inst
+                .connections
+                .iter()
+                .map(|(port, net_ref)| {
+                    Ok(NormalizedConnection {
+                        port: *port,
+                        bits: normalize_net_ref_bits(
+                            net_ref,
+                            nets,
+                            interner,
+                            index_by_bit,
+                            canonical_bits,
+                        )?,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(NormalizedInstance {
+                raw_index: InstIndex(inst_idx),
+                type_name: inst.type_name,
+                instance_name: inst.instance_name,
+                connections,
+                inst_lineno: inst.inst_lineno,
+                inst_colno: inst.inst_colno,
+            })
+        })
+        .collect()
+}
+
+fn normalize_assigns(
+    module: &NetlistModule,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    index_by_bit: &HashMap<bit_ref::NetBit, BitIndex>,
+    canonical_bits: &[BitIndex],
+) -> Result<Vec<NormalizedAssign>> {
+    let mut assigns = Vec::new();
+    for assign in module
+        .assigns
+        .iter()
+        .filter(|assign| assign.kind == NetlistAssignKind::Continuous)
+    {
+        let lhs_bits: Vec<BitIndex> = bit_ref::net_ref_lsb_targets(&assign.lhs, nets, interner)?
+            .into_iter()
+            .map(|bit| bit_index(index_by_bit, bit).map(|bit_idx| canonical_bits[bit_idx]))
+            .collect::<Result<Vec<_>>>()?;
+        let rhs_width = bit_ref::assign_expr_width_bits(&assign.rhs, nets, interner)?;
+        let allow_literal_zero_extend = is_bare_literal_assign_expr(&assign.rhs);
+        if lhs_bits.len() != rhs_width && !allow_literal_zero_extend {
+            return Err(anyhow!(
+                "assign to '{}' has lhs width {} but rhs width {}; normalized netlist requires exact-width assigns except for bare literal tie-offs",
+                bit_ref::render_net_ref(&assign.lhs, nets, interner),
+                lhs_bits.len(),
+                rhs_width
+            ));
+        }
+        let rhs_bits = normalize_assign_expr_bits(
+            &assign.rhs,
+            lhs_bits.len(),
+            allow_literal_zero_extend,
+            nets,
+            interner,
+            index_by_bit,
+            canonical_bits,
+        )?;
+        assigns.push(NormalizedAssign {
+            lhs_bits,
+            rhs_bits,
+            rendered_lhs: bit_ref::render_net_ref(&assign.lhs, nets, interner),
+            span: assign.span,
+        });
+    }
+    Ok(assigns)
+}
+
+fn normalize_assign_expr_bits(
+    expr: &AssignExpr,
+    expected_width: usize,
+    allow_bare_literal_zero_extend: bool,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    index_by_bit: &HashMap<bit_ref::NetBit, BitIndex>,
+    canonical_bits: &[BitIndex],
+) -> Result<Vec<BitExpr>> {
+    match expr {
+        AssignExpr::Leaf(net_ref) => {
+            let mut bits =
+                normalize_net_ref_bits(net_ref, nets, interner, index_by_bit, canonical_bits)?;
+            if bits.len() != expected_width {
+                if allow_bare_literal_zero_extend
+                    && matches!(net_ref, NetRef::Literal(_))
+                    && bits.len() <= expected_width
+                {
+                    bits.resize(expected_width, BitSource::Literal(false));
+                } else {
+                    return Err(anyhow!(
+                        "assign expression '{}' has width {} but expected {}",
+                        bit_ref::render_net_ref(net_ref, nets, interner),
+                        bits.len(),
+                        expected_width
+                    ));
+                }
+            }
+            Ok(bits.into_iter().map(BitExpr::Source).collect())
+        }
+        AssignExpr::Not(inner) => Ok(normalize_assign_expr_bits(
+            inner,
+            expected_width,
+            false,
+            nets,
+            interner,
+            index_by_bit,
+            canonical_bits,
+        )?
+        .into_iter()
+        .map(|bit| BitExpr::Not(Box::new(bit)))
+        .collect()),
+        AssignExpr::And(lhs, rhs) | AssignExpr::Or(lhs, rhs) | AssignExpr::Xor(lhs, rhs) => {
+            let lhs_bits = normalize_assign_expr_bits(
+                lhs,
+                expected_width,
+                false,
+                nets,
+                interner,
+                index_by_bit,
+                canonical_bits,
+            )?;
+            let rhs_bits = normalize_assign_expr_bits(
+                rhs,
+                expected_width,
+                false,
+                nets,
+                interner,
+                index_by_bit,
+                canonical_bits,
+            )?;
+            Ok(lhs_bits
+                .into_iter()
+                .zip(rhs_bits)
+                .map(|(lhs, rhs)| match expr {
+                    AssignExpr::And(_, _) => BitExpr::And(Box::new(lhs), Box::new(rhs)),
+                    AssignExpr::Or(_, _) => BitExpr::Or(Box::new(lhs), Box::new(rhs)),
+                    AssignExpr::Xor(_, _) => BitExpr::Xor(Box::new(lhs), Box::new(rhs)),
+                    _ => unreachable!("binary assign expression matched as non-binary"),
+                })
+                .collect())
+        }
+    }
+}
+
+fn normalize_net_ref_bits(
+    net_ref: &NetRef,
+    nets: &[Net],
+    interner: &StringInterner<StringBackend<SymbolU32>>,
+    index_by_bit: &HashMap<bit_ref::NetBit, BitIndex>,
+    canonical_bits: &[BitIndex],
+) -> Result<Vec<BitSource>> {
+    bit_ref::net_ref_lsb_bit_refs(net_ref, nets, interner)?
+        .into_iter()
+        .map(|bit_ref| match bit_ref {
+            bit_ref::NetBitRef::Net(bit) => {
+                bit_index(index_by_bit, bit).map(|bit_idx| BitSource::Bit(canonical_bits[bit_idx]))
+            }
+            bit_ref::NetBitRef::Literal(value) => Ok(BitSource::Literal(value)),
+            bit_ref::NetBitRef::Unknown => Ok(BitSource::Unknown),
+        })
+        .collect()
+}
+
+fn is_bare_literal_assign_expr(expr: &AssignExpr) -> bool {
+    matches!(expr, AssignExpr::Leaf(NetRef::Literal(_)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BitExpr, BitSource, NormalizedNetlistModule};
+    use crate::netlist::parse::{Parser, TokenScanner};
+
+    fn parse_single_module(
+        src: &str,
+    ) -> (
+        crate::netlist::parse::NetlistModule,
+        Vec<crate::netlist::parse::Net>,
+        string_interner::StringInterner<
+            string_interner::backend::StringBackend<string_interner::symbol::SymbolU32>,
+        >,
+    ) {
+        let lines: Vec<String> = src.lines().map(|line| line.to_string()).collect();
+        let lookup = move |lineno: u32| lines.get((lineno - 1) as usize).cloned();
+        let scanner = TokenScanner::with_line_lookup(
+            std::io::Cursor::new(src.as_bytes().to_vec()),
+            Box::new(lookup),
+        );
+        let mut parser = Parser::new(scanner);
+        let mut modules = parser.parse_file().expect("parse ok");
+        assert_eq!(modules.len(), 1);
+        (modules.remove(0), parser.nets, parser.interner)
+    }
+
+    #[test]
+    fn normalizes_concat_assign_and_tran_aliases() {
+        let (module, nets, interner) = parse_single_module(
+            r#"
+module top(a, y);
+  input [1:0] a;
+  output y;
+  wire [1:0] a;
+  wire y;
+  wire [1:0] tmp;
+  wire y_alias;
+  assign tmp = {a[0], a[1]};
+  tran(y, y_alias);
+  BUF u0 (.A(tmp[1]), .Y(y_alias));
+endmodule
+"#,
+        );
+        let normalized =
+            NormalizedNetlistModule::new(&module, &nets, &interner).expect("normalize netlist");
+        assert_eq!(normalized.assigns.len(), 1);
+        assert_eq!(normalized.assigns[0].lhs_bits.len(), 2);
+        assert!(matches!(
+            normalized.assigns[0].rhs_bits.as_slice(),
+            [
+                BitExpr::Source(BitSource::Bit(_)),
+                BitExpr::Source(BitSource::Bit(_))
+            ]
+        ));
+        let y = normalized
+            .ports
+            .iter()
+            .find(|port| interner.resolve(port.name) == Some("y"))
+            .expect("find y port");
+        let y_alias = nets
+            .iter()
+            .position(|net| interner.resolve(net.name) == Some("y_alias"))
+            .map(crate::netlist::parse::NetIndex)
+            .expect("find y_alias");
+        assert_eq!(
+            y.bits,
+            vec![normalized.canonical_bit(normalized.net_bits(y_alias)[0])]
+        );
+    }
+}

--- a/xlsynth-g8r/src/netlist/parse.rs
+++ b/xlsynth-g8r/src/netlist/parse.rs
@@ -184,9 +184,17 @@ impl AssignExpr {
 /// Continuous assignment preserved from the parsed netlist.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NetlistAssign {
+    pub kind: NetlistAssignKind,
     pub lhs: NetRef,
     pub rhs: AssignExpr,
     pub span: Span,
+}
+
+/// Preserved netlist statement kind represented by `NetlistAssign`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetlistAssignKind {
+    Continuous,
+    Tran,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1626,10 +1634,154 @@ impl<R: Read + 'static> Parser<R> {
             });
         }
         Ok(NetlistAssign {
+            kind: NetlistAssignKind::Continuous,
             lhs,
             rhs,
             span: Span {
                 start: t_assign.span.start,
+                limit: t_semi.span.limit,
+            },
+        })
+    }
+
+    /// Parses: tran [instance_name [msb:lsb]] ( lhs, rhs );
+    fn parse_tran(&mut self) -> Result<NetlistAssign, ScanError> {
+        let t_tran = self.scanner.popt()?.ok_or_else(|| ScanError {
+            message: "expected 'tran'".to_string(),
+            span: Span {
+                start: self.scanner.pos,
+                limit: self.scanner.pos,
+            },
+        })?;
+        if !matches!(t_tran.payload, TokenPayload::Identifier(ref s) if s == "tran") {
+            return Err(ScanError {
+                message: "expected 'tran'".to_string(),
+                span: t_tran.span,
+            });
+        }
+
+        self.skip_trivia()?;
+        if let Some(tok) = self.scanner.peekt()? {
+            if matches!(tok.payload, TokenPayload::Identifier(_)) {
+                self.scanner.popt()?;
+                self.skip_trivia()?;
+                if let Some(range_tok) = self.scanner.peekt()? {
+                    if matches!(range_tok.payload, TokenPayload::OBrack) {
+                        self.scanner.popt()?;
+                        self.skip_trivia()?;
+                        let _msb = self.scanner.popt()?.ok_or_else(|| ScanError {
+                            message: "expected msb in tran instance range".to_string(),
+                            span: Span {
+                                start: self.scanner.pos,
+                                limit: self.scanner.pos,
+                            },
+                        })?;
+                        self.skip_trivia()?;
+                        let colon = self.scanner.popt()?.ok_or_else(|| ScanError {
+                            message: "expected ':' in tran instance range".to_string(),
+                            span: Span {
+                                start: self.scanner.pos,
+                                limit: self.scanner.pos,
+                            },
+                        })?;
+                        if !matches!(colon.payload, TokenPayload::Colon) {
+                            return Err(ScanError {
+                                message: "expected ':' in tran instance range".to_string(),
+                                span: colon.span,
+                            });
+                        }
+                        self.skip_trivia()?;
+                        let _lsb = self.scanner.popt()?.ok_or_else(|| ScanError {
+                            message: "expected lsb in tran instance range".to_string(),
+                            span: Span {
+                                start: self.scanner.pos,
+                                limit: self.scanner.pos,
+                            },
+                        })?;
+                        self.skip_trivia()?;
+                        let cbrack = self.scanner.popt()?.ok_or_else(|| ScanError {
+                            message: "expected ']' after tran instance range".to_string(),
+                            span: Span {
+                                start: self.scanner.pos,
+                                limit: self.scanner.pos,
+                            },
+                        })?;
+                        if !matches!(cbrack.payload, TokenPayload::CBrack) {
+                            return Err(ScanError {
+                                message: "expected ']' after tran instance range".to_string(),
+                                span: cbrack.span,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        self.skip_trivia()?;
+        let oparen = self.scanner.popt()?.ok_or_else(|| ScanError {
+            message: "expected '(' after tran".to_string(),
+            span: Span {
+                start: self.scanner.pos,
+                limit: self.scanner.pos,
+            },
+        })?;
+        if !matches!(oparen.payload, TokenPayload::OParen) {
+            return Err(ScanError {
+                message: "expected '(' after tran".to_string(),
+                span: oparen.span,
+            });
+        }
+
+        let lhs = self.parse_netref_expr()?;
+        self.skip_trivia()?;
+        let comma = self.scanner.popt()?.ok_or_else(|| ScanError {
+            message: "expected ',' between tran terminals".to_string(),
+            span: Span {
+                start: self.scanner.pos,
+                limit: self.scanner.pos,
+            },
+        })?;
+        if !matches!(comma.payload, TokenPayload::Comma) {
+            return Err(ScanError {
+                message: "expected ',' between tran terminals".to_string(),
+                span: comma.span,
+            });
+        }
+        let rhs = self.parse_netref_expr()?;
+        self.skip_trivia()?;
+        let cparen = self.scanner.popt()?.ok_or_else(|| ScanError {
+            message: "expected ')' after tran terminals".to_string(),
+            span: Span {
+                start: self.scanner.pos,
+                limit: self.scanner.pos,
+            },
+        })?;
+        if !matches!(cparen.payload, TokenPayload::CParen) {
+            return Err(ScanError {
+                message: "expected ')' after tran terminals".to_string(),
+                span: cparen.span,
+            });
+        }
+        self.skip_trivia()?;
+        let t_semi = self.scanner.popt()?.ok_or_else(|| ScanError {
+            message: "expected ';' after tran".to_string(),
+            span: Span {
+                start: self.scanner.pos,
+                limit: self.scanner.pos,
+            },
+        })?;
+        if !matches!(t_semi.payload, TokenPayload::Semi) {
+            return Err(ScanError {
+                message: "expected ';' after tran".to_string(),
+                span: t_semi.span,
+            });
+        }
+        Ok(NetlistAssign {
+            kind: NetlistAssignKind::Tran,
+            lhs,
+            rhs: AssignExpr::Leaf(rhs),
+            span: Span {
+                start: t_tran.span.start,
                 limit: t_semi.span.limit,
             },
         })
@@ -1806,6 +1958,9 @@ impl<R: Read + 'static> Parser<R> {
                     }
                     TokenPayload::Identifier(s) if s == "assign" => {
                         assigns.push(self.parse_assign()?);
+                    }
+                    TokenPayload::Identifier(s) if s == "tran" => {
+                        assigns.push(self.parse_tran()?);
                     }
                     TokenPayload::Identifier(_) => {
                         let instance = self.parse_instance()?;
@@ -2444,10 +2599,55 @@ endmodule
         let modules = parser.parse_file().expect("parse ok");
         assert_eq!(modules.len(), 1);
         assert_eq!(modules[0].assigns.len(), 1);
+        assert_eq!(modules[0].assigns[0].kind, NetlistAssignKind::Continuous);
         assert!(matches!(modules[0].assigns[0].lhs, NetRef::BitSelect(_, 1)));
         assert!(matches!(
             modules[0].assigns[0].rhs,
             AssignExpr::Leaf(NetRef::Literal(_))
+        ));
+    }
+
+    #[test]
+    fn test_parse_module_accepts_unnamed_tran() {
+        let src = r#"
+module m(a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  tran(y, a);
+endmodule
+"#;
+        let mut parser = Parser::new(TokenScanner::from_str(src));
+        let modules = parser.parse_file().expect("tran should parse");
+        assert_eq!(modules[0].assigns.len(), 1);
+        assert_eq!(modules[0].assigns[0].kind, NetlistAssignKind::Tran);
+        assert!(matches!(modules[0].assigns[0].lhs, NetRef::Simple(_)));
+        assert!(matches!(
+            modules[0].assigns[0].rhs,
+            AssignExpr::Leaf(NetRef::Simple(_))
+        ));
+    }
+
+    #[test]
+    fn test_parse_module_accepts_named_arrayed_tran() {
+        let src = r#"
+module m(a, y);
+  input [1:0] a;
+  output [1:0] y;
+  wire [1:0] a;
+  wire [1:0] y;
+  tran t[1:0]({y[1], y[0]}, {a[1], a[0]});
+endmodule
+"#;
+        let mut parser = Parser::new(TokenScanner::from_str(src));
+        let modules = parser.parse_file().expect("arrayed tran should parse");
+        assert_eq!(modules[0].assigns.len(), 1);
+        assert_eq!(modules[0].assigns[0].kind, NetlistAssignKind::Tran);
+        assert!(matches!(modules[0].assigns[0].lhs, NetRef::Concat(_)));
+        assert!(matches!(
+            modules[0].assigns[0].rhs,
+            AssignExpr::Leaf(NetRef::Concat(_))
         ));
     }
 

--- a/xlsynth-g8r/src/netlist/report.rs
+++ b/xlsynth-g8r/src/netlist/report.rs
@@ -440,6 +440,37 @@ endmodule
     }
 
     #[test]
+    fn build_netlist_report_accepts_yosys_tran_alias() {
+        let parsed = parse_netlist(
+            r#"
+module top (x, y);
+  input x;
+  output y;
+  wire x;
+  wire y;
+  wire y_alias;
+  BUF u0 (.A(x), .Y(y_alias));
+  tran(y, y_alias);
+endmodule
+"#,
+        );
+        let module = select_module(&parsed, None).expect("select only module");
+        let library = LibraryWithTimingData::from_proto(inv_nand_library());
+        let report = build_netlist_report(
+            module,
+            &parsed.nets,
+            &parsed.interner,
+            &library,
+            StaOptions::default(),
+        )
+        .expect("build report with Yosys tran alias");
+        assert_eq!(report.area, 1.0);
+        assert_eq!(report.delay, 1.0);
+        assert_eq!(report.cell_count, 1);
+        assert_eq!(report.cell_levels, 1);
+    }
+
+    #[test]
     fn build_area_report_rejects_unknown_cells() {
         let parsed = parse_netlist(
             r#"

--- a/xlsynth-g8r/src/netlist/sta.rs
+++ b/xlsynth-g8r/src/netlist/sta.rs
@@ -51,8 +51,8 @@ use crate::liberty::LibraryWithTimingData;
 use crate::liberty::cell_formula::parse_formula;
 use crate::liberty::timing_table::TimingTableArrayView;
 use crate::liberty_proto::{LuTableTemplate, Pin, PinDirection, TimingArc, TimingTable};
-use crate::netlist::bit_ref;
-use crate::netlist::parse::{AssignExpr, Net, NetIndex, NetRef, NetlistModule, PortDirection};
+use crate::netlist::normalized::{BitExpr, BitSource, NormalizedNetlistModule};
+use crate::netlist::parse::{Net, NetIndex, NetlistModule, PortDirection};
 use anyhow::{Result, anyhow};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -331,73 +331,7 @@ struct AssignSourceAnalysis {
     unsupported_sources: Vec<UnsupportedAssignSource>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum PinBitSource {
-    Bit(usize),
-    Literal(bool),
-    Unknown,
-}
-
-struct StaBitIndex {
-    bits: Vec<bit_ref::NetBit>,
-    index_by_bit: HashMap<bit_ref::NetBit, usize>,
-    bits_by_net: Vec<Vec<usize>>,
-}
-
-impl StaBitIndex {
-    fn build(nets: &[Net]) -> Result<Self> {
-        let mut bits = Vec::new();
-        let mut index_by_bit = HashMap::new();
-        let mut bits_by_net = vec![Vec::new(); nets.len()];
-        for (net_raw_idx, net) in nets.iter().enumerate() {
-            let net_idx = NetIndex(net_raw_idx);
-            for offset in 0..net.width_bits() {
-                let bit_number = net.bit_number(offset).ok_or_else(|| {
-                    anyhow!(
-                        "internal error computing bit {} for net index {}",
-                        offset,
-                        net_raw_idx
-                    )
-                })?;
-                let bit = bit_ref::NetBit {
-                    net: net_idx,
-                    bit_number,
-                };
-                let bit_idx = bits.len();
-                bits.push(bit);
-                index_by_bit.insert(bit, bit_idx);
-                bits_by_net[net_raw_idx].push(bit_idx);
-            }
-        }
-        Ok(Self {
-            bits,
-            index_by_bit,
-            bits_by_net,
-        })
-    }
-
-    fn bit_index(&self, bit: bit_ref::NetBit) -> Result<usize> {
-        self.index_by_bit.get(&bit).copied().ok_or_else(|| {
-            anyhow!(
-                "net bit NetIndex({})[{}] is not present in STA bit index",
-                bit.net.0,
-                bit.bit_number
-            )
-        })
-    }
-
-    fn bit_ref_to_source(&self, bit_ref: bit_ref::NetBitRef) -> Result<PinBitSource> {
-        match bit_ref {
-            bit_ref::NetBitRef::Net(bit) => Ok(PinBitSource::Bit(self.bit_index(bit)?)),
-            bit_ref::NetBitRef::Literal(value) => Ok(PinBitSource::Literal(value)),
-            bit_ref::NetBitRef::Unknown => Ok(PinBitSource::Unknown),
-        }
-    }
-
-    fn net_bits(&self, net: NetIndex) -> &[usize] {
-        &self.bits_by_net[net.0]
-    }
-}
+type PinBitSource = BitSource;
 
 pub fn analyze_combinational_max_arrival(
     module: &NetlistModule,
@@ -442,13 +376,13 @@ fn analyze_combinational_max_arrival_proto(
     }
 
     let lib = StaLibraryIndex::new(library)?;
-    let instance_count = module.instances.len();
-    let bit_index = StaBitIndex::build(nets)?;
-    let bit_count = bit_index.bits.len();
-    let assign_analysis = analyze_assign_sources(module, nets, interner, &bit_index)?;
+    let normalized = NormalizedNetlistModule::new(module, nets, interner)?;
+    let instance_count = normalized.instances.len();
+    let bit_count = normalized.bit_count();
+    let assign_analysis = analyze_assign_sources(&normalized, nets, interner)?;
     let assign_sources = assign_analysis.bit_sources;
     let resolved_timing_sources =
-        resolve_timing_sources(assign_sources.as_slice(), &bit_index, nets, interner)?;
+        resolve_timing_sources(assign_sources.as_slice(), &normalized, nets, interner)?;
 
     let mut instance_cell_indices: Vec<usize> = Vec::with_capacity(instance_count);
     let mut instance_cell_names: Vec<String> = Vec::with_capacity(instance_count);
@@ -462,7 +396,7 @@ fn analyze_combinational_max_arrival_proto(
     let mut bit_drivers: Vec<Vec<NetEndpoint>> = vec![Vec::new(); bit_count];
     let mut bit_loads: Vec<Vec<NetEndpoint>> = vec![Vec::new(); bit_count];
 
-    for (inst_idx, inst) in module.instances.iter().enumerate() {
+    for (inst_idx, inst) in normalized.instances.iter().enumerate() {
         let cell_name = resolve_symbol(interner, inst.type_name, "cell type")?;
         let cell_idx = lib.cell_index(cell_name.as_str()).ok_or_else(|| {
             anyhow!(
@@ -509,8 +443,8 @@ fn analyze_combinational_max_arrival_proto(
 
         let mut pin_sources: HashMap<String, Vec<PinBitSource>> = HashMap::new();
         let mut known_pin_values = HashMap::new();
-        for (port_sym, netref) in &inst.connections {
-            let pin_name = resolve_symbol(interner, *port_sym, "pin name")?;
+        for connection in &inst.connections {
+            let pin_name = resolve_symbol(interner, connection.port, "pin name")?;
             if pin_sources.contains_key(pin_name.as_str()) {
                 return Err(anyhow!(
                     "instance '{}' of '{}' connects pin '{}' more than once; duplicate pin bindings are unsupported in basic STA",
@@ -529,11 +463,7 @@ fn analyze_combinational_max_arrival_proto(
                     pin_name
                 )
             })?;
-            let bit_refs = bit_ref::net_ref_lsb_bit_refs(netref, nets, interner)?;
-            let pin_bit_sources: Vec<PinBitSource> = bit_refs
-                .into_iter()
-                .map(|bit_ref| bit_index.bit_ref_to_source(bit_ref))
-                .collect::<Result<Vec<_>>>()?;
+            let pin_bit_sources = connection.bits.clone();
             let pin_bit_sources = if pin.direction == PinDirection::Input as i32 {
                 pin_bit_sources
                     .into_iter()
@@ -606,24 +536,20 @@ fn analyze_combinational_max_arrival_proto(
     let mut module_output_bits: Vec<usize> = Vec::new();
     let mut has_module_output = vec![false; bit_count];
     let mut is_module_input = vec![false; bit_count];
-    for port in &module.ports {
+    for port in &normalized.ports {
         let port_name = resolve_symbol(interner, port.name, "port name")
             .unwrap_or_else(|_| "<unknown>".to_string());
         match port.direction {
             PortDirection::Input => {
-                if let Some(net_idx) = module.find_net_index(port.name, nets) {
-                    for bit_idx in bit_index.net_bits(net_idx) {
-                        is_module_input[*bit_idx] = true;
-                    }
+                for bit_idx in &port.bits {
+                    is_module_input[*bit_idx] = true;
                 }
             }
             PortDirection::Output => {
-                if let Some(net_idx) = module.find_net_index(port.name, nets) {
-                    for bit_idx in bit_index.net_bits(net_idx) {
-                        if !has_module_output[*bit_idx] {
-                            has_module_output[*bit_idx] = true;
-                            module_output_bits.push(*bit_idx);
-                        }
+                for bit_idx in &port.bits {
+                    if !has_module_output[*bit_idx] {
+                        has_module_output[*bit_idx] = true;
+                        module_output_bits.push(*bit_idx);
                     }
                 }
             }
@@ -648,7 +574,7 @@ fn analyze_combinational_max_arrival_proto(
         assign_sources.as_slice(),
         bit_loads.as_slice(),
         has_module_output.as_slice(),
-        &bit_index,
+        &normalized,
         nets,
         interner,
     )?;
@@ -659,14 +585,14 @@ fn analyze_combinational_max_arrival_proto(
     for (bit_idx, drivers) in bit_drivers.iter().enumerate() {
         let has_assign_source = assign_sources[bit_idx].is_some();
         if is_module_input[bit_idx] && (!drivers.is_empty() || has_assign_source) {
-            let bit_name = bit_ref::render_net_bit(bit_index.bits[bit_idx], nets, interner);
+            let bit_name = normalized.render_bit(bit_idx, nets, interner);
             return Err(anyhow!(
                 "module input bit '{}' also has an internal driver; basic STA does not support multiply driven primary inputs",
                 bit_name
             ));
         }
         if drivers.len() > 1 || (!drivers.is_empty() && has_assign_source) {
-            let bit_name = bit_ref::render_net_bit(bit_index.bits[bit_idx], nets, interner);
+            let bit_name = normalized.render_bit(bit_idx, nets, interner);
             return Err(anyhow!(
                 "net bit '{}' has {} drivers; wired multi-driver nets are unsupported in basic STA",
                 bit_name,
@@ -766,7 +692,7 @@ fn analyze_combinational_max_arrival_proto(
         if !bit_loads[bit_idx].is_empty() || has_resolved_module_output[bit_idx] {
             return Err(anyhow!(
                 "net bit '{}' is undriven and is not a module input; basic STA does not support floating source nets",
-                bit_ref::render_net_bit(bit_index.bits[bit_idx], nets, interner)
+                normalized.render_bit(bit_idx, nets, interner)
             ));
         }
     }
@@ -788,7 +714,7 @@ fn analyze_combinational_max_arrival_proto(
         let cell_name = &instance_cell_names[inst_idx];
         let inst_pin_map = &instance_pin_sources[inst_idx];
         let known_pin_values = &instance_known_pin_values[inst_idx];
-        let instance = &module.instances[inst_idx];
+        let instance = &normalized.instances[inst_idx];
         let instance_name = resolve_symbol(interner, instance.instance_name, "instance name")
             .unwrap_or_else(|_| "<unknown>".to_string());
 
@@ -840,8 +766,7 @@ fn analyze_combinational_max_arrival_proto(
                     continue;
                 };
                 let output_load = bit_load_capacitance[output_bit_idx];
-                let output_net_name =
-                    bit_ref::render_net_bit(bit_index.bits[output_bit_idx], nets, interner);
+                let output_net_name = normalized.render_bit(output_bit_idx, nets, interner);
                 let mut accumulated: Option<SignalTimingSet> = None;
 
                 for arc in &combinational_arcs {
@@ -886,8 +811,8 @@ fn analyze_combinational_max_arrival_proto(
                                         .ok_or_else(|| {
                                             anyhow!(
                                                 "missing source timing for net bit '{}' feeding '{}.{}' (related pin '{}')",
-                                                bit_ref::render_net_bit(
-                                                    bit_index.bits[*related_bit_idx],
+                                                normalized.render_bit(
+                                                    *related_bit_idx,
                                                     nets,
                                                     interner
                                                 ),
@@ -898,11 +823,7 @@ fn analyze_combinational_max_arrival_proto(
                                         })?;
                                     (
                                         timing,
-                                        bit_ref::render_net_bit(
-                                            bit_index.bits[*related_bit_idx],
-                                            nets,
-                                            interner,
-                                        ),
+                                        normalized.render_bit(*related_bit_idx, nets, interner),
                                     )
                                 }
                                 PinBitSource::Literal(value) => (
@@ -1016,13 +937,13 @@ fn analyze_combinational_max_arrival_proto(
         .ok_or_else(|| {
             anyhow!(
                 "missing timing result for module output net bit '{}'",
-                bit_ref::render_net_bit(bit_index.bits[*bit_idx], nets, interner)
+                normalized.render_bit(*bit_idx, nets, interner)
             )
         })?;
         let output_arrival = timing_set.worst_arrival().ok_or_else(|| {
             anyhow!(
                 "missing edge timing candidates for module output net bit '{}'",
-                bit_ref::render_net_bit(bit_index.bits[*bit_idx], nets, interner)
+                normalized.render_bit(*bit_idx, nets, interner)
             )
         })?;
         worst_output_arrival = Some(
@@ -1041,7 +962,7 @@ fn analyze_combinational_max_arrival_proto(
         bit_timing_sets.as_slice(),
         resolved_timing_sources.as_slice(),
         &literal_source_timing_set,
-        &bit_index,
+        &normalized,
         nets.len(),
     );
 
@@ -1330,51 +1251,28 @@ pub fn validate_output_pin_for_basic_sta(
 /// Classifies continuous assigns into live-STA-supported bit sources and
 /// unsupported sources that may still be harmless if they are unused.
 fn analyze_assign_sources(
-    module: &NetlistModule,
+    normalized: &NormalizedNetlistModule<'_>,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
-    bit_index: &StaBitIndex,
 ) -> Result<AssignSourceAnalysis> {
-    let mut sources = vec![None; bit_index.bits.len()];
+    let mut sources = vec![None; normalized.bit_count()];
     let mut unsupported_sources = Vec::new();
-    for assign in &module.assigns {
-        let lhs_targets = bit_ref::net_ref_lsb_targets(&assign.lhs, nets, interner)?;
-        let lhs_bits: Vec<usize> = lhs_targets
-            .iter()
-            .copied()
-            .map(|bit| bit_index.bit_index(bit))
-            .collect::<Result<Vec<_>>>()?;
-        if let Some(rhs_sources) =
-            supported_assign_bit_sources(&assign.rhs, lhs_bits.len(), nets, interner)?
-        {
-            if rhs_sources.len() != lhs_bits.len() {
-                unsupported_sources.push(UnsupportedAssignSource {
-                    lhs_bits,
-                    rendered_lhs: bit_ref::render_net_ref(&assign.lhs, nets, interner),
-                });
-                continue;
-            }
-            for (lhs_bit_idx, rhs_source) in lhs_bits.into_iter().zip(rhs_sources) {
+    for assign in &normalized.assigns {
+        if let Some(rhs_sources) = supported_assign_bit_sources(assign.rhs_bits.as_slice()) {
+            for (lhs_bit_idx, rhs_source) in assign.lhs_bits.iter().copied().zip(rhs_sources) {
                 if sources[lhs_bit_idx].is_some() {
-                    let bit_name =
-                        bit_ref::render_net_bit(bit_index.bits[lhs_bit_idx], nets, interner);
+                    let bit_name = normalized.render_bit(lhs_bit_idx, nets, interner);
                     return Err(anyhow!(
                         "net bit '{}' has multiple continuous assign drivers; wired multi-driver nets are unsupported in basic STA",
                         bit_name
                     ));
                 }
-                sources[lhs_bit_idx] = Some(match rhs_source {
-                    bit_ref::NetBitRef::Literal(value) => BitAssignSource::Literal(value),
-                    bit_ref::NetBitRef::Unknown => BitAssignSource::Unknown,
-                    bit_ref::NetBitRef::Net(bit) => {
-                        BitAssignSource::Alias(bit_index.bit_index(bit)?)
-                    }
-                });
+                sources[lhs_bit_idx] = Some(rhs_source);
             }
         } else {
             unsupported_sources.push(UnsupportedAssignSource {
-                lhs_bits,
-                rendered_lhs: bit_ref::render_net_ref(&assign.lhs, nets, interner),
+                lhs_bits: assign.lhs_bits.clone(),
+                rendered_lhs: assign.rendered_lhs.clone(),
             });
         }
     }
@@ -1386,35 +1284,16 @@ fn analyze_assign_sources(
 
 /// Returns supported zero-delay assign bit sources, or `None` for unsupported
 /// expression shapes.
-fn supported_assign_bit_sources(
-    rhs: &AssignExpr,
-    lhs_width: usize,
-    nets: &[Net],
-    interner: &StringInterner<StringBackend<SymbolU32>>,
-) -> Result<Option<Vec<bit_ref::NetBitRef>>> {
-    match rhs {
-        AssignExpr::Leaf(NetRef::Literal(bits)) => {
-            let mut out = Vec::with_capacity(lhs_width);
-            for bit_idx in 0..lhs_width {
-                out.push(bit_ref::NetBitRef::Literal(
-                    bits.get_bit(bit_idx).unwrap_or(false),
-                ));
-            }
-            Ok(Some(out))
-        }
-        AssignExpr::Leaf(net_ref) => {
-            let refs = bit_ref::net_ref_lsb_bit_refs(net_ref, nets, interner)?;
-            if refs.len() == lhs_width {
-                Ok(Some(refs))
-            } else {
-                Ok(None)
-            }
-        }
-        AssignExpr::Not(_)
-        | AssignExpr::And(_, _)
-        | AssignExpr::Or(_, _)
-        | AssignExpr::Xor(_, _) => Ok(None),
-    }
+fn supported_assign_bit_sources(rhs_bits: &[BitExpr]) -> Option<Vec<BitAssignSource>> {
+    rhs_bits
+        .iter()
+        .map(|bit| match bit {
+            BitExpr::Source(BitSource::Bit(bit_idx)) => Some(BitAssignSource::Alias(*bit_idx)),
+            BitExpr::Source(BitSource::Literal(value)) => Some(BitAssignSource::Literal(*value)),
+            BitExpr::Source(BitSource::Unknown) => Some(BitAssignSource::Unknown),
+            BitExpr::Not(_) | BitExpr::And(_, _) | BitExpr::Or(_, _) | BitExpr::Xor(_, _) => None,
+        })
+        .collect()
 }
 
 /// Rejects unsupported continuous assigns only when they drive timing-live
@@ -1424,15 +1303,15 @@ fn reject_live_unsupported_assigns(
     assign_sources: &[Option<BitAssignSource>],
     bit_loads: &[Vec<NetEndpoint>],
     has_module_output: &[bool],
-    bit_index: &StaBitIndex,
+    normalized: &NormalizedNetlistModule<'_>,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
 ) -> Result<()> {
     if unsupported_sources.is_empty() {
         return Ok(());
     }
-    let mut live = vec![false; bit_index.bits.len()];
-    for bit_idx in 0..bit_index.bits.len() {
+    let mut live = vec![false; normalized.bit_count()];
+    for bit_idx in 0..normalized.bit_count() {
         live[bit_idx] = !bit_loads[bit_idx].is_empty() || has_module_output[bit_idx];
     }
     let mut changed = true;
@@ -1457,7 +1336,7 @@ fn reject_live_unsupported_assigns(
                 .lhs_bits
                 .iter()
                 .filter(|bit_idx| live[**bit_idx])
-                .map(|bit_idx| bit_ref::render_net_bit(bit_index.bits[*bit_idx], nets, interner))
+                .map(|bit_idx| normalized.render_bit(*bit_idx, nets, interner))
                 .collect();
             return Err(anyhow!(
                 "basic STA only supports literal, alias, slice, or concat continuous assigns for live bits; unsupported assign to '{}' drives live bit(s): {}",
@@ -1486,7 +1365,7 @@ fn canonicalize_pin_bit_source(
 /// Resolves zero-delay continuous-assign aliases once for all timing lookups.
 fn resolve_timing_sources(
     assign_sources: &[Option<BitAssignSource>],
-    bit_index: &StaBitIndex,
+    normalized: &NormalizedNetlistModule<'_>,
     nets: &[Net],
     interner: &StringInterner<StringBackend<SymbolU32>>,
 ) -> Result<Vec<ResolvedTimingSource>> {
@@ -1503,7 +1382,7 @@ fn resolve_timing_sources(
                 TimingSourceVisitState::Visiting => {
                     return Err(anyhow!(
                         "continuous assign aliases contain a cycle involving net bit '{}'",
-                        bit_ref::render_net_bit(bit_index.bits[current], nets, interner)
+                        normalized.render_bit(current, nets, interner)
                     ));
                 }
                 TimingSourceVisitState::Unvisited => {
@@ -1552,7 +1431,7 @@ fn aggregate_bit_timing_by_net(
     bit_timing_sets: &[Option<SignalTimingSet>],
     resolved_timing_sources: &[ResolvedTimingSource],
     literal_source_timing_set: &SignalTimingSet,
-    bit_index: &StaBitIndex,
+    normalized: &NormalizedNetlistModule<'_>,
     nets_len: usize,
 ) -> Vec<Option<SignalTiming>> {
     let mut aggregate_sets: Vec<Option<SignalTimingSet>> = vec![None; nets_len];
@@ -1562,7 +1441,7 @@ fn aggregate_bit_timing_by_net(
         else {
             continue;
         };
-        let net_idx = bit_index.bits[bit_idx].net.0;
+        let net_idx = normalized.bit(bit_idx).net.0;
         aggregate_sets[net_idx] = Some(match aggregate_sets[net_idx].take() {
             Some(prev) => prev.merge(timing_set),
             None => timing_set.clone(),

--- a/xlsynth-g8r/tests/gv2block_test.rs
+++ b/xlsynth-g8r/tests/gv2block_test.rs
@@ -573,12 +573,61 @@ endmodule
 }
 
 #[test]
-fn test_gv2block_rejects_preserved_assigns() {
+fn test_gv2block_accepts_preserved_wiring_assigns() {
     let netlist = r#"
 module top (a, y);
   input a;
   output y;
-  assign y = a;
+  wire a;
+  wire y;
+  wire n;
+  BUF u0 (.A(a), .Y(n));
+  assign y = n;
+endmodule
+"#;
+    let mut liberty_file = NamedTempFile::new().unwrap();
+    write!(liberty_file, "{}", LIBERTY_TEXTPROTO).unwrap();
+    let mut netlist_file = NamedTempFile::new().unwrap();
+    write!(netlist_file, "{}", netlist).unwrap();
+
+    let got = convert_gv2block_paths_to_string(netlist_file.path(), liberty_file.path()).unwrap();
+    assert!(got.contains("u0_A: () = instantiation_input(a, instantiation=u0, port_name=A"));
+    assert!(got.contains("y: () = output_port(u0_Y, name=y"));
+}
+
+#[test]
+fn test_gv2block_accepts_preserved_tran_aliases() {
+    let netlist = r#"
+module top (a, y);
+  input a;
+  output y;
+  wire a;
+  wire y;
+  wire y_alias;
+  BUF u0 (.A(a), .Y(y_alias));
+  tran(y, y_alias);
+endmodule
+"#;
+    let mut liberty_file = NamedTempFile::new().unwrap();
+    write!(liberty_file, "{}", LIBERTY_TEXTPROTO).unwrap();
+    let mut netlist_file = NamedTempFile::new().unwrap();
+    write!(netlist_file, "{}", netlist).unwrap();
+
+    let got = convert_gv2block_paths_to_string(netlist_file.path(), liberty_file.path()).unwrap();
+    assert!(got.contains("y: () = output_port(u0_Y, name=y"));
+}
+
+#[test]
+fn test_gv2block_rejects_preserved_combinational_assigns() {
+    let netlist = r#"
+module top (a, b, y);
+  input a;
+  input b;
+  output y;
+  wire a;
+  wire b;
+  wire y;
+  assign y = a & b;
 endmodule
 "#;
     let mut liberty_file = NamedTempFile::new().unwrap();
@@ -587,9 +636,8 @@ endmodule
     write!(netlist_file, "{}", netlist).unwrap();
 
     let err = convert_gv2block_paths_to_string(netlist_file.path(), liberty_file.path())
-        .expect_err("expected preserved assigns to be rejected");
-    assert!(
-        err.to_string()
-            .contains("gv2block does not support preserved continuous assigns")
-    );
+        .expect_err("expected top-level logic assign to be rejected");
+    let err_text = err.to_string();
+    assert!(err_text.contains("gv2block only supports techmapped netlists"));
+    assert!(err_text.contains("run technology mapping first"));
 }


### PR DESCRIPTION
Add support for "tran" which abc sometimes emits in netlist. Also, clean up logic around consumers of netlists. Connectivity through assigns/concats/tran/etc is resolved in one place producing a "normalized" netlist which is used by downstream consumers.