### PR TITLE
Add flag to disable extern_verilog handling.

### DIFF
--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -685,6 +685,13 @@ Additional outputs:
 - `--output_unopt_ir <PATH>` – write the unoptimized IR package to a file.
 - `--output_opt_ir <PATH>` – write the optimized IR package to a file.
 
+Extern-Verilog policy:
+
+- `--allow_extern_verilog=true|false` – permit codegen IR that still contains
+  Verilog FFI declarations (`#[ffi_proto(...)]`), such as IR emitted for DSLX
+  `extern_verilog`. The default is `true`; set it to `false` to reject such IR
+  before codegen.
+
 ### `dslx2ir`: DSLX to IR
 
 Converts DSLX source code to the XLS IR. The IR text is emitted on **stdout**.
@@ -1017,6 +1024,13 @@ Optional optimization:
 - `--opt=true` – optimize the IR before scheduling/codegen.
 - `--aug-opt=true|false` – use the augmented optimizer “opt sandwich” when `--opt=true` (default: `false`).
 
+Extern-Verilog policy:
+
+- `--allow_extern_verilog=true|false` – permit codegen IR that still contains
+  Verilog FFI declarations (`#[ffi_proto(...)]`), such as IR emitted for DSLX
+  `extern_verilog`. The default is `true`; set it to `false` to reject such IR
+  before codegen.
+
 ### `ir2combo`: IR to *combinational* SystemVerilog
 
 Similar to `ir2pipeline` but requests the *combinational* backend in `codegen_main`.
@@ -1028,6 +1042,13 @@ Optional optimization:
 
 - `--opt=true` – optimize the IR before code generation.
 - `--aug-opt=true|false` – use the augmented optimizer “opt sandwich” when `--opt=true` (default: `false`).
+
+Extern-Verilog policy:
+
+- `--allow_extern_verilog=true|false` – permit codegen IR that still contains
+  Verilog FFI declarations (`#[ffi_proto(...)]`), such as IR emitted for DSLX
+  `extern_verilog`. The default is `true`; set it to `false` to reject such IR
+  before codegen.
 
 Example:
 

--- a/xlsynth-driver/src/common.rs
+++ b/xlsynth-driver/src/common.rs
@@ -6,6 +6,7 @@ use std::io::Write;
 use std::process;
 use std::process::Command;
 use xlsynth::mangle_dslx_name;
+use xlsynth_pir::{ir::PackageMember, ir_parser};
 
 // By default in the driver we treat warnings as errors.
 pub const DEFAULT_WARNINGS_AS_ERRORS: bool = true;
@@ -30,6 +31,49 @@ pub fn parse_bool_flag(matches: &ArgMatches, flag_name: &str) -> Option<bool> {
 /// present on the command line.
 pub fn parse_bool_flag_or(matches: &ArgMatches, flag_name: &str, default_value: bool) -> bool {
     parse_bool_flag(matches, flag_name).unwrap_or(default_value)
+}
+
+/// Rejects codegen IR that still carries Verilog FFI declarations unless the
+/// caller explicitly opted in to them.
+pub fn enforce_extern_verilog_codegen_policy(
+    ir_text: &str,
+    allow_extern_verilog: bool,
+) -> Result<(), String> {
+    if allow_extern_verilog {
+        return Ok(());
+    }
+
+    let mut parser = ir_parser::Parser::new(ir_text);
+    let package = parser.parse_package().map_err(|err| {
+        format!(
+            "could not inspect IR for extern Verilog declarations while --allow_extern_verilog=false: {err}"
+        )
+    })?;
+
+    let ffi_members = package
+        .members
+        .iter()
+        .filter_map(|member| {
+            let function = match member {
+                PackageMember::Function(function) => function,
+                PackageMember::Block { func, .. } => func,
+            };
+            function
+                .outer_attrs
+                .iter()
+                .any(|attr| attr.trim_start().starts_with("#[ffi_proto("))
+                .then(|| function.name.clone())
+        })
+        .collect::<Vec<_>>();
+
+    if ffi_members.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "IR contains Verilog FFI declaration(s) via #[ffi_proto(...)] on: {}. Pass --allow_extern_verilog=true to permit codegen of DSLX extern_verilog / Verilog FFI IR.",
+            ffi_members.join(", ")
+        ))
+    }
 }
 
 /// Determines the effective value of the experimental `type_inference_v2`
