### PR TITLE
ci: validate standalone runtime release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1059,8 +1059,8 @@ jobs:
 
       - name: Install libc++ from llvm-18
         run: |
-          bash "${GITHUB_WORKSPACE}/scripts/ci_apt_retry.sh" update
-          bash "${GITHUB_WORKSPACE}/scripts/ci_apt_retry.sh" install --no-install-recommends libc++-18-dev libc++abi-18-dev
+          sudo bash "${GITHUB_WORKSPACE}/scripts/ci_apt_retry.sh" update
+          sudo bash "${GITHUB_WORKSPACE}/scripts/ci_apt_retry.sh" install --no-install-recommends libc++-18-dev libc++abi-18-dev
 
       - name: Run cargo tests using pre-downloaded artifacts
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1055,7 +1055,7 @@ jobs:
           # requirements.
           TAG='${{ steps.resolve-xls-tag-predownload.outputs.tag }}'
           echo "Resolved XLS release tag: ${TAG}"
-          python3 scripts/download_release.py -p rocky8 -o pre_download -d -v ${TAG}
+          python3 scripts/download_release.py -p rocky8 -o pre_download -d --standalone-aot-runtime -v ${TAG}
 
       - name: Run cargo tests using pre-downloaded artifacts
         env:
@@ -1066,6 +1066,24 @@ jobs:
           echo "Using XLS_DSO_PATH=${XLS_DSO_PATH}"
           echo "Using DSLX_STDLIB_PATH=${DSLX_STDLIB_PATH}"
           cargo test -p xlsynth --verbose
+
+      - name: Run standalone runtime tests using pre-downloaded artifacts
+        run: |
+          cat > pre_download/xlsynth_artifacts.toml <<'EOF'
+          dso_path = "libxls-rocky8.so"
+          dslx_stdlib_path = "xls/dslx/stdlib"
+          aot_runtime_path = "libxls_aot_runtime.a"
+          aot_runtime_link_config_path = "libxls_aot_runtime_link.toml"
+          EOF
+          export XLSYNTH_ARTIFACT_CONFIG="$(realpath pre_download/xlsynth_artifacts.toml)"
+          export LD_LIBRARY_PATH="$(realpath pre_download)${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+          echo "Using XLSYNTH_ARTIFACT_CONFIG=${XLSYNTH_ARTIFACT_CONFIG}"
+          cargo test \
+            -p xlsynth-aot-runtime \
+            -p xlsynth-aot-standalone-test-crate \
+            -p xlsynth-aot-test-crate \
+            -p sample-usage \
+            --verbose
 
   fuzz-smoke:
     name: Fuzz Smoke Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1057,6 +1057,11 @@ jobs:
           echo "Resolved XLS release tag: ${TAG}"
           python3 scripts/download_release.py -p rocky8 -o pre_download -d --standalone-aot-runtime -v ${TAG}
 
+      - name: Install libc++ from llvm-18
+        run: |
+          bash "${GITHUB_WORKSPACE}/scripts/ci_apt_retry.sh" update
+          bash "${GITHUB_WORKSPACE}/scripts/ci_apt_retry.sh" install --no-install-recommends libc++-18-dev libc++abi-18-dev
+
       - name: Run cargo tests using pre-downloaded artifacts
         env:
           XLS_DSO_PATH: ${{ github.workspace }}/pre_download/libxls-rocky8.so

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -118,7 +118,13 @@ def check_sha256sum(artifact_path: str, sha256_path: str) -> bool:
 
 
 def high_integrity_download(
-    base_url, filename, target_dir, max_attempts, is_binary=False, platform=None
+    base_url,
+    filename,
+    target_dir,
+    max_attempts,
+    is_binary=False,
+    platform=None,
+    output_filename=None,
 ):
     print(f"Starting download of {filename}...")
     start_time = time.time()
@@ -131,8 +137,13 @@ def high_integrity_download(
         artifact_path = os.path.join(temp_dir, filename)
 
         # Determine target filename and associated path.
-        target_filename = filename
-        if is_binary and platform and filename.endswith(f"-{platform}"):
+        target_filename = output_filename or filename
+        if (
+            output_filename is None
+            and is_binary
+            and platform
+            and filename.endswith(f"-{platform}")
+        ):
             target_filename = filename[: -(len(platform) + 1)]  # Remove '-platform'
 
         # Detect gzipped DSO assets (libxls-*.{so,dylib}.gz). For these we will
@@ -241,6 +252,35 @@ def ensure_versioned_dso_alias(output_dir: str, version: str, platform: str) -> 
     )
 
 
+def build_static_aot_runtime_release_filename(platform: str) -> str:
+    return f"libxls_aot_runtime-{platform}.a"
+
+
+def build_static_aot_runtime_link_config_release_filename(platform: str) -> str:
+    return f"libxls_aot_runtime_link-{platform}.toml"
+
+
+def download_static_aot_runtime_assets(
+    base_url: str, output_dir: str, platform: str, max_attempts: int
+) -> None:
+    high_integrity_download(
+        base_url,
+        build_static_aot_runtime_release_filename(platform),
+        output_dir,
+        max_attempts,
+        is_binary=False,
+        output_filename="libxls_aot_runtime.a",
+    )
+    high_integrity_download(
+        base_url,
+        build_static_aot_runtime_link_config_release_filename(platform),
+        output_dir,
+        max_attempts,
+        is_binary=False,
+        output_filename="libxls_aot_runtime_link.toml",
+    )
+
+
 def main():
     parser = OptionParser()
     parser.add_option(
@@ -260,6 +300,16 @@ def main():
         "--dso",
         dest="dso",
         help="Download the DSO library",
+        action="store_true",
+        default=False,
+    )
+    parser.add_option(
+        "--standalone-aot-runtime",
+        dest="standalone_aot_runtime",
+        help=(
+            "Download the same-version standalone AOT runtime archive and "
+            "producer-authored link config"
+        ),
         action="store_true",
         default=False,
     )
@@ -338,6 +388,14 @@ def main():
 
     if options.dso:
         ensure_versioned_dso_alias(output_dir, version, options.platform)
+
+    if options.standalone_aot_runtime:
+        download_static_aot_runtime_assets(
+            base_url,
+            output_dir,
+            options.platform,
+            options.max_attempts,
+        )
 
     # Download and extract dslx_stdlib.tar.gz
     stdlib_filename = "dslx_stdlib.tar.gz"


### PR DESCRIPTION
- Earlier PRs teach the system to produce:
  - `libxls_aot_runtime.a`
  - `libxls_aot_runtime_link.toml`
- This PR teaches CI to:
  1. download those released artifacts,
  2. assemble an `XLSYNTH_ARTIFACT_CONFIG`,
  3. run the standalone AOT consumer crates against that config.

Download the same-version standalone AOT archive plus producer-authored link config into the stable local filenames consumed by xlsynth-aot-runtime, then exercise that release-backed artifact-config path in GitHub Actions.

This keeps generic workspace CI artifact-less while adding one maintained lane that proves pre-downloaded release artifacts can drive the standalone runtime consumer crates through XLSYNTH_ARTIFACT_CONFIG.

<!-- spr-stack:start -->
**Stack**:
- ➡ #980

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
