### PR TITLE
aot-runtime: adopt XLS v0.50.1 with valid native-link coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1006,7 +1006,7 @@ jobs:
         run: |
           export SLANG_PATH=$(realpath slang)
           export XLSYNTH_TOOLS=$(realpath xlsynth_tools)
-          cp $(find -name 'libxls-v*-*.so' | head -n 1) .
+          cp "$(find . -name 'libxls-${{ steps.resolve-xls-tag-valgrind.outputs.tag }}-ubuntu2004.so' -print -quit)" .
           export LD_LIBRARY_PATH=$(pwd):$LD_LIBRARY_PATH
           python3 scripts/run_valgrind_on_tests.py --filter-to-run=sample_usage,ir_interpret_test
 

--- a/xlsynth-aot-runtime/tests/link_mode_test.rs
+++ b/xlsynth-aot-runtime/tests/link_mode_test.rs
@@ -101,10 +101,10 @@ fn output_text(output: &std::process::Output) -> String {
     )
 }
 
-/// Writes the minimal native-mode archive and platform link configuration.
+/// Writes a valid empty native-mode archive and platform link configuration.
 fn write_native_runtime_inputs(root: &Path) -> (PathBuf, PathBuf) {
     let archive_path = root.join("libxls_aot_runtime.a");
-    write_file(&archive_path, "");
+    write_file(&archive_path, "!<arch>\n");
     let target_os = if cfg!(target_os = "macos") {
         "macos"
     } else {

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.48.0";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.50.1";
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 6;
 
 struct ArtifactPaths {


### PR DESCRIPTION
This updates the crate's selected XLS release from `v0.48.0` to published `v0.50.1`, uses a valid empty static archive in the native-link smoke test, and makes Valgrind copy the DSO for the selected release. The new pin selects the repaired XLS release line, while the fixture and Valgrind fixes keep release-backed validation exercising that line instead of failing on invalid or stale local inputs.

### Problem Solved

PR #982 introduced `native_mode_emits_static_archive_link_directive` with a zero-byte file named `libxls_aot_runtime.a`. PR #980 exposed that defect in its pre-downloaded-artifacts CI lane, where `sccache` rejects the placeholder with `Invalid archive size` before the release-backed runtime coverage executes.

This PR now also advances `xlsynth-sys/build.rs` to public XLS `v0.50.1`. Public `v0.50.0` did not publish release assets after its Ubuntu packaging run failed; `v0.50.1` is the repaired release and contains the standalone AOT runtime assets needed for downstream release-backed validation.

After that version advance, `Valgrind Tests (Ubuntu)` restored a cached dangling `libxls-v0.48.0-ubuntu2004.so` alias and selected it through a version-agnostic wildcard. The workflow now selects `libxls-${resolved_tag}-ubuntu2004.so`, so the Valgrind lane uses the DSO matching this PR's release selection.

### Minimized Example

```text
before: XLS release = v0.48.0; libfoo.a = zero bytes -> sccache rejects the fixture
after:  XLS release = v0.50.1; libfoo.a = valid empty ar -> native-link smoke test reaches its assertion

cached DSO aliases: v0.48.0 -> missing, v0.50.1 -> current
before: find libxls-v*-*.so | head -> dangling v0.48.0 alias -> Valgrind setup fails
after:  find libxls-v0.50.1-ubuntu2004.so -> current DSO -> Valgrind can run
```

### Validation

- Public XLS `v0.50.1` was published with `xls-aot-runtime-source.tar.gz`, `libxls_aot_runtime-arm64.a`, and `libxls_aot_runtime_link-arm64.toml`; the downloaded arm64 runtime archive and link config matched their published SHA-256 manifests.
- Release-backed testing in a fresh target directory linked `xls-v0.50.1-arm64` and passed `xlsynth-aot-runtime`, `xlsynth-aot-standalone-test-crate`, `xlsynth-aot-test-crate`, and `sample-usage`.
- A minimized stale-alias selector fixture reproduces the failing wildcard copy and passes with selection restricted to the resolved `v0.50.1` DSO.
