### PR TITLE
aot-runtime: let Bazel declare standalone runtime links

### DIFF
--- a/xlsynth-aot-runtime/Cargo.toml
+++ b/xlsynth-aot-runtime/Cargo.toml
@@ -16,3 +16,6 @@ workspace = true
 
 [build-dependencies]
 toml = "0.8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/xlsynth-aot-runtime/README.md
+++ b/xlsynth-aot-runtime/README.md
@@ -1,0 +1,39 @@
+# xlsynth-aot-runtime
+
+`xlsynth-aot-runtime` supplies reusable runtime support for executing generated
+standalone AOT artifacts. It can be consumed directly from Cargo or integrated
+into a Bazel final link.
+
+## Native Link Ownership
+
+Direct Cargo consumers use the default native link mode:
+
+```text
+xlsynth-aot-runtime
+  -> links libxls_aot_runtime.a
+  -> receives the native runtime symbols from the released archive
+```
+
+Bazel consumers that declare the standalone runtime dependency use declared
+link mode:
+
+```text
+XLS_AOT_RUNTIME_LINK_MODE=declared
+
+Bazel target
+  -> depends on @<name>_runtime//:xls_aot_runtime_source_dep
+  -> depends on xlsynth-aot-runtime
+
+xlsynth-aot-runtime
+  -> emits no native runtime archive link request
+```
+
+Declared link mode changes only which build graph supplies the native runtime
+symbols. It does not change the standalone AOT runtime ABI or execution
+behavior.
+
+Use `native` mode, the default, when Cargo must link the released
+`libxls_aot_runtime.a` archive. Use `declared` mode only when the enclosing
+build graph declares an equivalent runtime dependency, such as the source-backed
+Bazel export from `rules_xlsynth`; otherwise the final link will have no
+provider for the standalone runtime symbols.

--- a/xlsynth-aot-runtime/build.rs
+++ b/xlsynth-aot-runtime/build.rs
@@ -1,10 +1,31 @@
 // SPDX-License-Identifier: Apache-2.0
+//! Selects the native linking contract for the standalone AOT runtime crate.
+//!
+//! Direct Cargo consumers use the released native archive and companion link
+//! configuration. Bazel consumers set declared-link mode because their final
+//! target declares and links the source-backed runtime dependency itself; in
+//! that mode this build script must not issue duplicate native link requests.
 
 use std::path::{Path, PathBuf};
 
 const XLS_AOT_RUNTIME_PATH_ENV: &str = "XLS_AOT_RUNTIME_PATH";
 const XLS_AOT_RUNTIME_LINK_CONFIG_PATH_ENV: &str = "XLS_AOT_RUNTIME_LINK_CONFIG_PATH";
+/// Selects whether Cargo or the enclosing build graph owns native runtime
+/// linking.
+const XLS_AOT_RUNTIME_LINK_MODE_ENV: &str = "XLS_AOT_RUNTIME_LINK_MODE";
 const XLSYNTH_ARTIFACT_CONFIG_ENV: &str = "XLSYNTH_ARTIFACT_CONFIG";