@@ -641,6 +685,47 @@ pub fn parse_uf_spec(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const IR_WITH_VERILOG_FFI: &str = r#"package extern_verilog_policy
+
+#[ffi_proto("""code_template: "assign {return} = {x};"
+""")]
+fn verilog_passthrough(x: bits[8] id=1) -> bits[8] {
+  ret x: bits[8] = param(name=x, id=1)
+}
+
+top fn main(x: bits[8] id=2) -> bits[8] {
+  ret x: bits[8] = param(name=x, id=2)
+}
+"#;
+
+    const IR_WITHOUT_VERILOG_FFI: &str = r#"package ordinary_codegen
+
+top fn main(x: bits[8] id=1) -> bits[8] {
+  ret x: bits[8] = param(name=x, id=1)
+}
+"#;
+
+    #[test]
+    fn extern_verilog_codegen_policy_accepts_ordinary_ir() {
+        enforce_extern_verilog_codegen_policy(IR_WITHOUT_VERILOG_FFI, false)
+            .expect("ordinary IR should pass policy check");
+    }
+
+    #[test]
+    fn extern_verilog_codegen_policy_rejects_ffi_ir_when_disabled() {
+        let err = enforce_extern_verilog_codegen_policy(IR_WITH_VERILOG_FFI, false)
+            .expect_err("Verilog FFI IR should require explicit opt-in");
+
+        assert!(err.contains("verilog_passthrough"), "{err}");
+        assert!(err.contains("--allow_extern_verilog=true"), "{err}");
+    }
+
+    #[test]
+    fn extern_verilog_codegen_policy_accepts_ffi_ir_when_enabled() {
+        enforce_extern_verilog_codegen_policy(IR_WITH_VERILOG_FFI, true)
+            .expect("explicit opt-in should allow Verilog FFI IR");
+    }
 
     #[test]
     fn test_get_function_enum_param_domains_cross_module() {

--- a/xlsynth-driver/src/dslx2pipeline.rs
+++ b/xlsynth-driver/src/dslx2pipeline.rs
@@ -5,10 +5,11 @@ use std::process;
 use clap::ArgMatches;
 
 use crate::common::{
-    extract_codegen_flags, extract_pipeline_spec, parse_bool_flag, pipeline_codegen_flags_proto,
-    resolve_type_inference_v2, scheduling_options_proto, CodegenFlags, PipelineSpec,
-    DEFAULT_WARNINGS_AS_ERRORS,
+    enforce_extern_verilog_codegen_policy, extract_codegen_flags, extract_pipeline_spec,
+    parse_bool_flag, parse_bool_flag_or, pipeline_codegen_flags_proto, resolve_type_inference_v2,
+    scheduling_options_proto, CodegenFlags, PipelineSpec, DEFAULT_WARNINGS_AS_ERRORS,
 };
+use crate::report_cli_error::report_cli_error_and_exit;
 use crate::toolchain_config::ToolchainConfig;
 use crate::tools::{run_codegen_pipeline, run_ir_converter_main, run_opt_main};
 
@@ -22,6 +23,7 @@ fn dslx2pipeline(
     delay_model: &str,
     keep_temps: &Option<bool>,
     type_inference_v2: Option<bool>,
+    allow_extern_verilog: bool,
     output_unopt_ir: &Option<&std::path::Path>,
     output_opt_ir: &Option<&std::path::Path>,
     config: &Option<ToolchainConfig>,
@@ -68,6 +70,8 @@ fn dslx2pipeline(
         std::fs::write(&unopt_ir_path, unopt_ir).unwrap();
 
         let opt_ir = run_opt_main(&unopt_ir_path, Some(&ir_top), tool_path);
+        enforce_extern_verilog_codegen_policy(&opt_ir, allow_extern_verilog)
+            .unwrap_or_else(|err| report_cli_error_and_exit(&err, Some("dslx2pipeline"), vec![]));
         let opt_ir_path = temp_dir.path().join("opt.ir");
         std::fs::write(&opt_ir_path, opt_ir.clone()).unwrap();
 
@@ -163,13 +167,16 @@ fn dslx2pipeline(
         }
 
         let opt_ir = xlsynth::optimize_ir(&convert_result.ir, &ir_top).unwrap();
+        let opt_ir_text = opt_ir.to_string();
+        enforce_extern_verilog_codegen_policy(&opt_ir_text, allow_extern_verilog)
+            .unwrap_or_else(|err| report_cli_error_and_exit(&err, Some("dslx2pipeline"), vec![]));
 
         // If user requested, persist the IR artifacts to the provided paths.
         if let Some(path) = output_unopt_ir {
             std::fs::write(path, &convert_result.ir.to_string()).expect("write output_unopt_ir");
         }
         if let Some(path) = output_opt_ir {
-            std::fs::write(path, &opt_ir.to_string()).expect("write output_opt_ir");
+            std::fs::write(path, &opt_ir_text).expect("write output_opt_ir");
         }
 
         let scheduling_options_flags_proto = scheduling_options_proto(delay_model, pipeline_spec);
@@ -193,6 +200,7 @@ pub fn handle_dslx2pipeline(matches: &ArgMatches, config: &Option<ToolchainConfi
     let pipeline_spec = extract_pipeline_spec(matches);
     let delay_model = matches.get_one::<String>("DELAY_MODEL").unwrap();
     let keep_temps = parse_bool_flag(matches, "keep_temps");
+    let allow_extern_verilog = parse_bool_flag_or(matches, "allow_extern_verilog", true);
     let codegen_flags = extract_codegen_flags(matches, config.as_ref());
 
     // New optional output paths for capturing IR artifacts
@@ -213,6 +221,7 @@ pub fn handle_dslx2pipeline(matches: &ArgMatches, config: &Option<ToolchainConfi
         delay_model,
         &keep_temps,
         type_inference_v2,
+        allow_extern_verilog,
         &output_unopt_ir.as_deref(),
         &output_opt_ir.as_deref(),
         config,

--- a/xlsynth-driver/src/ir2combo.rs
+++ b/xlsynth-driver/src/ir2combo.rs
@@ -7,7 +7,10 @@
 use clap::ArgMatches;
 use std::process;
 
-use crate::common::{extract_codegen_flags, CodegenFlags};
+use crate::common::{
+    enforce_extern_verilog_codegen_policy, extract_codegen_flags, parse_bool_flag_or, CodegenFlags,
+};
+use crate::report_cli_error::report_cli_error_and_exit;
 use crate::toolchain_config::ToolchainConfig;
 use crate::tools::{run_codegen_combinational, run_opt_main};
 use xlsynth_pir::{run_aug_opt_over_ir_text, AugOptOptions};
@@ -33,6 +36,7 @@ pub fn handle_ir2combo(matches: &ArgMatches, config: &Option<ToolchainConfig>) {
         .get_one::<String>("aug_opt")
         .map(|s| s == "true")
         .unwrap_or(false);
+    let allow_extern_verilog = parse_bool_flag_or(matches, "allow_extern_verilog", true);
 
     let ir_top_opt = matches.get_one::<String>("ir_top");
 
@@ -42,6 +46,7 @@ pub fn handle_ir2combo(matches: &ArgMatches, config: &Option<ToolchainConfig>) {
         &codegen_flags,
         optimize,
         aug_opt,
+        allow_extern_verilog,
         ir_top_opt.map(|s| s.as_str()),
         &keep_temps,
         config,
@@ -54,6 +59,7 @@ fn ir2combo(
     codegen_flags: &CodegenFlags,
     optimize: bool,
     aug_opt: bool,
+    allow_extern_verilog: bool,
     ir_top: Option<&str>,
     keep_temps: &Option<bool>,
     config: &Option<ToolchainConfig>,
@@ -101,6 +107,10 @@ fn ir2combo(
     } else {
         input_file.to_path_buf()
     };
+    let ir_for_codegen_text = std::fs::read_to_string(&ir_for_codegen_path)
+        .expect("IR file handed to codegen should be readable");
+    enforce_extern_verilog_codegen_policy(&ir_for_codegen_text, allow_extern_verilog)
+        .unwrap_or_else(|err| report_cli_error_and_exit(&err, Some("ir2combo"), vec![]));
 
     let sv = run_codegen_combinational(&ir_for_codegen_path, delay_model, codegen_flags, tool_path);
 

--- a/xlsynth-driver/src/ir2pipeline.rs
+++ b/xlsynth-driver/src/ir2pipeline.rs
@@ -3,9 +3,11 @@
 use clap::ArgMatches;
 
 use crate::common::{
-    extract_codegen_flags, extract_pipeline_spec, pipeline_codegen_flags_proto,
-    scheduling_options_proto, CodegenFlags, PipelineSpec,
+    enforce_extern_verilog_codegen_policy, extract_codegen_flags, extract_pipeline_spec,
+    parse_bool_flag_or, pipeline_codegen_flags_proto, scheduling_options_proto, CodegenFlags,
+    PipelineSpec,
 };
+use crate::report_cli_error::report_cli_error_and_exit;
 use crate::toolchain_config::ToolchainConfig;
 use crate::tools::{run_codegen_pipeline, run_opt_main};
 use xlsynth_pir::{run_aug_opt_over_ir_text, AugOptOptions};
@@ -31,6 +33,7 @@ pub fn handle_ir2pipeline(matches: &ArgMatches, config: &Option<ToolchainConfig>
         .get_one::<String>("aug_opt")
         .map(|s| s == "true")
         .unwrap_or(false);
+    let allow_extern_verilog = parse_bool_flag_or(matches, "allow_extern_verilog", true);
 
     let ir_top_opt = matches.get_one::<String>("ir_top");
 
@@ -41,6 +44,7 @@ pub fn handle_ir2pipeline(matches: &ArgMatches, config: &Option<ToolchainConfig>
         &codegen_flags,
         optimize,
         aug_opt,
+        allow_extern_verilog,
         ir_top_opt.map(|s| s.as_str()),
         &keep_temps,
         config,
@@ -56,6 +60,7 @@ fn ir2pipeline(
     codegen_flags: &CodegenFlags,
     optimize: bool,
     aug_opt: bool,
+    allow_extern_verilog: bool,
     ir_top: Option<&str>,
     keep_temps: &Option<bool>,
     config: &Option<ToolchainConfig>,
@@ -99,6 +104,10 @@ fn ir2pipeline(
             // Just use the input file directly (no optimization step).
             input_file.to_path_buf()
         };
+        let ir_for_codegen_text = std::fs::read_to_string(&ir_for_codegen_path)
+            .expect("IR file handed to codegen should be readable");
+        enforce_extern_verilog_codegen_policy(&ir_for_codegen_text, allow_extern_verilog)
+            .unwrap_or_else(|err| report_cli_error_and_exit(&err, Some("ir2pipeline"), vec![]));
 
         // Run the codegen pipeline.
         let sv = run_codegen_pipeline(
@@ -160,6 +169,9 @@ fn ir2pipeline(
                     .expect("IR optimization should succeed");
             }
         }
+        let ir_for_codegen_text = ir_package.to_string();
+        enforce_extern_verilog_codegen_policy(&ir_for_codegen_text, allow_extern_verilog)
+            .unwrap_or_else(|err| report_cli_error_and_exit(&err, Some("ir2pipeline"), vec![]));
 
         let scheduling_options_flags_proto = scheduling_options_proto(delay_model, pipeline_spec);
         let codegen_flags_proto = pipeline_codegen_flags_proto(codegen_flags);

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -538,6 +538,10 @@ fn main() {
                 .add_dslx_input_args(true)
                 .add_pipeline_args()
                 .add_codegen_args()
+                .add_bool_arg(
+                    "allow_extern_verilog",
+                    "Allow codegen IR containing Verilog FFI declarations emitted from DSLX extern_verilog",
+                )
                 .add_bool_arg("keep_temps", "Keep temporary files")
                 .add_bool_arg(
                     "type_inference_v2",
@@ -930,6 +934,10 @@ fn main() {
                 .add_codegen_args()
                 .add_pipeline_args()
                 .add_bool_arg("opt", "Optimize the IR before scheduling pipeline")
+                .add_bool_arg(
+                    "allow_extern_verilog",
+                    "Allow codegen IR containing Verilog FFI declarations emitted from DSLX extern_verilog",
+                )
                 .arg(
                     Arg::new("aug_opt")
                         .long("aug-opt")
@@ -954,6 +962,10 @@ fn main() {
                 .add_ir_top_arg(false)
                 .add_codegen_args()
                 .add_bool_arg("opt", "Optimize the IR before codegen")
+                .add_bool_arg(
+                    "allow_extern_verilog",
+                    "Allow codegen IR containing Verilog FFI declarations emitted from DSLX extern_verilog",
+                )
                 .arg(
                     Arg::new("aug_opt")
                         .long("aug-opt")

--- a/xlsynth-driver/tests/extern_verilog_codegen_policy_test.rs
+++ b/xlsynth-driver/tests/extern_verilog_codegen_policy_test.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+const IR_WITH_VERILOG_FFI: &str = r#"package extern_verilog_policy
+
+#[ffi_proto("""code_template: "assign {return} = {x};"
+""")]
+fn verilog_passthrough(x: bits[8] id=1) -> bits[8] {
+  ret x: bits[8] = param(name=x, id=1)
+}
+
+top fn main(x: bits[8] id=2) -> bits[8] {
+  ret x: bits[8] = param(name=x, id=2)
+}
+"#;
+
+fn write_ir_input(temp_dir: &tempfile::TempDir) -> std::path::PathBuf {
+    let ir_path = temp_dir.path().join("extern_verilog.ir");
+    std::fs::write(&ir_path, IR_WITH_VERILOG_FFI).expect("write IR input");
+    ir_path
+}
+
+fn write_toolchain_config(
+    temp_dir: &tempfile::TempDir,
+    tool_path: &std::path::Path,
+) -> std::path::PathBuf {
+    let config_path = temp_dir.path().join("xlsynth-toolchain.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[toolchain]\ntool_path = {:?}\n",
+            tool_path.to_str().expect("tool path should be utf-8")
+        ),
+    )
+    .expect("write toolchain config");
+    config_path
+}
+
+fn assert_extern_verilog_rejected(output: std::process::Output, subcommand: &str) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "{subcommand} unexpectedly succeeded:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("--allow_extern_verilog=true"),
+        "{subcommand} rejection should explain the opt-in flag:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("verilog_passthrough"),
+        "{subcommand} rejection should name the FFI function:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn ir2pipeline_rejects_verilog_ffi_ir_when_disabled() {
+    let temp_dir = tempfile::tempdir().expect("make temp dir");
+    let ir_path = write_ir_input(&temp_dir);
+    let toolchain_path = write_toolchain_config(&temp_dir, temp_dir.path());
+    let driver = env!("CARGO_BIN_EXE_xlsynth-driver");
+
+    let output = Command::new(driver)
+        .arg("--toolchain")
+        .arg(toolchain_path)
+        .arg("ir2pipeline")
+        .arg(ir_path)
+        .arg("--pipeline_stages")
+        .arg("1")
+        .arg("--delay_model")
+        .arg("unit")
+        .arg("--allow_extern_verilog=false")
+        .output()
+        .expect("run ir2pipeline");
+
+    assert_extern_verilog_rejected(output, "ir2pipeline");
+}
+
+#[test]
+fn ir2combo_rejects_verilog_ffi_ir_when_disabled() {
+    let temp_dir = tempfile::tempdir().expect("make temp dir");
+    let ir_path = write_ir_input(&temp_dir);
+    let toolchain_path = write_toolchain_config(&temp_dir, temp_dir.path());
+    let driver = env!("CARGO_BIN_EXE_xlsynth-driver");
+
+    let output = Command::new(driver)
+        .arg("--toolchain")
+        .arg(toolchain_path)
+        .arg("ir2combo")
+        .arg(ir_path)
+        .arg("--delay_model")
+        .arg("unit")
+        .arg("--allow_extern_verilog=false")
+        .output()
+        .expect("run ir2combo");
+
+    assert_extern_verilog_rejected(output, "ir2combo");
+}
+
+#[cfg(unix)]
+fn write_executable_script(path: &std::path::Path, text: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::write(path, text).expect("write tool script");
+    let mut permissions = std::fs::metadata(path)
+        .expect("stat tool script")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("mark tool script executable");
+}
+
+#[cfg(unix)]
+#[test]
+fn dslx2pipeline_rejects_generated_verilog_ffi_ir_when_disabled() {
+    let temp_dir = tempfile::tempdir().expect("make temp dir");
+    let fake_tools = temp_dir.path().join("fake-tools");
+    std::fs::create_dir(&fake_tools).expect("create fake tool dir");
+    write_executable_script(
+        &fake_tools.join("ir_converter_main"),
+        "#!/bin/sh\ncat \"$FAKE_EXTERN_IR_PATH\"\n",
+    );
+    write_executable_script(&fake_tools.join("opt_main"), "#!/bin/sh\ncat \"$1\"\n");
+
+    let emitted_ir_path = write_ir_input(&temp_dir);
+    let dslx_path = temp_dir.path().join("input.x");
+    std::fs::write(&dslx_path, "fn main(x: u8) -> u8 { x }\n").expect("write DSLX input");
+    let toolchain_path = write_toolchain_config(&temp_dir, &fake_tools);
+    let driver = env!("CARGO_BIN_EXE_xlsynth-driver");
+
+    let output = Command::new(driver)
+        .arg("--toolchain")
+        .arg(toolchain_path)
+        .arg("dslx2pipeline")
+        .arg("--dslx_input_file")
+        .arg(dslx_path)
+        .arg("--dslx_top")
+        .arg("main")
+        .arg("--pipeline_stages")
+        .arg("1")
+        .arg("--delay_model")
+        .arg("unit")
+        .arg("--allow_extern_verilog=false")
+        .env("FAKE_EXTERN_IR_PATH", emitted_ir_path)
+        .output()
+        .expect("run dslx2pipeline");
+
+    assert_extern_verilog_rejected(output, "dslx2pipeline");
+}


### PR DESCRIPTION
The check is done on ir->verilog conversion in ir2combo, ir2pipeline, and dslx2pipeline.