+
+/// Identifies which build system is responsible for providing native runtime
+/// symbols.
+#[derive(Clone, Copy)]
+enum LinkDirectiveMode {
+    /// Cargo links the released `libxls_aot_runtime.a` archive and its system
+    /// dependencies.
+    Native,
+    /// The enclosing build graph supplies the runtime dependency and Cargo
+    /// emits no native links.
+    Declared,
+}
 
 struct RuntimeInputs {
     archive_path: PathBuf,
@@ -14,6 +35,31 @@ struct RuntimeInputs {
 struct RuntimeLinkConfig {
     system_libraries: Vec<String>,
     frameworks: Vec<String>,
+}
+
+/// Parses the link-ownership contract, preserving native linking as the
+/// default.
+///
+/// Declared mode is opt-in because ordinary Cargo builds do not otherwise have
+/// a Bazel target available to satisfy the standalone runtime symbols.
+fn parse_link_directive_mode() -> LinkDirectiveMode {
+    match std::env::var(XLS_AOT_RUNTIME_LINK_MODE_ENV) {
+        Ok(value) => match value.as_str() {
+            "native" => LinkDirectiveMode::Native,
+            "declared" => LinkDirectiveMode::Declared,
+            _ => panic!(
+                "{XLS_AOT_RUNTIME_LINK_MODE_ENV} must be one of 'native' or 'declared'; got {:?}",
+                value
+            ),
+        },
+        Err(std::env::VarError::NotPresent) => LinkDirectiveMode::Native,
+        Err(std::env::VarError::NotUnicode(value)) => {
+            panic!(
+                "{XLS_AOT_RUNTIME_LINK_MODE_ENV} must be valid UTF-8; got {:?}",
+                value
+            )
+        }
+    }
 }
 
 fn parse_toml_file(path: &Path, label: &str) -> toml::Table {
@@ -159,12 +205,11 @@ fn read_link_config(path: &Path, target_os: &str) -> RuntimeLinkConfig {
     }
 }
 
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-env-changed={XLS_AOT_RUNTIME_PATH_ENV}");
-    println!("cargo:rerun-if-env-changed={XLS_AOT_RUNTIME_LINK_CONFIG_PATH_ENV}");
-    println!("cargo:rerun-if-env-changed={XLSYNTH_ARTIFACT_CONFIG_ENV}");
-
+/// Emits all native linker inputs required by direct Cargo consumers.
+///
+/// This must not be invoked in declared-link mode: doing so would cause both
+/// Cargo and the enclosing Bazel link graph to provide the runtime dependency.
+fn emit_native_link_directives() {
     let inputs = resolve_runtime_inputs();
     let archive_path = &inputs.archive_path;
     if archive_path.file_name().and_then(|name| name.to_str()) != Some("libxls_aot_runtime.a") {
@@ -207,5 +252,25 @@ fn main() {
     }
     for framework in link_config.frameworks {
         println!("cargo:rustc-link-lib=framework={framework}");
+    }
+}
+
+/// Applies the selected native-link ownership contract to this crate build.
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed={XLS_AOT_RUNTIME_PATH_ENV}");
+    println!("cargo:rerun-if-env-changed={XLS_AOT_RUNTIME_LINK_CONFIG_PATH_ENV}");
+    println!("cargo:rerun-if-env-changed={XLS_AOT_RUNTIME_LINK_MODE_ENV}");
+    println!("cargo:rerun-if-env-changed={XLSYNTH_ARTIFACT_CONFIG_ENV}");
+    println!("cargo:rustc-check-cfg=cfg(xls_aot_runtime_declared_link)");
+
+    match parse_link_directive_mode() {
+        LinkDirectiveMode::Native => emit_native_link_directives(),
+        LinkDirectiveMode::Declared => {
+            println!("cargo:rustc-cfg=xls_aot_runtime_declared_link");
+            println!(
+                "cargo:info=Skipping native link directives because {XLS_AOT_RUNTIME_LINK_MODE_ENV}=declared"
+            );
+        }
     }
 }

--- a/xlsynth-aot-runtime/src/lib.rs
+++ b/xlsynth-aot-runtime/src/lib.rs
@@ -318,7 +318,14 @@ struct XlsStandaloneAotRuntime {
     _private: [u8; 0],
 }
 
-#[link(name = "xls_aot_runtime", kind = "static")]
+// Import the standalone runtime ABI without choosing a second native link
+// owner. Direct Cargo builds retain the released static archive annotation;
+// Bazel-declared builds omit it because the final Bazel target provides the
+// same symbols through its source-backed runtime dependency.
+#[cfg_attr(
+    not(xls_aot_runtime_declared_link),
+    link(name = "xls_aot_runtime", kind = "static")
+)]
 unsafe extern "C" {
     fn xls_standalone_aot_runtime_create(
         abi_version: u32,

--- a/xlsynth-aot-runtime/tests/link_mode_test.rs
+++ b/xlsynth-aot-runtime/tests/link_mode_test.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Exercises native and Bazel-declared standalone runtime link modes through
+//! nested Cargo smoke crates.
+//!
+//! These tests deliberately invoke Cargo rather than unit-testing parsing:
+//! the observable contract spans build-script directives and the crate's FFI
+//! link annotation, either of which can make a final binary request the native
+//! standalone runtime archive.
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+
+/// Writes one file used to assemble a throwaway nested Cargo package.
+fn write_file(path: &Path, contents: &str) {
+    fs::write(path, contents)
+        .unwrap_or_else(|err| panic!("Failed to write {}: {}", path.display(), err));
+}
+
+/// Creates the smallest dependent crate that compiles this runtime package.
+fn write_smoke_crate(crate_dir: &Path, runtime_manifest: &Path) {
+    let src_dir = crate_dir.join("src");
+    fs::create_dir_all(&src_dir)
+        .unwrap_or_else(|err| panic!("Failed to create {}: {}", src_dir.display(), err));
+    write_file(
+        &crate_dir.join("Cargo.toml"),
+        &format!(
+            concat!(
+                "[package]\n",
+                "name = \"xlsynth-aot-runtime-link-mode-smoke\"\n",
+                "version = \"0.1.0\"\n",
+                "edition = \"2021\"\n\n",
+                "[dependencies]\n",
+                "xlsynth-aot-runtime = {{ path = {:?} }}\n"
+            ),
+            runtime_manifest.display().to_string(),
+        ),
+    );
+    write_file(
+        &src_dir.join("main.rs"),
+        concat!(
+            "fn main() {\n",
+            "    let _ = xlsynth_aot_runtime::SUPPORTED_ARTIFACT_ABI_VERSION;\n",
+            "}\n",
+        ),
+    );
+}
+
+/// Creates isolated filesystem state for a single nested Cargo invocation.
+fn make_temp_dir() -> TempDir {
+    tempfile::Builder::new()
+        .prefix("xlsynth-aot-runtime-link-mode-test-")
+        .tempdir()
+        .unwrap_or_else(|err| panic!("Failed to create temporary test directory: {}", err))
+}
+
+/// Executes a nested offline Cargo command with one selected link contract.
+///
+/// Separate target directories prevent a build in one mode from reusing a
+/// prior build-script result from the other mode.
+fn run_nested_cargo(
+    crate_dir: &Path,
+    target_dir: &Path,
+    cargo_subcommand: &str,
+    envs: &[(&str, &Path)],
+    link_mode: Option<&str>,
+) -> std::process::Output {
+    let cargo_binary = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let mut command = Command::new(&cargo_binary);
+    command
+        .arg(cargo_subcommand)
+        .arg("-vv")
+        .arg("--offline")
+        .env("CARGO_NET_OFFLINE", "true")
+        .env("CARGO_TARGET_DIR", target_dir)
+        .current_dir(crate_dir);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    if let Some(link_mode) = link_mode {
+        command.env("XLS_AOT_RUNTIME_LINK_MODE", link_mode);
+    }
+    command.output().unwrap_or_else(|err| {
+        panic!(
+            "Failed to run nested cargo {} in {}: {}",
+            cargo_subcommand,
+            crate_dir.display(),
+            err,
+        )
+    })
+}
+
+/// Renders nested Cargo output in assertion messages for actionable failures.
+fn output_text(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    )
+}
+
+/// Writes the minimal native-mode archive and platform link configuration.
+fn write_native_runtime_inputs(root: &Path) -> (PathBuf, PathBuf) {
+    let archive_path = root.join("libxls_aot_runtime.a");
+    write_file(&archive_path, "");
+    let target_os = if cfg!(target_os = "macos") {
+        "macos"
+    } else {
+        "linux"
+    };
+    let link_config_path = root.join("libxls_aot_runtime_link.toml");
+    write_file(
+        &link_config_path,
+        &format!(
+            concat!(
+                "format_version = 1\n\n",
+                "[targets.{target_os}]\n",
+                "system_libraries = []\n",
+                "frameworks = []\n",
+            ),
+            target_os = target_os,
+        ),
+    );
+    (archive_path, link_config_path)
+}
+
+// Verifies: Native mode tells Cargo to link the released standalone archive.
+// Catches: Removing the default direct-Cargo runtime dependency.
+#[test]
+fn native_mode_emits_static_archive_link_directive() {
+    let temp_dir = make_temp_dir();
+    let crate_dir = temp_dir.path().join("native-smoke");
+    let runtime_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    write_smoke_crate(&crate_dir, &runtime_manifest);
+    let (archive_path, link_config_path) = write_native_runtime_inputs(temp_dir.path());
+
+    let output = run_nested_cargo(
+        &crate_dir,
+        &temp_dir.path().join("native-target"),
+        "check",
+        &[
+            ("XLS_AOT_RUNTIME_PATH", archive_path.as_path()),
+            (
+                "XLS_AOT_RUNTIME_LINK_CONFIG_PATH",
+                link_config_path.as_path(),
+            ),
+        ],
+        None,
+    );
+    let output_text = output_text(&output);
+    assert!(
+        output.status.success(),
+        "Nested native-mode cargo check failed with status {:?}.\n{}",
+        output.status,
+        output_text,
+    );
+    assert!(
+        output_text.contains("cargo:rustc-link-lib=static=xls_aot_runtime"),
+        "Native mode did not emit the standalone runtime archive link directive.\n{}",
+        output_text,
+    );
+}
+
+// Verifies: Declared mode emits no native runtime archive request.
+// Catches: Bazel and Cargo both linking the runtime.
+#[test]
+fn declared_mode_builds_without_native_archive_link_requests() {
+    let temp_dir = make_temp_dir();
+    let crate_dir = temp_dir.path().join("declared-smoke");
+    let runtime_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    write_smoke_crate(&crate_dir, &runtime_manifest);
+
+    let output = run_nested_cargo(
+        &crate_dir,
+        &temp_dir.path().join("declared-target"),
+        "build",
+        &[],
+        Some("declared"),
+    );
+    let output_text = output_text(&output);
+    assert!(
+        output.status.success(),
+        "Nested declared-mode cargo build failed without a native runtime archive.\n{}",
+        output_text,
+    );
+    assert!(
+        output_text.contains(
+            "cargo:info=Skipping native link directives because XLS_AOT_RUNTIME_LINK_MODE=declared"
+        ),
+        "Declared mode did not report the skipped native directives.\n{}",
+        output_text,
+    );
+    assert!(
+        !output_text.contains("cargo:rustc-link-lib=static=xls_aot_runtime"),
+        "Declared mode still emitted a flattened runtime archive link directive.\n{}",
+        output_text,
+    );
+}


### PR DESCRIPTION
This change lets `xlsynth-aot-runtime` run in a Bazel-declared link mode, so rules_rust can supply the standalone runtime dependency instead of the Rust crate also requesting the released static archive. Direct Cargo consumers keep the existing native archive link behavior by default.

# Problem Solved

`xlsynth-aot-runtime` currently asks Rust to link `libxls_aot_runtime.a` through both its build-script output and its inline static link annotation. That is correct for direct Cargo consumers, but it conflicts with the source-backed Bazel path where the final Bazel target should declare the C++ runtime dependency once.

Minimized example:

```text
Cargo default:
  crate -> emits static archive link request

Bazel declared mode:
  crate -> emits no runtime archive link request
  Bazel target -> depends on runtime source target
```

# What Changed

- Add `XLS_AOT_RUNTIME_LINK_MODE` with `native` default and `declared` Bazel mode.
- In declared mode, suppress both build-script native link directives and the inline Rust static-link attribute.
- Keep native mode on the existing archive and link-config contract.
- Add smoke tests that exercise both modes through nested Cargo builds.

# Validation

- `cargo clippy -p xlsynth-aot-runtime --tests`
- `XLS_AOT_RUNTIME_PATH=<path-to-libxls_aot_runtime.a> XLS_AOT_RUNTIME_LINK_CONFIG_PATH=<path-to-libxls_aot_runtime_link.toml> cargo test -p xlsynth-aot-runtime`