### PR TITLE
Add SequentialGateFn to g8r.

### DIFF
--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -349,11 +349,11 @@ Output format:
 
 ### `ir2g8r`: IR to gate-level representation
 
-Converts an XLS IR file to an `xlsynth_g8r::GateFn` (i.e. a gate-level netlist in AIG form).
+Converts an XLS IR file to an `xlsynth_g8r::GateFn` (i.e. a gate-level netlist in AIG form), then stores it as a native `SequentialGateFn` design with no clock or registers.
 
-- By default the pretty-printed GateFn is sent to **stdout**.
+- By default a text `.g8r` design beginning with `g8r_v1` is sent to **stdout**.
 - Additional artifacts can be emitted with flags:
-  - `--bin-out <PATH>` – write the GateFn as a binary **.g8rbin** file (bincode-encoded).
+  - `--bin-out <PATH>` – write the design as a binary **.g8rbin** file beginning with the visible `g8rbin_v1` format prefix.
   - `--aiger-out <PATH>` – write the GateFn as AIGER:
     - use a `.aag` suffix for ASCII AIGER (`aag`)
     - use a `.aig` suffix for binary AIGER (`aig`)
@@ -382,9 +382,15 @@ xlsynth-driver ir2g8r my_module.opt.ir \
 
 The command above leaves three artifacts:
 
-1. `my_module.g8r` – human-readable GateFn (stdout redirection).
-1. `my_module.g8rbin` – compact bincode serialisation of the same GateFn.
+1. `my_module.g8r` – human-readable native g8r file containing the combinational design.
+1. `my_module.g8rbin` – compact native g8r binary file containing the same design.
 1. `my_module.stats.json` – structural summary statistics as JSON.
+
+Every native `.g8r` and `.g8rbin` file stores a `SequentialGateFn`: transition
+logic plus optional clock and register bindings. Its single clock is an XLS
+block clock port; the native representation does not include an alternate
+clock-edge selector. Combinational consumers accept only designs with no clock
+and no registers, converting those designs to `GateFn` after loading.
 
 ### `ir-prep-for-gates`: IR to prepared residual PIR
 
@@ -410,7 +416,7 @@ xlsynth-driver ir-prep-for-gates my_module.opt.ir --top main > my_module.prepare
 
 ### `g8r2v`: GateFn to gate-level netlist (Verilog-like)
 
-Converts a `.g8r` (text) or `.g8rbin` (bincode) file containing a gate-level `GateFn` to a `.ugv` netlist (human-readable, Verilog-like) on **stdout**.
+Converts a combinational `.g8r` (text) or `.g8rbin` (binary) design to a `.ugv` netlist (human-readable, Verilog-like) on **stdout**. Designs that declare a clock or contain registers are rejected because this command does not yet emit stored sequential boundaries.
 
 - By default, emits the netlist with the original GateFn inputs.
 - The `--add-clk-port[=NAME]` flag inserts an (unused) clock port as the first input:
@@ -525,7 +531,7 @@ xlsynth-driver aig2v design.aig \
 
 ### `g8r2ir`: GateFn to XLS IR package
 
-Converts a `.g8r` (text) or `.g8rbin` (bincode) file containing a gate-level `GateFn` into an XLS IR *package* and prints it on **stdout**.
+Converts a combinational `.g8r` (text) or `.g8rbin` (binary) design into an XLS IR *package* and prints it on **stdout**. Designs that declare a clock or contain registers are rejected because this command currently produces function IR rather than block IR.
 
 - The reconstructed IR uses the GateFn’s flattened bit-vector signature (one `bits[W]` parameter per input and a `bits[W]` or tuple-of-bits return type).
 - This is useful for IR-level inspection, equivalence checking, and debugging of GateFn transforms.
@@ -572,7 +578,7 @@ xlsynth-driver aig2ir my_module.aag --fn-type '(bits[8][4]) -> bits[8][4]' > my_
 
 ### `g8r-area-table`: Per-PIR-node live AIG area attribution
 
-Reads a `.g8r` or `.g8rbin` `GateFn` plus an XLS IR package and prints a table that attributes live AIG AND-node area back to PIR node ids carried in g8r provenance.
+Reads a combinational `.g8r` or `.g8rbin` design plus an XLS IR package and prints a table that attributes live AIG AND-node area back to PIR node ids carried in g8r provenance. Designs with clocks or registers are not accepted by this combinational attribution command.
 
 - One row is emitted per PIR node id that appears on at least one live `And2` node and resolves against the selected IR member.
 
@@ -614,7 +620,7 @@ xlsynth-driver g8r-area-table my_module.g8r my_module.ir --group-by-opcode
 
 ### `g8r-critical-path-table`: Per-PIR-node attribution for level-critical AIG nodes
 
-Reads a `.g8r` or `.g8rbin` `GateFn` plus an XLS IR package and prints the same attribution table shape as `g8r-area-table`, but only for live AIG `And2` nodes that lie on at least one critical path as measured by AIG levels from primary inputs to primary outputs.
+Reads a combinational `.g8r` or `.g8rbin` design plus an XLS IR package and prints the same attribution table shape as `g8r-area-table`, but only for live AIG `And2` nodes that lie on at least one critical path as measured by AIG levels from primary inputs to primary outputs. Designs with clocks or registers are not accepted by this combinational attribution command.
 
 - One row is emitted per PIR node id that appears on at least one critical-path `And2` node and resolves against the selected IR member.
 
@@ -1913,7 +1919,7 @@ xlsynth-driver ir-diverse-samples ./corpus_dir > selected.txt
 
 ### `g8r-equiv`
 
-Checks two GateFns for functional equivalence by lifting both sides to IR and
+Checks two combinational `.g8r`/`.g8rbin` designs for functional equivalence by lifting both sides to IR and
 running the same prover-backed flow as `ir-equiv`.
 
 - Positional arguments: `<lhs_g8r_file> <rhs_g8r_file>`
@@ -1929,9 +1935,10 @@ non-zero.
 
 ### `g8r-ir-equiv`
 
-Checks a **GateFn (`.g8r` or `.g8rbin`)** design against an **IR** function by
+Checks a combinational **`.g8r` or `.g8rbin`** design against an **IR** function by
 lifting the GateFn into IR and then running the same IR equivalence flow as
-`ir-equiv`.
+`ir-equiv`. Designs with clocks or registers are not accepted by this
+function-equivalence command.
 
 - Positional arguments: `<g8r_file> <rhs_ir_file>`
 - Top selection:

--- a/xlsynth-driver/src/g8r2ir.rs
+++ b/xlsynth-driver/src/g8r2ir.rs
@@ -1,36 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs;
 use std::path::Path;
 
-use xlsynth_g8r::aig::GateFn;
+use xlsynth_g8r::aig_serdes::g8r::load_gate_fn_from_path;
 use xlsynth_g8r::aig_serdes::gate2ir::gate_fn_to_xlsynth_ir;
 
 use crate::toolchain_config::ToolchainConfig;
-
-fn load_gate_fn(path: &Path) -> Result<GateFn, String> {
-    let bytes = fs::read(path).map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
-    if path.extension().map(|e| e == "g8rbin").unwrap_or(false) {
-        bincode::deserialize(&bytes).map_err(|e| {
-            format!(
-                "failed to deserialize GateFn from {}: {}",
-                path.display(),
-                e
-            )
-        })
-    } else {
-        let txt = String::from_utf8(bytes)
-            .map_err(|e| format!("failed to decode utf8 from {}: {}", path.display(), e))?;
-        GateFn::try_from(txt.as_str())
-            .map_err(|e| format!("failed to parse GateFn from {}: {}", path.display(), e))
-    }
-}
 
 pub fn handle_g8r2ir(matches: &clap::ArgMatches, _config: &Option<ToolchainConfig>) {
     let g8r_input_file = matches.get_one::<String>("g8r_input_file").unwrap();
     let g8r_path = Path::new(g8r_input_file);
 
-    let gate_fn = match load_gate_fn(g8r_path) {
+    let gate_fn = match load_gate_fn_from_path(g8r_path) {
         Ok(g) => g,
         Err(e) => {
             eprintln!("g8r2ir error: {}", e);

--- a/xlsynth-driver/src/g8r2v.rs
+++ b/xlsynth-driver/src/g8r2v.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::Path;
+
+use xlsynth_g8r::aig_serdes::g8r::load_gate_fn_from_path;
+
 pub fn handle_g8r2v(matches: &clap::ArgMatches) -> Result<(), String> {
     let g8r_input_file = matches.get_one::<String>("g8r_input_file").unwrap();
     let add_clk_port = matches.get_one::<String>("add-clk-port").cloned();
@@ -15,10 +19,7 @@ pub fn handle_g8r2v(matches: &clap::ArgMatches) -> Result<(), String> {
         );
     }
 
-    let g8r_contents = std::fs::read_to_string(g8r_input_file)
-        .map_err(|e| format!("Failed to read .g8r file '{}': {}", g8r_input_file, e))?;
-    let gate_fn = xlsynth_g8r::aig::GateFn::try_from(g8r_contents.as_str())
-        .map_err(|e| format!("Failed to parse GateFn from '{}': {}", g8r_input_file, e))?;
+    let gate_fn = load_gate_fn_from_path(Path::new(g8r_input_file))?;
 
     let final_module_name = module_name_override.as_deref().unwrap_or(&gate_fn.name);
 

--- a/xlsynth-driver/src/g8r_equiv.rs
+++ b/xlsynth-driver/src/g8r_equiv.rs
@@ -1,32 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use xlsynth_g8r::aig::GateFn;
+use xlsynth_g8r::aig_serdes::g8r::load_gate_fn_from_path;
 use xlsynth_prover::prover::SolverChoice;
 
-use std::fs;
 use std::path::Path;
 
 use crate::gate_ir_equiv::prove_gate_fns_equiv_via_ir;
 use crate::ir_equiv::emit_equiv_outcome_and_exit;
 use crate::toolchain_config::ToolchainConfig;
-
-fn load_gate_fn(path: &Path) -> Result<GateFn, String> {
-    let bytes = fs::read(path).map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
-    if path.extension().map(|e| e == "g8rbin").unwrap_or(false) {
-        bincode::deserialize(&bytes).map_err(|e| {
-            format!(
-                "failed to deserialize GateFn from {}: {}",
-                path.display(),
-                e
-            )
-        })
-    } else {
-        let txt = String::from_utf8(bytes)
-            .map_err(|e| format!("failed to decode utf8 from {}: {}", path.display(), e))?;
-        GateFn::try_from(txt.as_str())
-            .map_err(|e| format!("failed to parse GateFn from {}: {}", path.display(), e))
-    }
-}
 
 pub fn handle_g8r_equiv(matches: &clap::ArgMatches, config: &Option<ToolchainConfig>) {
     let lhs_path = Path::new(matches.get_one::<String>("lhs_g8r_file").unwrap());
@@ -36,14 +17,14 @@ pub fn handle_g8r_equiv(matches: &clap::ArgMatches, config: &Option<ToolchainCon
         .map(|s| s.parse().unwrap());
     let output_json = matches.get_one::<String>("output_json");
 
-    let lhs = match load_gate_fn(lhs_path) {
+    let lhs = match load_gate_fn_from_path(lhs_path) {
         Ok(g) => g,
         Err(e) => {
             eprintln!("g8r-equiv error: {}", e);
             std::process::exit(2);
         }
     };
-    let rhs = match load_gate_fn(rhs_path) {
+    let rhs = match load_gate_fn_from_path(rhs_path) {
         Ok(g) => g,
         Err(e) => {
             eprintln!("g8r-equiv error: {}", e);

--- a/xlsynth-driver/src/g8r_ir_equiv.rs
+++ b/xlsynth-driver/src/g8r_ir_equiv.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs;
 use std::path::Path;
 
 use crate::ir_equiv::{dispatch_ir_equiv, IrEquivRequest, IrModule};
 use crate::toolchain_config::ToolchainConfig;
 use xlsynth_g8r::aig::GateFn;
+use xlsynth_g8r::aig_serdes::g8r::load_gate_fn_from_path;
 use xlsynth_g8r::aig_serdes::gate2ir::gate_fn_to_xlsynth_ir;
 use xlsynth_pir::ir;
 use xlsynth_pir::ir_parser;
@@ -13,24 +13,6 @@ use xlsynth_prover::prover::types::{AssertionSemantics, EquivParallelism};
 use xlsynth_prover::prover::SolverChoice;
 
 const SUBCOMMAND: &str = "g8r-ir-equiv";
-
-fn load_gate_fn(path: &Path) -> Result<GateFn, String> {
-    let bytes = fs::read(path).map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
-    if path.extension().map(|e| e == "g8rbin").unwrap_or(false) {
-        bincode::deserialize(&bytes).map_err(|e| {
-            format!(
-                "failed to deserialize GateFn from {}: {}",
-                path.display(),
-                e
-            )
-        })
-    } else {
-        let txt = String::from_utf8(bytes)
-            .map_err(|e| format!("failed to decode utf8 from {}: {}", path.display(), e))?;
-        GateFn::try_from(txt.as_str())
-            .map_err(|e| format!("failed to parse GateFn from {}: {}", path.display(), e))
-    }
-}
 
 fn parse_pir_top_fn(
     ir_text: &str,
@@ -148,7 +130,7 @@ pub fn handle_g8r_ir_equiv(matches: &clap::ArgMatches, config: &Option<Toolchain
             std::process::exit(2)
         });
 
-    let gate_fn = load_gate_fn(g8r_path).unwrap_or_else(|e| {
+    let gate_fn = load_gate_fn_from_path(g8r_path).unwrap_or_else(|e| {
         eprintln!("{} error: {}", SUBCOMMAND, e);
         std::process::exit(2)
     });

--- a/xlsynth-driver/src/g8r_table.rs
+++ b/xlsynth-driver/src/g8r_table.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cmp::Ordering;
-use std::fs;
 use std::path::Path;
 
 use comfy_table::presets::ASCII_MARKDOWN;
@@ -12,7 +11,7 @@ use xlsynth_g8r::aig::table::{
     OpcodeAreaTableReport, UnattributedAreaTableRow,
 };
 use xlsynth_g8r::aig::GateFn;
-use xlsynth_g8r::aig_serdes::gate_parser::parse_gate_fn;
+use xlsynth_g8r::aig_serdes::g8r::load_gate_fn_from_path;
 use xlsynth_pir::ir;
 use xlsynth_pir::ir_parser;
 
@@ -50,23 +49,7 @@ fn truncate_for_table(value: &str, max_width: usize) -> String {
 
 fn load_gate_fn(path: &Path, subcommand: &str) -> Result<GateFn, String> {
     match path.extension().and_then(|e| e.to_str()) {
-        Some("g8rbin") => {
-            let bytes =
-                fs::read(path).map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
-            bincode::deserialize(&bytes).map_err(|e| {
-                format!(
-                    "failed to deserialize GateFn from {}: {}",
-                    path.display(),
-                    e
-                )
-            })
-        }
-        Some("g8r") => {
-            let text = fs::read_to_string(path)
-                .map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
-            parse_gate_fn(&text)
-                .map_err(|e| format!("failed to parse GateFn from {}: {}", path.display(), e))
-        }
+        Some("g8rbin") | Some("g8r") => load_gate_fn_from_path(path),
         _ => Err(format!(
             "{} requires a .g8r or .g8rbin input, got {}",
             subcommand,
@@ -474,6 +457,8 @@ fn handle_g8r_attribution_table(
 mod tests {
     use tempfile::Builder;
     use xlsynth_g8r::aig::table::{AreaTableReport, AreaTableRow, UnattributedAreaTableRow};
+    use xlsynth_g8r::aig::SequentialGateFn;
+    use xlsynth_g8r::aig_serdes::g8r::emit_g8r;
     use xlsynth_g8r::test_utils::setup_simple_graph;
 
     use super::{
@@ -617,7 +602,7 @@ Metrics:
         for (idx, node) in g.gates.iter_mut().enumerate() {
             node.try_add_pir_node_ids(&[u32::try_from(idx + 21).expect("fits in u32")]);
         }
-        let text = g.to_string();
+        let text = emit_g8r(&SequentialGateFn::from_gate_fn(g.clone()));
 
         let file = Builder::new()
             .suffix(".g8r")

--- a/xlsynth-driver/src/ir2gates.rs
+++ b/xlsynth-driver/src/ir2gates.rs
@@ -7,9 +7,11 @@ use clap::ArgMatches;
 use crate::toolchain_config::ToolchainConfig;
 use std::fs::File;
 use std::io::Write;
+use xlsynth_g8r::aig::SequentialGateFn;
 use xlsynth_g8r::aig_serdes::emit_aiger::emit_aiger;
 use xlsynth_g8r::aig_serdes::emit_aiger_binary::emit_aiger_binary;
 use xlsynth_g8r::aig_serdes::emit_netlist;
+use xlsynth_g8r::aig_serdes::g8r::{emit_g8r, encode_g8r_binary};
 use xlsynth_g8r::process_ir_path;
 use xlsynth_g8r::process_ir_path::canonical_ir_text_to_g8r_lowering_artifacts;
 
@@ -92,11 +94,12 @@ pub fn handle_ir2g8r(matches: &ArgMatches, _config: &Option<ToolchainConfig>) {
             });
     let gate_fn = artifacts.gate_fn;
     let stats = artifacts.stats;
-    // Always print the GateFn to stdout
-    println!("{}", gate_fn.to_string());
-    // If --bin-out is given, write the GateFn as bincode
+    let design = SequentialGateFn::from_gate_fn(gate_fn.clone());
+    // Always print the native sequential design representation to stdout.
+    println!("{}", emit_g8r(&design));
+    // If --bin-out is given, write the native binary representation.
     if let Some(bin_path) = bin_out {
-        let bin = bincode::serialize(&gate_fn).expect("Failed to serialize GateFn");
+        let bin = encode_g8r_binary(&design).expect("Failed to serialize g8r design");
         let mut f = File::create(bin_path).expect("Failed to create bin_out file");
         f.write_all(&bin).expect("Failed to write bin_out file");
     }

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -1596,7 +1596,7 @@ fn main() {
         )
         .subcommand(
             clap::Command::new("ir2g8r")
-                .about("Converts IR to GateFn and emits it to stdout; optionally writes .g8rbin, netlist, and stats")
+                .about("Converts IR to a combinational SequentialGateFn in native .g8r format on stdout; optionally writes .g8rbin, netlist, and stats")
                 .arg(
                     clap::Arg::new("ir_input_file")
                         .help("The input IR file")
@@ -2127,7 +2127,7 @@ fn main() {
         )
         .subcommand(
             clap::Command::new("g8r2v")
-                .about("Converts a .g8r or .g8rbin file to a .ugv netlist on stdout, optionally adding a clock port as the first input.")
+                .about("Converts a combinational .g8r or .g8rbin design to a .ugv netlist on stdout, optionally adding a clock port as the first input.")
                 .arg(
                     clap::Arg::new("g8r_input_file")
                         .help("The input .g8r or .g8rbin file")
@@ -2263,7 +2263,7 @@ fn main() {
         )
         .subcommand(
             clap::Command::new("g8r2ir")
-                .about("Converts a .g8r or .g8rbin GateFn file to an XLS IR package on stdout.")
+                .about("Converts a combinational .g8r or .g8rbin design to an XLS IR package on stdout.")
                 .arg(
                     clap::Arg::new("g8r_input_file")
                         .help("The input .g8r or .g8rbin file")

--- a/xlsynth-driver/tests/invoke_test.rs
+++ b/xlsynth-driver/tests/invoke_test.rs
@@ -9,9 +9,10 @@ use std::io::Write;
 use std::process::Command;
 use std::process::Stdio;
 use xlsynth::{IrBits, IrValue};
-use xlsynth_g8r::aig::{AigBitVector, AigOperand, GateFn};
+use xlsynth_g8r::aig::{AigBitVector, AigOperand, GateFn, SequentialGateFn};
 use xlsynth_g8r::aig_serdes::emit_aiger::emit_aiger;
 use xlsynth_g8r::aig_serdes::emit_aiger_binary::emit_aiger_binary;
+use xlsynth_g8r::aig_serdes::g8r::{emit_g8r, encode_g8r_binary};
 use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
 use xlsynth_g8r::test_utils::interesting_ir_roundtrip_cases;
 use xlsynth_pir::ir_parser;
@@ -61,6 +62,17 @@ fn write_aiger_binary_file(
     let path = temp_dir.path().join(file_name);
     std::fs::write(&path, aiger).expect("failed to write binary aiger file");
     path
+}
+
+fn write_g8r_file(path: &std::path::Path, gate_fn: &GateFn) {
+    let design = SequentialGateFn::from_gate_fn(gate_fn.clone());
+    std::fs::write(path, emit_g8r(&design)).expect("failed to write g8r file");
+}
+
+fn write_g8r_binary_file(path: &std::path::Path, gate_fn: &GateFn) {
+    let design = SequentialGateFn::from_gate_fn(gate_fn.clone());
+    let bytes = encode_g8r_binary(&design).expect("failed to serialize g8rbin file");
+    std::fs::write(path, bytes).expect("failed to write g8rbin file");
 }
 
 fn ir_bits_to_msb_string(bits: &IrBits) -> String {
@@ -4460,7 +4472,7 @@ fn test_ir2pipeline_subcommand(use_tool_path: bool, optimize: bool) {
 
 #[test]
 fn test_ir2g8r_emits_all_outputs() {
-    // This test checks that ir2g8r emits the pretty GateFn to stdout,
+    // This test checks that ir2g8r emits native g8r text to stdout,
     // and writes both the .g8rbin and stats JSON files when requested.
     let _ = env_logger::try_init();
     // Use a simple DSLX function to generate IR
@@ -4508,8 +4520,13 @@ fn test_ir2g8r_emits_all_outputs() {
         "ir2g8r failed: {}",
         String::from_utf8_lossy(&ir2g8r_output.stderr)
     );
-    // Check stdout contains the pretty GateFn (should have 'fn __main__main(')
+    // Check stdout identifies the native format and contains its transition body.
     let stdout = String::from_utf8_lossy(&ir2g8r_output.stdout);
+    assert!(
+        stdout.starts_with("g8r_v1\n"),
+        "stdout did not contain the g8r header: {}",
+        stdout
+    );
     assert!(
         stdout.contains("fn __main__main("),
         "stdout did not contain pretty GateFn: {}",
@@ -4518,6 +4535,7 @@ fn test_ir2g8r_emits_all_outputs() {
     // Check .g8rbin file exists and is non-empty
     let g8rbin_data = std::fs::read(&g8rbin_path).expect(".g8rbin file not found");
     assert!(!g8rbin_data.is_empty(), ".g8rbin file is empty");
+    assert!(g8rbin_data.starts_with(b"g8rbin_v1\n"));
     // Check stats JSON file exists and contains expected keys
     let stats_json = std::fs::read_to_string(&stats_path).expect("stats JSON file not found");
     let stats: serde_json::Value =
@@ -4553,7 +4571,7 @@ fn test_g8r2ir_basic_ir_output() {
 
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("testmod.g8r");
-    std::fs::write(&g8r_path, gate_fn.to_string()).unwrap();
+    write_g8r_file(&g8r_path, &gate_fn);
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(command_path)
@@ -4591,7 +4609,7 @@ fn test_g8r2ir_preserves_scalar_multi_output_order() {
 
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("testmod_multi_output.g8r");
-    std::fs::write(&g8r_path, gate_fn.to_string()).unwrap();
+    write_g8r_file(&g8r_path, &gate_fn);
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(command_path)
@@ -4889,7 +4907,7 @@ top fn f(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("testmod.g8rbin");
     let ir_path = temp_dir.path().join("sample.ir");
-    std::fs::write(&g8r_path, bincode::serialize(&gate_fn).unwrap()).unwrap();
+    write_g8r_binary_file(&g8r_path, &gate_fn);
     std::fs::write(&ir_path, ir_text).unwrap();
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
@@ -4961,7 +4979,7 @@ top fn f(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("testmod.g8rbin");
     let ir_path = temp_dir.path().join("sample.ir");
-    std::fs::write(&g8r_path, bincode::serialize(&gate_fn).unwrap()).unwrap();
+    write_g8r_binary_file(&g8r_path, &gate_fn);
     std::fs::write(&ir_path, ir_text).unwrap();
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
@@ -5036,7 +5054,7 @@ top fn f(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("testmod.g8rbin");
     let ir_path = temp_dir.path().join("sample.ir");
-    std::fs::write(&g8r_path, bincode::serialize(&gate_fn).unwrap()).unwrap();
+    write_g8r_binary_file(&g8r_path, &gate_fn);
     std::fs::write(&ir_path, ir_text).unwrap();
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
@@ -5110,7 +5128,7 @@ top fn f(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("testmod.g8rbin");
     let ir_path = temp_dir.path().join("sample.ir");
-    std::fs::write(&g8r_path, bincode::serialize(&gate_fn).unwrap()).unwrap();
+    write_g8r_binary_file(&g8r_path, &gate_fn);
     std::fs::write(&ir_path, ir_text).unwrap();
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
@@ -5773,7 +5791,7 @@ fn test_g8r2v_add_clk_port_behavior() {
 
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("testmod.g8r");
-    std::fs::write(&g8r_path, gate_fn.to_string()).unwrap();
+    write_g8r_file(&g8r_path, &gate_fn);
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(command_path)
@@ -5806,7 +5824,7 @@ fn test_g8r2v_module_name() {
 
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("testmod.g8r");
-    std::fs::write(&g8r_path, gate_fn.to_string()).unwrap();
+    write_g8r_file(&g8r_path, &gate_fn);
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(command_path)
@@ -5864,7 +5882,7 @@ fn test_g8r2v_flop_inputs_outputs() {
 
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("my_flop_inv.g8r");
-    std::fs::write(&g8r_path, gate_fn.to_string()).unwrap();
+    write_g8r_file(&g8r_path, &gate_fn);
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(command_path)
@@ -5902,7 +5920,7 @@ fn test_g8r2v_flop_inputs_only() {
 
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("my_flop_inv_fi.g8r");
-    std::fs::write(&g8r_path, gate_fn.to_string()).unwrap();
+    write_g8r_file(&g8r_path, &gate_fn);
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(command_path)
@@ -5951,7 +5969,7 @@ fn test_g8r2v_flop_outputs_only() {
 
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("my_flop_inv_fo.g8r");
-    std::fs::write(&g8r_path, gate_fn.to_string()).unwrap();
+    write_g8r_file(&g8r_path, &gate_fn);
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(command_path)
@@ -5987,7 +6005,7 @@ fn test_g8r2v_flop_requires_clk_port_error() {
 
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("dummy.g8r");
-    std::fs::write(&g8r_path, gate_fn.to_string()).unwrap();
+    write_g8r_file(&g8r_path, &gate_fn);
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(command_path)
@@ -6024,7 +6042,7 @@ fn test_g8r2v_flop_with_custom_clk_name() {
 
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("my_custom_clk_inv.g8r");
-    std::fs::write(&g8r_path, gate_fn.to_string()).unwrap();
+    write_g8r_file(&g8r_path, &gate_fn);
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(command_path)
@@ -6075,7 +6093,7 @@ fn test_g8r2v_use_system_verilog() {
 
     let temp_dir = tempfile::tempdir().unwrap();
     let g8r_path = temp_dir.path().join("my_sv_inv.g8r");
-    std::fs::write(&g8r_path, gate_fn.to_string()).unwrap();
+    write_g8r_file(&g8r_path, &gate_fn);
 
     let command_path = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(command_path)
@@ -11227,8 +11245,8 @@ fn test_g8r_equiv_reports_equivalent_designs() {
     let rhs_gate = two_input_gate_fn("and_rhs", |a, b, gb| gb.add_and_binary(b, a));
     let lhs_g8r_path = temp_dir.path().join("lhs.g8r");
     let rhs_g8r_path = temp_dir.path().join("rhs.g8r");
-    std::fs::write(&lhs_g8r_path, lhs_gate.to_string()).unwrap();
-    std::fs::write(&rhs_g8r_path, rhs_gate.to_string()).unwrap();
+    write_g8r_file(&lhs_g8r_path, &lhs_gate);
+    write_g8r_file(&rhs_g8r_path, &rhs_gate);
 
     let driver = env!("CARGO_BIN_EXE_xlsynth-driver");
     let output = Command::new(driver)
@@ -11267,7 +11285,7 @@ fn test_g8r_ir_equiv_reports_equivalent_designs() {
 
     let lhs_gate = two_input_gate_fn("main", |a, b, gb| gb.add_and_binary(a, b));
     let lhs_g8r_path = temp_dir.path().join("lhs.g8r");
-    std::fs::write(&lhs_g8r_path, lhs_gate.to_string()).unwrap();
+    write_g8r_file(&lhs_g8r_path, &lhs_gate);
     let rhs_ir = r#"package sample
 
 top fn main(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
@@ -11316,7 +11334,7 @@ fn test_g8r_ir_equiv_reports_non_equivalent_designs() {
 
     let lhs_gate = two_input_gate_fn("main", |a, b, gb| gb.add_and_binary(a, b));
     let lhs_g8r_path = temp_dir.path().join("lhs_not_equiv.g8r");
-    std::fs::write(&lhs_g8r_path, lhs_gate.to_string()).unwrap();
+    write_g8r_file(&lhs_g8r_path, &lhs_gate);
     let rhs_ir = r#"package sample
 
 top fn main(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
@@ -11369,7 +11387,7 @@ fn test_g8r_ir_equiv_preserves_scalar_multi_output_order() {
     builder.add_output("o1".to_string(), AigBitVector::from_bit(*b.get_lsb(0)));
     let lhs_gate = builder.build();
     let lhs_g8r_path = temp_dir.path().join("lhs_multi_output.g8r");
-    std::fs::write(&lhs_g8r_path, lhs_gate.to_string()).unwrap();
+    write_g8r_file(&lhs_g8r_path, &lhs_gate);
 
     let rhs_ir = r#"package sample
 

--- a/xlsynth-g8r/src/aig/mod.rs
+++ b/xlsynth-g8r/src/aig/mod.rs
@@ -16,8 +16,12 @@ pub mod graph_logical_effort;
 pub mod logical_effort;
 pub mod match_and_rewrite;
 pub mod reassociation;
+pub mod sequential_gate;
 pub mod table;
 pub mod topo;
 
 pub use crate::aig::gate::{AigBitVector, AigNode, AigOperand, AigRef, GateFn, Input, Output};
+pub use crate::aig::sequential_gate::{
+    ClockPort, RegisterBinding, ResetSpec, SequentialGateFn, TransitionInputId, TransitionOutputId,
+};
 pub use crate::gate_builder::{GateBuilder, GateBuilderOptions};

--- a/xlsynth-g8r/src/aig/sequential_gate.rs
+++ b/xlsynth-g8r/src/aig/sequential_gate.rs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Sequential design metadata around a combinational one-cycle transition
+//! function.
+
+use std::collections::BTreeSet;
+
+use xlsynth::IrBits;
+
+use crate::aig::gate::{GateFn, Input, Output};
+
+/// Identifies an input of a [`SequentialGateFn::transition`] function.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct TransitionInputId(usize);
+
+impl TransitionInputId {
+    pub fn new(index: usize) -> Self {
+        Self(index)
+    }
+
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// Identifies an output of a [`SequentialGateFn::transition`] function.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct TransitionOutputId(usize);
+
+impl TransitionOutputId {
+    pub fn new(index: usize) -> Self {
+        Self(index)
+    }
+
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// The single clock port of an XLS-compatible sequential design.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ClockPort {
+    pub name: String,
+}
+
+/// Reset behavior of a register.
+///
+/// `signal` is an output of the transition function because reset may be a
+/// combinational expression and must remain live during AIG optimization.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ResetSpec {
+    pub signal: TransitionOutputId,
+    pub asynchronous: bool,
+    pub active_low: bool,
+    pub value: IrBits,
+}
+
+/// Binds one state element to the transition function interface.
+///
+/// Register `Q` is a source of combinational logic, represented as a
+/// transition input. Register `D`, load enable, and reset are sequential-cell
+/// inputs, represented as transition outputs.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RegisterBinding {
+    pub name: String,
+    pub q: TransitionInputId,
+    pub d: TransitionOutputId,
+    pub load_enable: Option<TransitionOutputId>,
+    pub reset: Option<ResetSpec>,
+    pub initial_value: Option<IrBits>,
+}
+
+/// A synchronous design represented as a combinational transition function
+/// plus its sequential boundaries.
+///
+/// `transition.inputs` are classified as external `inputs` or register `Q`
+/// values. `transition.outputs` are externally visible `outputs`, register
+/// `D` values, or register control inputs. A design with no registers is valid
+/// and may omit `clock`.
+#[derive(Debug, Clone)]
+pub struct SequentialGateFn {
+    pub name: String,
+    pub transition: GateFn,
+    pub inputs: Vec<TransitionInputId>,
+    pub outputs: Vec<TransitionOutputId>,
+    pub clock: Option<ClockPort>,
+    pub registers: Vec<RegisterBinding>,
+}
+
+impl SequentialGateFn {
+    /// Wraps a combinational gate function in the canonical sequential design
+    /// representation without adding state or clock metadata.
+    pub fn from_gate_fn(gate_fn: GateFn) -> Self {
+        let name = gate_fn.name.clone();
+        let inputs = (0..gate_fn.inputs.len())
+            .map(TransitionInputId::new)
+            .collect();
+        let outputs = (0..gate_fn.outputs.len())
+            .map(TransitionOutputId::new)
+            .collect();
+        Self::new(name, gate_fn, inputs, outputs, None, vec![])
+            .expect("identity bindings for a GateFn must form a valid SequentialGateFn")
+    }
+
+    /// Returns a combinational gate function when this design contains no
+    /// sequential boundary metadata.
+    pub fn try_into_gate_fn(self) -> Result<GateFn, String> {
+        self.validate().map_err(|e| {
+            format!(
+                "cannot convert design '{}' to GateFn: invalid SequentialGateFn: {}",
+                self.name, e
+            )
+        })?;
+        match (&self.clock, self.registers.len()) {
+            (Some(clock), register_count) if register_count != 0 => {
+                return Err(format!(
+                    "cannot convert design '{}' to GateFn: design contains {} register(s) and clock '{}'",
+                    self.name, register_count, clock.name
+                ));
+            }
+            (Some(clock), _) => {
+                return Err(format!(
+                    "cannot convert design '{}' to GateFn: design declares clock '{}'",
+                    self.name, clock.name
+                ));
+            }
+            (None, register_count) if register_count != 0 => {
+                return Err(format!(
+                    "cannot convert design '{}' to GateFn: design contains {} register(s)",
+                    self.name, register_count
+                ));
+            }
+            (None, _) => {}
+        }
+
+        let inputs = self
+            .inputs
+            .iter()
+            .map(|id| self.transition.inputs[id.index()].clone())
+            .collect();
+        let outputs = self
+            .outputs
+            .iter()
+            .map(|id| self.transition.outputs[id.index()].clone())
+            .collect();
+        let mut gate_fn = self.transition;
+        gate_fn.name = self.name;
+        gate_fn.inputs = inputs;
+        gate_fn.outputs = outputs;
+        Ok(gate_fn)
+    }
+
+    /// Constructs a sequential function after validating its interface
+    /// bindings.
+    pub fn new(
+        name: String,
+        transition: GateFn,
+        inputs: Vec<TransitionInputId>,
+        outputs: Vec<TransitionOutputId>,
+        clock: Option<ClockPort>,
+        registers: Vec<RegisterBinding>,
+    ) -> Result<Self, String> {
+        let result = Self {
+            name,
+            transition,
+            inputs,
+            outputs,
+            clock,
+            registers,
+        };
+        result.validate()?;
+        Ok(result)
+    }
+
+    /// Validates sequential metadata and its bindings to the transition
+    /// function.
+    pub fn validate(&self) -> Result<(), String> {
+        self.transition.check_invariants_with_debug_assert();
+
+        if !self.registers.is_empty() && self.clock.is_none() {
+            return Err("a SequentialGateFn with registers must have a clock".to_string());
+        }
+
+        let mut input_claims = vec![None; self.transition.inputs.len()];
+        for id in &self.inputs {
+            self.claim_transition_input(&mut input_claims, *id, "external input".to_string())?;
+        }
+
+        let mut output_is_bound = vec![false; self.transition.outputs.len()];
+        let mut external_outputs = BTreeSet::new();
+        for id in &self.outputs {
+            self.transition_output(*id, "external output")?;
+            if !external_outputs.insert(*id) {
+                return Err(format!(
+                    "transition output index {} is listed more than once as an external output",
+                    id.index()
+                ));
+            }
+            output_is_bound[id.index()] = true;
+        }
+
+        let mut register_names = BTreeSet::new();
+        for register in &self.registers {
+            if !register_names.insert(register.name.clone()) {
+                return Err(format!("duplicate register name '{}'", register.name));
+            }
+
+            self.claim_transition_input(
+                &mut input_claims,
+                register.q,
+                format!("register '{}' Q", register.name),
+            )?;
+
+            let q =
+                self.transition_input(register.q, &format!("register '{}' Q", register.name))?;
+            let d = self.bind_transition_output(
+                &mut output_is_bound,
+                register.d,
+                &format!("register '{}' D", register.name),
+            )?;
+            let register_width = q.get_bit_count();
+            if d.get_bit_count() != register_width {
+                return Err(format!(
+                    "register '{}' has Q width {} but D width {}",
+                    register.name,
+                    register_width,
+                    d.get_bit_count()
+                ));
+            }
+
+            if let Some(load_enable) = register.load_enable {
+                let output = self.bind_transition_output(
+                    &mut output_is_bound,
+                    load_enable,
+                    &format!("register '{}' load enable", register.name),
+                )?;
+                if output.get_bit_count() != 1 {
+                    return Err(format!(
+                        "register '{}' load enable must be bits[1], got bits[{}]",
+                        register.name,
+                        output.get_bit_count()
+                    ));
+                }
+            }
+
+            if let Some(reset) = &register.reset {
+                let output = self.bind_transition_output(
+                    &mut output_is_bound,
+                    reset.signal,
+                    &format!("register '{}' reset", register.name),
+                )?;
+                if output.get_bit_count() != 1 {
+                    return Err(format!(
+                        "register '{}' reset signal must be bits[1], got bits[{}]",
+                        register.name,
+                        output.get_bit_count()
+                    ));
+                }
+                if reset.value.get_bit_count() != register_width {
+                    return Err(format!(
+                        "register '{}' reset value has width {} but register width is {}",
+                        register.name,
+                        reset.value.get_bit_count(),
+                        register_width
+                    ));
+                }
+            }
+
+            if let Some(initial_value) = &register.initial_value
+                && initial_value.get_bit_count() != register_width
+            {
+                return Err(format!(
+                    "register '{}' initial value has width {} but register width is {}",
+                    register.name,
+                    initial_value.get_bit_count(),
+                    register_width
+                ));
+            }
+        }
+
+        for (index, claim) in input_claims.iter().enumerate() {
+            if claim.is_none() {
+                return Err(format!(
+                    "transition input '{}' at index {} is not bound as an external input or register Q",
+                    self.transition.inputs[index].name, index
+                ));
+            }
+        }
+        for (index, is_bound) in output_is_bound.iter().enumerate() {
+            if !is_bound {
+                return Err(format!(
+                    "transition output '{}' at index {} is not bound as an external output or register input",
+                    self.transition.outputs[index].name, index
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn claim_transition_input(
+        &self,
+        claims: &mut [Option<String>],
+        id: TransitionInputId,
+        claim: String,
+    ) -> Result<(), String> {
+        self.transition_input(id, &claim)?;
+        if let Some(previous) = &claims[id.index()] {
+            return Err(format!(
+                "transition input index {} is bound both as {} and {}",
+                id.index(),
+                previous,
+                claim
+            ));
+        }
+        claims[id.index()] = Some(claim);
+        Ok(())
+    }
+
+    fn transition_input(&self, id: TransitionInputId, context: &str) -> Result<&Input, String> {
+        self.transition.inputs.get(id.index()).ok_or_else(|| {
+            format!(
+                "{} references transition input index {}, but only {} inputs exist",
+                context,
+                id.index(),
+                self.transition.inputs.len()
+            )
+        })
+    }
+
+    fn bind_transition_output(
+        &self,
+        output_is_bound: &mut [bool],
+        id: TransitionOutputId,
+        context: &str,
+    ) -> Result<&Output, String> {
+        let output = self.transition_output(id, context)?;
+        output_is_bound[id.index()] = true;
+        Ok(output)
+    }
+
+    fn transition_output(&self, id: TransitionOutputId, context: &str) -> Result<&Output, String> {
+        self.transition.outputs.get(id.index()).ok_or_else(|| {
+            format!(
+                "{} references transition output index {}, but only {} outputs exist",
+                context,
+                id.index(),
+                self.transition.outputs.len()
+            )
+        })
+    }
+}

--- a/xlsynth-g8r/src/aig_serdes/g8r.rs
+++ b/xlsynth-g8r/src/aig_serdes/g8r.rs
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Text and binary serialization for native g8r designs.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use xlsynth::ir_value::IrFormatPreference;
+use xlsynth::{IrBits, IrValue};
+
+use crate::aig::{
+    ClockPort, GateFn, RegisterBinding, ResetSpec, SequentialGateFn, TransitionInputId,
+    TransitionOutputId,
+};
+use crate::aig_serdes::gate_parser::parse_gate_fn;
+
+const TEXT_HEADER: &str = "g8r_v1";
+const BINARY_HEADER: &[u8] = b"g8rbin_v1\n";
+
+/// Emits the canonical human-readable `.g8r` representation of a design.
+pub fn emit_g8r(design: &SequentialGateFn) -> String {
+    emit_sequential_g8r(design)
+}
+
+/// Parses a human-readable `.g8r` design.
+pub fn parse_g8r(text: &str) -> Result<SequentialGateFn, String> {
+    let (header, body) = text
+        .split_once('\n')
+        .ok_or_else(|| "g8r file is missing its header".to_string())?;
+    if header != TEXT_HEADER {
+        return Err(format!(
+            "unsupported g8r header '{}'; expected '{}'",
+            header, TEXT_HEADER
+        ));
+    }
+    parse_sequential_g8r(body)
+}
+
+/// Serializes a native design as `.g8rbin`.
+///
+/// The ASCII prefix lets tools identify the native format before decoding its
+/// bincode body.
+pub fn encode_g8r_binary(design: &SequentialGateFn) -> Result<Vec<u8>, String> {
+    let body = bincode::serialize(&BinarySequentialGateFn::from(design))
+        .map_err(|e| format!("failed to serialize SequentialGateFn payload: {}", e))?;
+    let mut bytes = Vec::with_capacity(BINARY_HEADER.len() + body.len());
+    bytes.extend_from_slice(BINARY_HEADER);
+    bytes.extend_from_slice(&body);
+    Ok(bytes)
+}
+
+/// Decodes a `.g8rbin` design after inspecting its format prefix.
+pub fn decode_g8r_binary(bytes: &[u8]) -> Result<SequentialGateFn, String> {
+    let body = bytes
+        .strip_prefix(BINARY_HEADER)
+        .ok_or_else(|| "unsupported g8rbin header; expected 'g8rbin_v1'".to_string())?;
+    let binary: BinarySequentialGateFn = bincode::deserialize(body)
+        .map_err(|e| format!("failed to deserialize SequentialGateFn payload: {}", e))?;
+    binary.try_into()
+}
+
+/// Loads a `.g8r` or `.g8rbin` sequential design from a path.
+pub fn load_sequential_gate_fn_from_path(path: &Path) -> Result<SequentialGateFn, String> {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("g8rbin") => {
+            let bytes =
+                fs::read(path).map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
+            decode_g8r_binary(&bytes)
+                .map_err(|e| format!("failed to decode {}: {}", path.display(), e))
+        }
+        Some("g8r") => {
+            let text = fs::read_to_string(path)
+                .map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
+            parse_g8r(&text).map_err(|e| format!("failed to parse {}: {}", path.display(), e))
+        }
+        _ => Err(format!(
+            "expected a .g8r or .g8rbin input, got {}",
+            path.display()
+        )),
+    }
+}
+
+/// Loads a native design for a consumer that operates only on combinational
+/// `GateFn`s.
+pub fn load_gate_fn_from_path(path: &Path) -> Result<GateFn, String> {
+    load_sequential_gate_fn_from_path(path)?
+        .try_into_gate_fn()
+        .map_err(|e| format!("{}: {}", path.display(), e))
+}
+
+fn emit_sequential_g8r(sequential: &SequentialGateFn) -> String {
+    let mut text = String::new();
+    text.push_str(TEXT_HEADER);
+    text.push('\n');
+    text.push_str(&format!("name {}\n", sequential.name));
+    match &sequential.clock {
+        None => text.push_str("clock none\n"),
+        Some(clock) => text.push_str(&format!("clock {}\n", clock.name)),
+    }
+    text.push_str(&format!(
+        "inputs {}\n",
+        format_input_ids(&sequential.inputs)
+    ));
+    text.push_str(&format!(
+        "outputs {}\n",
+        format_output_ids(&sequential.outputs)
+    ));
+    text.push_str(&format!("registers {}\n", sequential.registers.len()));
+    for register in &sequential.registers {
+        let (reset_signal, reset_asynchronous, reset_active_low, reset_value) =
+            match &register.reset {
+                None => (
+                    "none".to_string(),
+                    "none".to_string(),
+                    "none".to_string(),
+                    "none".to_string(),
+                ),
+                Some(reset) => (
+                    reset.signal.index().to_string(),
+                    reset.asynchronous.to_string(),
+                    reset.active_low.to_string(),
+                    format_bits(&reset.value),
+                ),
+            };
+        text.push_str(&format!(
+            "register {} q={} d={} load_enable={} reset_signal={} reset_asynchronous={} reset_active_low={} reset_value={} initial_value={}\n",
+            register.name,
+            register.q.index(),
+            register.d.index(),
+            register
+                .load_enable
+                .map(|id| id.index().to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            reset_signal,
+            reset_asynchronous,
+            reset_active_low,
+            reset_value,
+            register
+                .initial_value
+                .as_ref()
+                .map(format_bits)
+                .unwrap_or_else(|| "none".to_string())
+        ));
+    }
+    text.push_str("transition\n");
+    text.push_str(&sequential.transition.to_string());
+    text
+}
+
+fn parse_sequential_g8r(body: &str) -> Result<SequentialGateFn, String> {
+    let (metadata, transition_text) = body
+        .split_once("\ntransition\n")
+        .ok_or_else(|| "SequentialGateFn payload is missing its transition section".to_string())?;
+    let mut lines = metadata.lines();
+    let name = parse_prefixed_line(
+        lines
+            .next()
+            .ok_or_else(|| "SequentialGateFn payload is missing its name".to_string())?,
+        "name ",
+        "name",
+    )?
+    .to_string();
+    let clock = parse_clock(
+        lines
+            .next()
+            .ok_or_else(|| "SequentialGateFn payload is missing its clock".to_string())?,
+    )?;
+    let inputs = parse_input_ids(parse_prefixed_line(
+        lines
+            .next()
+            .ok_or_else(|| "SequentialGateFn payload is missing its inputs".to_string())?,
+        "inputs ",
+        "inputs",
+    )?)?;
+    let outputs = parse_output_ids(parse_prefixed_line(
+        lines
+            .next()
+            .ok_or_else(|| "SequentialGateFn payload is missing its outputs".to_string())?,
+        "outputs ",
+        "outputs",
+    )?)?;
+    let register_count: usize = parse_prefixed_line(
+        lines
+            .next()
+            .ok_or_else(|| "SequentialGateFn payload is missing its register count".to_string())?,
+        "registers ",
+        "register count",
+    )?
+    .parse()
+    .map_err(|e| format!("invalid SequentialGateFn register count: {}", e))?;
+    let mut registers = Vec::with_capacity(register_count);
+    for _ in 0..register_count {
+        let line = lines.next().ok_or_else(|| {
+            "SequentialGateFn payload has fewer registers than declared".to_string()
+        })?;
+        registers.push(parse_register(line)?);
+    }
+    if let Some(line) = lines.find(|line| !line.is_empty()) {
+        return Err(format!(
+            "unexpected SequentialGateFn metadata after registers: '{}'",
+            line
+        ));
+    }
+    let transition = parse_gate_fn(transition_text)
+        .map_err(|e| format!("failed to parse SequentialGateFn transition: {}", e))?;
+    SequentialGateFn::new(name, transition, inputs, outputs, clock, registers)
+        .map_err(|e| format!("invalid SequentialGateFn payload: {}", e))
+}
+
+fn parse_prefixed_line<'a>(line: &'a str, prefix: &str, field: &str) -> Result<&'a str, String> {
+    line.strip_prefix(prefix).ok_or_else(|| {
+        format!(
+            "invalid SequentialGateFn {} line '{}'; expected prefix '{}'",
+            field, line, prefix
+        )
+    })
+}
+
+fn parse_clock(line: &str) -> Result<Option<ClockPort>, String> {
+    let value = parse_prefixed_line(line, "clock ", "clock")?;
+    if value == "none" {
+        return Ok(None);
+    }
+    if value.is_empty() {
+        return Err("SequentialGateFn clock line is missing its port name".to_string());
+    }
+    if value.split_whitespace().count() != 1 {
+        return Err("SequentialGateFn clock line has trailing fields".to_string());
+    }
+    Ok(Some(ClockPort {
+        name: value.to_string(),
+    }))
+}
+
+fn format_input_ids(ids: &[TransitionInputId]) -> String {
+    format_ids(ids.iter().map(|id| id.index()))
+}
+
+fn format_output_ids(ids: &[TransitionOutputId]) -> String {
+    format_ids(ids.iter().map(|id| id.index()))
+}
+
+fn format_ids(ids: impl Iterator<Item = usize>) -> String {
+    let text = ids
+        .map(|id| id.to_string())
+        .collect::<Vec<String>>()
+        .join(",");
+    if text.is_empty() {
+        "-".to_string()
+    } else {
+        text
+    }
+}
+
+fn parse_input_ids(text: &str) -> Result<Vec<TransitionInputId>, String> {
+    parse_ids(text)
+        .map(|ids| ids.into_iter().map(TransitionInputId::new).collect())
+        .map_err(|e| format!("invalid SequentialGateFn inputs: {}", e))
+}
+
+fn parse_output_ids(text: &str) -> Result<Vec<TransitionOutputId>, String> {
+    parse_ids(text)
+        .map(|ids| ids.into_iter().map(TransitionOutputId::new).collect())
+        .map_err(|e| format!("invalid SequentialGateFn outputs: {}", e))
+}
+
+fn parse_ids(text: &str) -> Result<Vec<usize>, String> {
+    if text == "-" {
+        return Ok(vec![]);
+    }
+    text.split(',')
+        .map(|piece| {
+            piece
+                .parse::<usize>()
+                .map_err(|e| format!("invalid transition index '{}': {}", piece, e))
+        })
+        .collect()
+}
+
+fn parse_register(line: &str) -> Result<RegisterBinding, String> {
+    let mut parts = line.split_whitespace();
+    if parts.next() != Some("register") {
+        return Err(format!(
+            "invalid SequentialGateFn register line '{}'; expected 'register'",
+            line
+        ));
+    }
+    let name = parts
+        .next()
+        .ok_or_else(|| "SequentialGateFn register is missing its name".to_string())?
+        .to_string();
+    let mut fields = BTreeMap::new();
+    for part in parts {
+        let (key, value) = part
+            .split_once('=')
+            .ok_or_else(|| format!("invalid register field '{}'", part))?;
+        if fields.insert(key, value).is_some() {
+            return Err(format!("duplicate register field '{}'", key));
+        }
+    }
+    let q = TransitionInputId::new(parse_required_usize(&mut fields, "q")?);
+    let d = TransitionOutputId::new(parse_required_usize(&mut fields, "d")?);
+    let load_enable =
+        parse_optional_usize(&mut fields, "load_enable")?.map(TransitionOutputId::new);
+    let reset_signal = parse_optional_usize(&mut fields, "reset_signal")?;
+    let reset_asynchronous = parse_optional_bool(&mut fields, "reset_asynchronous")?;
+    let reset_active_low = parse_optional_bool(&mut fields, "reset_active_low")?;
+    let reset_value = parse_optional_bits(&mut fields, "reset_value")?;
+    let reset = match (
+        reset_signal,
+        reset_asynchronous,
+        reset_active_low,
+        reset_value,
+    ) {
+        (None, None, None, None) => None,
+        (Some(signal), Some(asynchronous), Some(active_low), Some(value)) => Some(ResetSpec {
+            signal: TransitionOutputId::new(signal),
+            asynchronous,
+            active_low,
+            value,
+        }),
+        _ => {
+            return Err(format!(
+                "register '{}' must provide all reset fields or none of them",
+                name
+            ));
+        }
+    };
+    let initial_value = parse_optional_bits(&mut fields, "initial_value")?;
+    if let Some(field) = fields.keys().next() {
+        return Err(format!("unknown register field '{}'", field));
+    }
+    Ok(RegisterBinding {
+        name,
+        q,
+        d,
+        load_enable,
+        reset,
+        initial_value,
+    })
+}
+
+fn take_required_field<'a>(
+    fields: &mut BTreeMap<&'a str, &'a str>,
+    name: &str,
+) -> Result<&'a str, String> {
+    fields
+        .remove(name)
+        .ok_or_else(|| format!("register is missing '{}' field", name))
+}
+
+fn parse_required_usize<'a>(
+    fields: &mut BTreeMap<&'a str, &'a str>,
+    name: &str,
+) -> Result<usize, String> {
+    let value = take_required_field(fields, name)?;
+    value
+        .parse()
+        .map_err(|e| format!("invalid register '{}' value '{}': {}", name, value, e))
+}
+
+fn parse_optional_usize<'a>(
+    fields: &mut BTreeMap<&'a str, &'a str>,
+    name: &str,
+) -> Result<Option<usize>, String> {
+    let value = take_required_field(fields, name)?;
+    if value == "none" {
+        Ok(None)
+    } else {
+        value
+            .parse()
+            .map(Some)
+            .map_err(|e| format!("invalid register '{}' value '{}': {}", name, value, e))
+    }
+}
+
+fn parse_optional_bool<'a>(
+    fields: &mut BTreeMap<&'a str, &'a str>,
+    name: &str,
+) -> Result<Option<bool>, String> {
+    match take_required_field(fields, name)? {
+        "none" => Ok(None),
+        "true" => Ok(Some(true)),
+        "false" => Ok(Some(false)),
+        value => Err(format!(
+            "invalid register '{}' bool value '{}'",
+            name, value
+        )),
+    }
+}
+
+fn format_bits(bits: &IrBits) -> String {
+    format!(
+        "bits[{}]:{}",
+        bits.get_bit_count(),
+        bits.to_string_fmt(IrFormatPreference::Hex, false)
+    )
+}
+
+fn parse_optional_bits<'a>(
+    fields: &mut BTreeMap<&'a str, &'a str>,
+    name: &str,
+) -> Result<Option<IrBits>, String> {
+    let value = take_required_field(fields, name)?;
+    if value == "none" {
+        return Ok(None);
+    }
+    let parsed = IrValue::parse_typed(value)
+        .map_err(|e| format!("invalid register '{}' bits value '{}': {}", name, value, e))?;
+    parsed
+        .to_bits()
+        .map(Some)
+        .map_err(|e| format!("register '{}' value is not bits: {}", name, e))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BinarySequentialGateFn {
+    name: String,
+    transition: GateFn,
+    inputs: Vec<usize>,
+    outputs: Vec<usize>,
+    clock: Option<String>,
+    registers: Vec<BinaryRegisterBinding>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BinaryBits {
+    lsb_is_0: Vec<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BinaryResetSpec {
+    signal: usize,
+    asynchronous: bool,
+    active_low: bool,
+    value: BinaryBits,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BinaryRegisterBinding {
+    name: String,
+    q: usize,
+    d: usize,
+    load_enable: Option<usize>,
+    reset: Option<BinaryResetSpec>,
+    initial_value: Option<BinaryBits>,
+}
+
+impl From<&SequentialGateFn> for BinarySequentialGateFn {
+    fn from(value: &SequentialGateFn) -> Self {
+        Self {
+            name: value.name.clone(),
+            transition: value.transition.clone(),
+            inputs: value.inputs.iter().map(|id| id.index()).collect(),
+            outputs: value.outputs.iter().map(|id| id.index()).collect(),
+            clock: value.clock.as_ref().map(|clock| clock.name.clone()),
+            registers: value
+                .registers
+                .iter()
+                .map(BinaryRegisterBinding::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<&RegisterBinding> for BinaryRegisterBinding {
+    fn from(value: &RegisterBinding) -> Self {
+        Self {
+            name: value.name.clone(),
+            q: value.q.index(),
+            d: value.d.index(),
+            load_enable: value.load_enable.map(|id| id.index()),
+            reset: value.reset.as_ref().map(|reset| BinaryResetSpec {
+                signal: reset.signal.index(),
+                asynchronous: reset.asynchronous,
+                active_low: reset.active_low,
+                value: BinaryBits::from(&reset.value),
+            }),
+            initial_value: value.initial_value.as_ref().map(BinaryBits::from),
+        }
+    }
+}
+
+impl From<&IrBits> for BinaryBits {
+    fn from(value: &IrBits) -> Self {
+        Self {
+            lsb_is_0: (0..value.get_bit_count())
+                .map(|index| value.get_bit(index).expect("bit index is in range"))
+                .collect(),
+        }
+    }
+}
+
+impl From<BinaryBits> for IrBits {
+    fn from(value: BinaryBits) -> Self {
+        IrBits::from_lsb_is_0(&value.lsb_is_0)
+    }
+}
+
+impl TryFrom<BinarySequentialGateFn> for SequentialGateFn {
+    type Error = String;
+
+    fn try_from(value: BinarySequentialGateFn) -> Result<Self, Self::Error> {
+        let clock = value.clock.map(|name| ClockPort { name });
+        let registers = value
+            .registers
+            .into_iter()
+            .map(|register| RegisterBinding {
+                name: register.name,
+                q: TransitionInputId::new(register.q),
+                d: TransitionOutputId::new(register.d),
+                load_enable: register.load_enable.map(TransitionOutputId::new),
+                reset: register.reset.map(|reset| ResetSpec {
+                    signal: TransitionOutputId::new(reset.signal),
+                    asynchronous: reset.asynchronous,
+                    active_low: reset.active_low,
+                    value: reset.value.into(),
+                }),
+                initial_value: register.initial_value.map(IrBits::from),
+            })
+            .collect();
+        SequentialGateFn::new(
+            value.name,
+            value.transition,
+            value
+                .inputs
+                .into_iter()
+                .map(TransitionInputId::new)
+                .collect(),
+            value
+                .outputs
+                .into_iter()
+                .map(TransitionOutputId::new)
+                .collect(),
+            clock,
+            registers,
+        )
+        .map_err(|e| format!("invalid SequentialGateFn payload: {}", e))
+    }
+}

--- a/xlsynth-g8r/src/aig_serdes/mod.rs
+++ b/xlsynth-g8r/src/aig_serdes/mod.rs
@@ -5,6 +5,7 @@ mod canonical_aiger_layout;
 pub mod emit_aiger;
 pub mod emit_aiger_binary;
 pub mod emit_netlist;
+pub mod g8r;
 pub mod gate2ir;
 pub mod gate_parser;
 pub mod load_aiger;

--- a/xlsynth-g8r/src/bin/g8r-equivalent.rs
+++ b/xlsynth-g8r/src/bin/g8r-equivalent.rs
@@ -7,14 +7,13 @@
 //!   1 – at least one checker reports non-equivalence or disagreement occurs
 //!   2 – command-line / I/O / parse error
 
-use std::fs;
 use std::path::PathBuf;
 use std::process::exit;
 
-use anyhow::Context;
 use clap::Parser;
 
 use xlsynth_g8r::aig::GateFn;
+use xlsynth_g8r::aig_serdes::g8r::load_gate_fn_from_path;
 use xlsynth_g8r::mcmc_logic::oracle_equiv_sat;
 use xlsynth_g8r::prove_gate_fn_equiv_sat::{self, EquivResult};
 
@@ -29,22 +28,7 @@ struct Cli {
 }
 
 fn load_gfn(p: &PathBuf) -> anyhow::Result<GateFn> {
-    let bytes =
-        fs::read(p).with_context(|| format!("failed to read GateFn file {}", p.display()))?;
-    if p.extension().map(|e| e == "g8rbin").unwrap_or(false) {
-        bincode::deserialize(&bytes).map_err(|e| {
-            anyhow::anyhow!(
-                "failed to bincode-deserialize GateFn from {}: {}",
-                p.display(),
-                e
-            )
-        })
-    } else {
-        let txt = String::from_utf8(bytes)
-            .map_err(|e| anyhow::anyhow!("failed to decode utf8 from {}: {}", p.display(), e))?;
-        GateFn::try_from(txt.as_str())
-            .map_err(|e| anyhow::anyhow!("failed to parse GateFn from {}: {}", p.display(), e))
-    }
+    load_gate_fn_from_path(p).map_err(anyhow::Error::msg)
 }
 
 fn main() {

--- a/xlsynth-g8r/src/bin/mcmc-driver.rs
+++ b/xlsynth-g8r/src/bin/mcmc-driver.rs
@@ -13,8 +13,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tempfile::Builder;
-use xlsynth_g8r::aig::GateFn;
 use xlsynth_g8r::aig::get_summary_stats::SummaryStats;
+use xlsynth_g8r::aig::{GateFn, SequentialGateFn};
+use xlsynth_g8r::aig_serdes::g8r::emit_g8r;
 
 use xlsynth_g8r::aig::fraig::{IterationBounds, fraig_optimize_with_backend};
 use xlsynth_g8r::aig::get_summary_stats;
@@ -579,7 +580,7 @@ fn main() -> Result<()> {
         output_g8r_path.display()
     );
     let mut f_g8r = fs::File::create(&output_g8r_path)?;
-    f_g8r.write_all(best_gfn.to_string().as_bytes())?;
+    f_g8r.write_all(emit_g8r(&SequentialGateFn::from_gate_fn(best_gfn.clone())).as_bytes())?;
     println!(
         "[mcmc] Successfully wrote output to {}",
         output_g8r_path.display()

--- a/xlsynth-g8r/src/block2sequential.rs
+++ b/xlsynth-g8r/src/block2sequential.rs
@@ -1,0 +1,769 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lowering from XLS block IR into a state-preserving sequential gate function.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use xlsynth::IrBits;
+use xlsynth_pir::block_inline::inline_all_blocks_in_package;
+use xlsynth_pir::dce::remove_dead_nodes;
+use xlsynth_pir::ir::{self, BlockMetadata, MemberType, NodePayload, NodeRef, PackageMember, Type};
+use xlsynth_pir::ir_parser::Parser;
+use xlsynth_pir::ir_utils::{get_topological, operands, remap_payload_with};
+use xlsynth_pir::ir_validate;
+use xlsynth_pir::ir_value_utils::flatten_ir_value_to_lsb0_bits_for_type;
+
+use crate::aig::{
+    ClockPort, GateFn, Output, RegisterBinding, ResetSpec, SequentialGateFn, TransitionInputId,
+    TransitionOutputId,
+};
+use crate::gatify::ir2gate::{GatifyOptions, gatify};
+
+#[derive(Debug, Clone)]
+struct TransitionEndpoint {
+    name: String,
+    node_ref: NodeRef,
+    ty: Type,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RegisterWriteRefs {
+    arg: NodeRef,
+    load_enable: Option<NodeRef>,
+    reset: Option<NodeRef>,
+}
+
+#[derive(Debug)]
+struct PendingRegisterBinding {
+    name: String,
+    q: TransitionInputId,
+    d_output_index: usize,
+    load_enable_output_index: Option<usize>,
+    reset: Option<PendingResetSpec>,
+}
+
+#[derive(Debug)]
+struct PendingResetSpec {
+    signal_output_index: usize,
+    asynchronous: bool,
+    active_low: bool,
+    value: IrBits,
+}
+
+/// Parses an XLS IR package and lowers its selected block into a sequential
+/// gate function.
+pub fn block_ir_to_sequential_gate_fn(
+    block_ir_text: &str,
+    gatify_options: GatifyOptions,
+) -> Result<SequentialGateFn, String> {
+    let mut parser = Parser::new(block_ir_text);
+    let package = parser
+        .parse_and_validate_package()
+        .map_err(|e| format!("parse block IR: {e}"))?;
+    block_package_to_sequential_gate_fn(&package, gatify_options)
+}
+
+/// Lowers the selected block in a PIR package, inlining block instantiations
+/// first.
+pub fn block_package_to_sequential_gate_fn(
+    package: &ir::Package,
+    gatify_options: GatifyOptions,
+) -> Result<SequentialGateFn, String> {
+    ir_validate::validate_package(package)
+        .map_err(|e| format!("block2sequential: input package validation failed: {e}"))?;
+
+    let top_name = selected_block_name(package)?;
+    validate_hierarchical_sequential_metadata(package, &top_name)?;
+    let mut inlined_package = package.clone();
+    inlined_package.top = Some((top_name, MemberType::Block));
+    inline_all_blocks_in_package(&mut inlined_package)
+        .map_err(|e| format!("block2sequential: block inlining failed: {e}"))?;
+    ir_validate::validate_package(&inlined_package)
+        .map_err(|e| format!("block2sequential: inlined package validation failed: {e}"))?;
+
+    let PackageMember::Block { func, metadata } = inlined_package
+        .get_top_block()
+        .ok_or_else(|| "block2sequential: package has no selected block".to_string())?
+    else {
+        return Err("block2sequential: selected member is not a block".to_string());
+    };
+    lower_block_to_sequential_gate_fn(func, metadata, gatify_options)
+}
+
+/// Lowers an already flattened/inlined block into a sequential gate function.
+pub fn lower_block_to_sequential_gate_fn(
+    block: &ir::Fn,
+    metadata: &BlockMetadata,
+    gatify_options: GatifyOptions,
+) -> Result<SequentialGateFn, String> {
+    if !metadata.instantiations.is_empty() {
+        return Err(
+            "block2sequential: block contains instantiations; lower a package so they can be inlined"
+                .to_string(),
+        );
+    }
+
+    let validation_package = ir::Package {
+        name: "block2sequential_validate".to_string(),
+        file_table: ir::FileTable::new(),
+        members: vec![PackageMember::Block {
+            func: block.clone(),
+            metadata: metadata.clone(),
+        }],
+        top: Some((block.name.clone(), MemberType::Block)),
+    };
+    ir_validate::validate_package(&validation_package)
+        .map_err(|e| format!("block2sequential: block validation failed: {e}"))?;
+
+    let (transition_fn, endpoints, pending_registers, external_input_count, clock) =
+        build_transition_function(block, metadata)?;
+    let mut transition = gatify(&transition_fn, gatify_options)
+        .map_err(|e| format!("block2sequential: gatify transition function failed: {e}"))?
+        .gate_fn;
+    split_transition_outputs(&mut transition, &endpoints)?;
+
+    let registers = pending_registers
+        .into_iter()
+        .map(|register| RegisterBinding {
+            name: register.name,
+            q: register.q,
+            d: TransitionOutputId::new(register.d_output_index),
+            load_enable: register
+                .load_enable_output_index
+                .map(TransitionOutputId::new),
+            reset: register.reset.map(|reset| ResetSpec {
+                signal: TransitionOutputId::new(reset.signal_output_index),
+                asynchronous: reset.asynchronous,
+                active_low: reset.active_low,
+                value: reset.value,
+            }),
+            initial_value: None,
+        })
+        .collect();
+
+    SequentialGateFn::new(
+        block.name.clone(),
+        transition,
+        (0..external_input_count)
+            .map(TransitionInputId::new)
+            .collect(),
+        (0..metadata.output_names.len())
+            .map(TransitionOutputId::new)
+            .collect(),
+        clock,
+        registers,
+    )
+    .map_err(|e| format!("block2sequential: invalid lowered sequential function: {e}"))
+}
+
+fn selected_block_name(package: &ir::Package) -> Result<String, String> {
+    match &package.top {
+        Some((name, MemberType::Block)) => Ok(name.clone()),
+        Some((name, MemberType::Function)) => Err(format!(
+            "block2sequential: package top '{}' is a function, not a block",
+            name
+        )),
+        None => {
+            let block_names: Vec<String> = package
+                .members
+                .iter()
+                .filter_map(|member| match member {
+                    PackageMember::Block { func, .. } => Some(func.name.clone()),
+                    PackageMember::Function(_) => None,
+                })
+                .collect();
+            match block_names.as_slice() {
+                [] => Err("block2sequential: package has no blocks".to_string()),
+                [name] => Ok(name.clone()),
+                _ => Err(
+                    "block2sequential: package has multiple blocks and no top block selection"
+                        .to_string(),
+                ),
+            }
+        }
+    }
+}
+
+/// Rejects explicit child sequential behavior that would be lost during block
+/// inlining.
+fn validate_hierarchical_sequential_metadata(
+    package: &ir::Package,
+    top_name: &str,
+) -> Result<(), String> {
+    let (_, top_metadata) = get_block(package, top_name)?;
+    let mut has_registers_memo = BTreeMap::new();
+    let mut has_reset_writes_memo = BTreeMap::new();
+    validate_instantiated_sequential_metadata(
+        package,
+        top_name,
+        top_name,
+        top_metadata,
+        &mut has_registers_memo,
+        &mut has_reset_writes_memo,
+    )
+}
+
+fn validate_instantiated_sequential_metadata(
+    package: &ir::Package,
+    block_name: &str,
+    path: &str,
+    top_metadata: &BlockMetadata,
+    has_registers_memo: &mut BTreeMap<String, bool>,
+    has_reset_writes_memo: &mut BTreeMap<String, bool>,
+) -> Result<(), String> {
+    let (_, metadata) = get_block(package, block_name)?;
+    for instantiation in &metadata.instantiations {
+        let (_, child_metadata) = get_block(package, &instantiation.block)?;
+        let child_path = format!("{path}.{}", instantiation.name);
+
+        if subtree_has_registers(package, &instantiation.block, has_registers_memo)? {
+            if let Some(child_clock) = child_metadata.clock_port_name.as_deref() {
+                match top_metadata.clock_port_name.as_deref() {
+                    Some(top_clock) if child_clock == top_clock => {}
+                    Some(top_clock) => {
+                        return Err(format!(
+                            "block2sequential: registered instantiated block '{}' at '{}' declares clock '{}' incompatible with top clock '{}'",
+                            instantiation.block, child_path, child_clock, top_clock
+                        ));
+                    }
+                    None => {
+                        return Err(format!(
+                            "block2sequential: registered instantiated block '{}' at '{}' declares clock '{}' but the top block has no clock",
+                            instantiation.block, child_path, child_clock
+                        ));
+                    }
+                }
+            }
+        }
+
+        if subtree_has_reset_writes(package, &instantiation.block, has_reset_writes_memo)? {
+            if let Some(child_reset) = child_metadata.reset.as_ref() {
+                match top_metadata.reset.as_ref() {
+                    Some(top_reset)
+                        if child_reset.asynchronous == top_reset.asynchronous
+                            && child_reset.active_low == top_reset.active_low => {}
+                    Some(top_reset) => {
+                        return Err(format!(
+                            "block2sequential: reset-bearing instantiated block '{}' at '{}' declares reset behavior (asynchronous={}, active_low={}) incompatible with top reset behavior (asynchronous={}, active_low={})",
+                            instantiation.block,
+                            child_path,
+                            child_reset.asynchronous,
+                            child_reset.active_low,
+                            top_reset.asynchronous,
+                            top_reset.active_low
+                        ));
+                    }
+                    None => {
+                        return Err(format!(
+                            "block2sequential: reset-bearing instantiated block '{}' at '{}' declares reset behavior but the top block has no reset metadata",
+                            instantiation.block, child_path
+                        ));
+                    }
+                }
+            }
+        }
+
+        validate_instantiated_sequential_metadata(
+            package,
+            &instantiation.block,
+            &child_path,
+            top_metadata,
+            has_registers_memo,
+            has_reset_writes_memo,
+        )?;
+    }
+    Ok(())
+}
+
+fn subtree_has_registers(
+    package: &ir::Package,
+    block_name: &str,
+    memo: &mut BTreeMap<String, bool>,
+) -> Result<bool, String> {
+    if let Some(has_registers) = memo.get(block_name) {
+        return Ok(*has_registers);
+    }
+    let (_, metadata) = get_block(package, block_name)?;
+    let mut has_registers = !metadata.registers.is_empty();
+    for instantiation in &metadata.instantiations {
+        has_registers |= subtree_has_registers(package, &instantiation.block, memo)?;
+    }
+    memo.insert(block_name.to_string(), has_registers);
+    Ok(has_registers)
+}
+
+fn subtree_has_reset_writes(
+    package: &ir::Package,
+    block_name: &str,
+    memo: &mut BTreeMap<String, bool>,
+) -> Result<bool, String> {
+    if let Some(has_reset_writes) = memo.get(block_name) {
+        return Ok(*has_reset_writes);
+    }
+    let (block, metadata) = get_block(package, block_name)?;
+    let mut has_reset_writes = block.nodes.iter().any(|node| {
+        matches!(
+            &node.payload,
+            NodePayload::RegisterWrite { reset: Some(_), .. }
+        )
+    });
+    for instantiation in &metadata.instantiations {
+        has_reset_writes |= subtree_has_reset_writes(package, &instantiation.block, memo)?;
+    }
+    memo.insert(block_name.to_string(), has_reset_writes);
+    Ok(has_reset_writes)
+}
+
+fn get_block<'a>(
+    package: &'a ir::Package,
+    block_name: &str,
+) -> Result<(&'a ir::Fn, &'a BlockMetadata), String> {
+    match package.get_block(block_name) {
+        Some(PackageMember::Block { func, metadata }) => Ok((func, metadata)),
+        _ => Err(format!(
+            "block2sequential: referenced block '{}' is unavailable",
+            block_name
+        )),
+    }
+}
+
+fn build_transition_function(
+    block: &ir::Fn,
+    metadata: &BlockMetadata,
+) -> Result<
+    (
+        ir::Fn,
+        Vec<TransitionEndpoint>,
+        Vec<PendingRegisterBinding>,
+        usize,
+        Option<ClockPort>,
+    ),
+    String,
+> {
+    block
+        .check_pir_layout_invariants()
+        .map_err(|e| format!("block2sequential: invalid block layout: {e}"))?;
+
+    let original_outputs = collect_block_outputs(block, metadata)?;
+    let register_writes = collect_register_writes(block)?;
+    let external_input_count = block.params.len();
+    let mut used_param_names: BTreeSet<String> = block
+        .params
+        .iter()
+        .map(|param| param.name.clone())
+        .collect();
+    let mut used_output_names: BTreeSet<String> = BTreeSet::new();
+    let mut max_text_id = block
+        .nodes
+        .iter()
+        .map(|node| node.text_id)
+        .max()
+        .unwrap_or(0);
+
+    let mut transition = ir::Fn {
+        name: format!("{}__transition", block.name),
+        params: block.params.clone(),
+        ret_ty: Type::nil(),
+        nodes: vec![block.nodes[0].clone()],
+        ret_node_ref: None,
+        outer_attrs: vec![],
+        inner_attrs: vec![],
+    };
+    let mut old_to_new: Vec<Option<NodeRef>> = vec![None; block.nodes.len()];
+    old_to_new[0] = Some(NodeRef { index: 0 });
+    for (index, param) in block.params.iter().enumerate() {
+        let old_ref = NodeRef { index: index + 1 };
+        let new_ref = NodeRef {
+            index: transition.nodes.len(),
+        };
+        transition.nodes.push(block.nodes[old_ref.index].clone());
+        old_to_new[old_ref.index] = Some(new_ref);
+        debug_assert_eq!(
+            transition.nodes[new_ref.index].payload,
+            NodePayload::GetParam(param.id)
+        );
+    }
+
+    let mut register_q_refs: BTreeMap<String, (NodeRef, TransitionInputId)> = BTreeMap::new();
+    for register in &metadata.registers {
+        max_text_id += 1;
+        let q_name = unique_name(&format!("{}__q", register.name), &mut used_param_names);
+        let param_id = ir::ParamId::new(max_text_id);
+        let q_ref = NodeRef {
+            index: transition.nodes.len(),
+        };
+        transition.params.push(ir::Param {
+            name: q_name.clone(),
+            ty: register.ty.clone(),
+            id: param_id,
+        });
+        transition.nodes.push(ir::Node {
+            text_id: max_text_id,
+            name: Some(q_name),
+            ty: register.ty.clone(),
+            payload: NodePayload::GetParam(param_id),
+            pos: None,
+        });
+        register_q_refs.insert(
+            register.name.clone(),
+            (q_ref, TransitionInputId::new(transition.params.len() - 1)),
+        );
+    }
+
+    for old_ref in get_topological(block) {
+        if old_ref.index == 0 || (1..=block.params.len()).contains(&old_ref.index) {
+            continue;
+        }
+        let node = block.get_node(old_ref);
+        match &node.payload {
+            NodePayload::RegisterRead { register } => {
+                let (q_ref, _) = register_q_refs.get(register).ok_or_else(|| {
+                    format!(
+                        "block2sequential: register_read references unknown register '{}'",
+                        register
+                    )
+                })?;
+                old_to_new[old_ref.index] = Some(*q_ref);
+            }
+            NodePayload::RegisterWrite { .. } => {
+                // Register writes become named transition outputs below.
+            }
+            NodePayload::InstantiationInput { .. } | NodePayload::InstantiationOutput { .. } => {
+                return Err(
+                    "block2sequential: instantiation nodes remain after block inlining".to_string(),
+                );
+            }
+            NodePayload::Nil => {
+                // Dead nodes have no transition-function meaning.
+            }
+            _ => {
+                for dependency in operands(&node.payload) {
+                    if old_to_new[dependency.index].is_none() {
+                        return Err(format!(
+                            "block2sequential: node {} depends on an unsupported sequential side-effect node",
+                            node.text_id
+                        ));
+                    }
+                }
+                let payload = remap_payload_with(&node.payload, |(_, dependency)| {
+                    old_to_new[dependency.index]
+                        .expect("dependencies were checked before payload remapping")
+                });
+                let new_ref = NodeRef {
+                    index: transition.nodes.len(),
+                };
+                transition.nodes.push(ir::Node {
+                    payload,
+                    ..node.clone()
+                });
+                old_to_new[old_ref.index] = Some(new_ref);
+            }
+        }
+    }
+
+    let mut endpoints: Vec<TransitionEndpoint> = Vec::new();
+    for output in original_outputs {
+        let mapped_ref = old_to_new[output.node_ref.index].ok_or_else(|| {
+            format!(
+                "block2sequential: external output '{}' refers to an unsupported node",
+                output.name
+            )
+        })?;
+        if !used_output_names.insert(output.name.clone()) {
+            return Err(format!(
+                "block2sequential: duplicate external output name '{}'",
+                output.name
+            ));
+        }
+        endpoints.push(TransitionEndpoint {
+            node_ref: mapped_ref,
+            ..output
+        });
+    }
+
+    let reset_metadata = metadata.reset.as_ref();
+    let mut pending_registers = Vec::with_capacity(metadata.registers.len());
+    for register in &metadata.registers {
+        let (q_ref, q_input) = *register_q_refs
+            .get(&register.name)
+            .expect("Q parameter was created for each register");
+        let write = register_writes.get(&register.name).copied();
+        let d_ref = match write {
+            Some(write) => remapped_ref(
+                &old_to_new,
+                write.arg,
+                &format!("register '{}' D", register.name),
+            )?,
+            None => q_ref,
+        };
+        let d_output_index = push_endpoint(
+            &mut endpoints,
+            &mut used_output_names,
+            format!("{}__d", register.name),
+            d_ref,
+            register.ty.clone(),
+        );
+
+        let load_enable_output_index = match write.and_then(|write| write.load_enable) {
+            Some(load_enable) => {
+                let load_enable_ref = remapped_ref(
+                    &old_to_new,
+                    load_enable,
+                    &format!("register '{}' load enable", register.name),
+                )?;
+                Some(push_endpoint(
+                    &mut endpoints,
+                    &mut used_output_names,
+                    format!("{}__load_enable", register.name),
+                    load_enable_ref,
+                    Type::Bits(1),
+                ))
+            }
+            None => None,
+        };
+
+        let reset = match (
+            write.and_then(|write| write.reset),
+            register.reset_value.as_ref(),
+        ) {
+            (Some(reset_ref), Some(reset_value)) => {
+                let reset_metadata = reset_metadata.ok_or_else(|| {
+                    format!(
+                        "block2sequential: register '{}' has a reset write but the block has no reset metadata",
+                        register.name
+                    )
+                })?;
+                let reset_ref = remapped_ref(
+                    &old_to_new,
+                    reset_ref,
+                    &format!("register '{}' reset", register.name),
+                )?;
+                let signal_output_index = push_endpoint(
+                    &mut endpoints,
+                    &mut used_output_names,
+                    format!("{}__reset", register.name),
+                    reset_ref,
+                    Type::Bits(1),
+                );
+                Some(PendingResetSpec {
+                    signal_output_index,
+                    asynchronous: reset_metadata.asynchronous,
+                    active_low: reset_metadata.active_low,
+                    value: flatten_value(reset_value, &register.ty)?,
+                })
+            }
+            (Some(_), None) => {
+                return Err(format!(
+                    "block2sequential: register '{}' has a reset write but no reset value",
+                    register.name
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(format!(
+                    "block2sequential: register '{}' has a reset value but no reset write",
+                    register.name
+                ));
+            }
+            (None, None) => None,
+        };
+
+        pending_registers.push(PendingRegisterBinding {
+            name: register.name.clone(),
+            q: q_input,
+            d_output_index,
+            load_enable_output_index,
+            reset,
+        });
+    }
+
+    set_transition_return(&mut transition, &endpoints, &mut max_text_id);
+    let transition = remove_dead_nodes(&transition);
+    let clock = metadata
+        .clock_port_name
+        .as_ref()
+        .map(|name| ClockPort { name: name.clone() });
+    Ok((
+        transition,
+        endpoints,
+        pending_registers,
+        external_input_count,
+        clock,
+    ))
+}
+
+fn collect_block_outputs(
+    block: &ir::Fn,
+    metadata: &BlockMetadata,
+) -> Result<Vec<TransitionEndpoint>, String> {
+    let ret_ref = block
+        .ret_node_ref
+        .ok_or_else(|| "block2sequential: block has no return node".to_string())?;
+    if metadata.output_names.len() == 1 {
+        return Ok(vec![TransitionEndpoint {
+            name: metadata.output_names[0].clone(),
+            node_ref: ret_ref,
+            ty: block.ret_ty.clone(),
+        }]);
+    }
+    let NodePayload::Tuple(elements) = &block.get_node(ret_ref).payload else {
+        return Err(
+            "block2sequential: multiple block outputs require a tuple return node".to_string(),
+        );
+    };
+    let Type::Tuple(types) = &block.ret_ty else {
+        return Err("block2sequential: multiple block outputs require a tuple type".to_string());
+    };
+    if elements.len() != metadata.output_names.len() || types.len() != elements.len() {
+        return Err("block2sequential: block output arity mismatch".to_string());
+    }
+    Ok(metadata
+        .output_names
+        .iter()
+        .zip(elements)
+        .zip(types)
+        .map(|((name, node_ref), ty)| TransitionEndpoint {
+            name: name.clone(),
+            node_ref: *node_ref,
+            ty: (**ty).clone(),
+        })
+        .collect())
+}
+
+fn collect_register_writes(block: &ir::Fn) -> Result<BTreeMap<String, RegisterWriteRefs>, String> {
+    let mut writes = BTreeMap::new();
+    for node in &block.nodes {
+        if let NodePayload::RegisterWrite {
+            arg,
+            register,
+            load_enable,
+            reset,
+        } = &node.payload
+        {
+            let write = RegisterWriteRefs {
+                arg: *arg,
+                load_enable: *load_enable,
+                reset: *reset,
+            };
+            if writes.insert(register.clone(), write).is_some() {
+                return Err(format!(
+                    "block2sequential: multiple register writes for '{}'",
+                    register
+                ));
+            }
+        }
+    }
+    Ok(writes)
+}
+
+fn remapped_ref(
+    old_to_new: &[Option<NodeRef>],
+    old_ref: NodeRef,
+    context: &str,
+) -> Result<NodeRef, String> {
+    old_to_new[old_ref.index]
+        .ok_or_else(|| format!("block2sequential: {context} refers to an unsupported node"))
+}
+
+fn unique_name(base: &str, used: &mut BTreeSet<String>) -> String {
+    if used.insert(base.to_string()) {
+        return base.to_string();
+    }
+    for suffix in 1usize.. {
+        let candidate = format!("{base}__{suffix}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
+    unreachable!("unbounded suffix sequence must provide a unique name")
+}
+
+fn push_endpoint(
+    endpoints: &mut Vec<TransitionEndpoint>,
+    used_names: &mut BTreeSet<String>,
+    preferred_name: String,
+    node_ref: NodeRef,
+    ty: Type,
+) -> usize {
+    let name = unique_name(&preferred_name, used_names);
+    let index = endpoints.len();
+    endpoints.push(TransitionEndpoint { name, node_ref, ty });
+    index
+}
+
+fn flatten_value(value: &xlsynth::IrValue, ty: &Type) -> Result<IrBits, String> {
+    let mut flat_bits = Vec::with_capacity(ty.bit_count());
+    flatten_ir_value_to_lsb0_bits_for_type(value, ty, &mut flat_bits)
+        .map_err(|e| format!("block2sequential: flatten reset value failed: {e}"))?;
+    Ok(IrBits::from_lsb_is_0(&flat_bits))
+}
+
+fn set_transition_return(
+    transition: &mut ir::Fn,
+    endpoints: &[TransitionEndpoint],
+    max_text_id: &mut usize,
+) {
+    assert!(
+        !endpoints.is_empty(),
+        "parsed blocks must have at least one output endpoint"
+    );
+    if endpoints.len() == 1 {
+        transition.ret_ty = endpoints[0].ty.clone();
+        transition.ret_node_ref = Some(endpoints[0].node_ref);
+        return;
+    }
+
+    *max_text_id += 1;
+    let ret_ty = Type::Tuple(
+        endpoints
+            .iter()
+            .map(|endpoint| Box::new(endpoint.ty.clone()))
+            .collect(),
+    );
+    let ret_ref = NodeRef {
+        index: transition.nodes.len(),
+    };
+    transition.nodes.push(ir::Node {
+        text_id: *max_text_id,
+        name: Some("transition_outputs".to_string()),
+        ty: ret_ty.clone(),
+        payload: NodePayload::Tuple(endpoints.iter().map(|endpoint| endpoint.node_ref).collect()),
+        pos: None,
+    });
+    transition.ret_ty = ret_ty;
+    transition.ret_node_ref = Some(ret_ref);
+}
+
+fn split_transition_outputs(
+    transition: &mut GateFn,
+    endpoints: &[TransitionEndpoint],
+) -> Result<(), String> {
+    if transition.outputs.len() != 1 {
+        return Err(format!(
+            "block2sequential: gatify produced {} transition outputs, expected one flat output",
+            transition.outputs.len()
+        ));
+    }
+    let flat_output = transition.outputs.remove(0).bit_vector;
+    let expected_width: usize = endpoints
+        .iter()
+        .map(|endpoint| endpoint.ty.bit_count())
+        .sum();
+    if flat_output.get_bit_count() != expected_width {
+        return Err(format!(
+            "block2sequential: gatify transition output has width {}, expected {}",
+            flat_output.get_bit_count(),
+            expected_width
+        ));
+    }
+
+    let mut lsb_start = expected_width;
+    for endpoint in endpoints {
+        let width = endpoint.ty.bit_count();
+        lsb_start -= width;
+        transition.outputs.push(Output {
+            name: endpoint.name.clone(),
+            bit_vector: flat_output.get_lsb_slice(lsb_start, width),
+        });
+    }
+    Ok(())
+}

--- a/xlsynth-g8r/src/lib.rs
+++ b/xlsynth-g8r/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod aig;
 pub mod aig_serdes;
 pub mod aig_sim;
+pub mod block2sequential;
 pub mod gatify;
 pub mod ir_aig_sharing;
 

--- a/xlsynth-g8r/src/mcmc_logic.rs
+++ b/xlsynth-g8r/src/mcmc_logic.rs
@@ -19,8 +19,10 @@ use xlsynth_mcmc::McmcStats as SharedMcmcStats;
 use xlsynth_mcmc::metropolis_accept;
 
 // Imports from the xlsynth_g8r crate
+use crate::aig::SequentialGateFn;
 use crate::aig::gate::GateFn;
 use crate::aig::{dce, get_summary_stats};
+use crate::aig_serdes::g8r::{emit_g8r, encode_g8r_binary, load_gate_fn_from_path};
 use crate::aig_sim::gate_simd::{self, Vec256};
 use crate::gatify::ir2gate::{self, GatifyOptions};
 use crate::prove_gate_fn_equiv_common::{EquivResult, GateFormalBackend};
@@ -34,7 +36,7 @@ use crate::transforms::transform_trait::{TransformDirection, TransformKind};
 use clap::ValueEnum;
 use core::simd::u64x4;
 use serde_json;
-use std::fs::{self, OpenOptions};
+use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::sync::mpsc;
 use std::thread;
@@ -762,12 +764,7 @@ pub fn load_start<P: AsRef<Path>>(p_generic: P) -> Result<GateFn> {
         match path.extension().and_then(|e| e.to_str()) {
             Some("g8r") => {
                 println!("Loading GateFn from path: {}", p_str);
-                let contents = fs::read_to_string(path).map_err(|e| {
-                    anyhow::anyhow!("Failed to read GateFn file '{}': {}", p_str, e)
-                })?;
-                let gfn = GateFn::try_from(contents.as_str()).map_err(|e| {
-                    anyhow::anyhow!("Failed to parse GateFn from '{}': {}", p_str, e)
-                })?;
+                let gfn = load_gate_fn_from_path(path).map_err(anyhow::Error::msg)?;
                 let g_cost = cost(&gfn);
                 println!(
                     "Loaded GateFn. Initial stats: nodes={}, depth={}",
@@ -853,10 +850,18 @@ fn write_checkpoint(
             let cand_dump = dump_dir.join(format!("cand_iter_{}.g8r", iter));
             let orig_bin_dump = dump_dir.join(format!("orig_iter_{}.g8rbin", iter));
             let cand_bin_dump = dump_dir.join(format!("cand_iter_{}.g8rbin", iter));
-            let _ = std::fs::write(&orig_dump, original_gfn.to_string());
-            let _ = std::fs::write(&cand_dump, best_gfn.to_string());
-            let _ = std::fs::write(&orig_bin_dump, bincode::serialize(original_gfn).unwrap());
-            let _ = std::fs::write(&cand_bin_dump, bincode::serialize(best_gfn).unwrap());
+            let original_design = SequentialGateFn::from_gate_fn(original_gfn.clone());
+            let candidate_design = SequentialGateFn::from_gate_fn(best_gfn.clone());
+            let _ = std::fs::write(&orig_dump, emit_g8r(&original_design));
+            let _ = std::fs::write(&cand_dump, emit_g8r(&candidate_design));
+            let _ = std::fs::write(
+                &orig_bin_dump,
+                encode_g8r_binary(&original_design).expect("serializing GateFn should succeed"),
+            );
+            let _ = std::fs::write(
+                &cand_bin_dump,
+                encode_g8r_binary(&candidate_design).expect("serializing GateFn should succeed"),
+            );
             eprintln!(
                 "[mcmc] Disagreeing GateFns dumped to {} and {} (text), {} and {} (bincode)",
                 orig_dump.display(),
@@ -889,7 +894,8 @@ fn write_checkpoint(
         }
         IrCheckResult::NotEquivalent => {}
     }
-    if let Err(e) = std::fs::write(g8r_path, best_gfn.to_string()) {
+    let best_design = SequentialGateFn::from_gate_fn(best_gfn.clone());
+    if let Err(e) = std::fs::write(g8r_path, emit_g8r(&best_design)) {
         eprintln!(
             "[mcmc] Warning: Failed to write {} checkpoint to {}: {:?}",
             context,

--- a/xlsynth-g8r/tests/block2sequential_test.rs
+++ b/xlsynth-g8r/tests/block2sequential_test.rs
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use xlsynth::IrBits;
+use xlsynth_g8r::aig_sim::gate_sim::{self, Collect};
+use xlsynth_g8r::block2sequential::block_ir_to_sequential_gate_fn;
+use xlsynth_g8r::gatify::ir2gate::GatifyOptions;
+
+fn lower(block_ir: &str) -> xlsynth_g8r::aig::SequentialGateFn {
+    block_ir_to_sequential_gate_fn(block_ir, GatifyOptions::all_opts_disabled())
+        .expect("block lowering should succeed")
+}
+
+#[test]
+fn lowers_combinational_block_without_registers_or_clock() {
+    let block_ir = r#"package combinational
+
+top block top(a: bits[1], b: bits[1], y: bits[1], z: bits[1]) {
+  a: bits[1] = input_port(name=a, id=1)
+  b: bits[1] = input_port(name=b, id=2)
+  and.3: bits[1] = and(a, b, id=3)
+  not.4: bits[1] = not(and.3, id=4)
+  y: () = output_port(and.3, name=y, id=5)
+  z: () = output_port(not.4, name=z, id=6)
+}
+"#;
+
+    let sequential = lower(block_ir);
+
+    assert!(sequential.registers.is_empty());
+    assert!(sequential.clock.is_none());
+    assert_eq!(
+        sequential
+            .transition
+            .inputs
+            .iter()
+            .map(|input| input.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "b"]
+    );
+    assert_eq!(
+        sequential
+            .transition
+            .outputs
+            .iter()
+            .map(|output| output.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["y", "z"]
+    );
+
+    let result = gate_sim::eval(
+        &sequential.transition,
+        &[IrBits::bool(true), IrBits::bool(true)],
+        Collect::None,
+    );
+    assert_eq!(
+        result.outputs,
+        vec![IrBits::bool(true), IrBits::bool(false)]
+    );
+}
+
+#[test]
+fn lowers_register_data_enable_and_reset_to_transition_boundaries() {
+    let block_ir = r#"package pipeline
+
+top block pipe(clk: clock, rst: bits[1], data: bits[8], le: bits[1], out: bits[8]) {
+  #![reset(port="rst", asynchronous=false, active_low=true)]
+  reg state(bits[8], reset_value=3)
+  rst: bits[1] = input_port(name=rst, id=1)
+  data: bits[8] = input_port(name=data, id=2)
+  le: bits[1] = input_port(name=le, id=3)
+  state_q: bits[8] = register_read(register=state, id=4)
+  add.5: bits[8] = add(state_q, data, id=5)
+  state_d: () = register_write(add.5, register=state, load_enable=le, reset=rst, id=6)
+  out: () = output_port(state_q, name=out, id=7)
+}
+"#;
+
+    let sequential = lower(block_ir);
+
+    let clock = sequential.clock.as_ref().expect("clock");
+    assert_eq!(clock.name, "clk");
+    assert_eq!(
+        sequential
+            .transition
+            .inputs
+            .iter()
+            .map(|input| input.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["rst", "data", "le", "state__q"]
+    );
+    assert_eq!(
+        sequential
+            .transition
+            .outputs
+            .iter()
+            .map(|output| output.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["out", "state__d", "state__load_enable", "state__reset"]
+    );
+
+    let register = &sequential.registers[0];
+    assert_eq!(register.name, "state");
+    assert_eq!(register.q.index(), 3);
+    assert_eq!(register.d.index(), 1);
+    assert_eq!(register.load_enable.expect("load enable").index(), 2);
+    let reset = register.reset.as_ref().expect("reset");
+    assert_eq!(reset.signal.index(), 3);
+    assert!(!reset.asynchronous);
+    assert!(reset.active_low);
+    assert_eq!(reset.value, IrBits::make_ubits(8, 3).unwrap());
+
+    let result = gate_sim::eval(
+        &sequential.transition,
+        &[
+            IrBits::bool(false),
+            IrBits::make_ubits(8, 2).unwrap(),
+            IrBits::bool(true),
+            IrBits::make_ubits(8, 5).unwrap(),
+        ],
+        Collect::None,
+    );
+    assert_eq!(
+        result.outputs,
+        vec![
+            IrBits::make_ubits(8, 5).unwrap(),
+            IrBits::make_ubits(8, 7).unwrap(),
+            IrBits::bool(true),
+            IrBits::bool(false),
+        ]
+    );
+}
+
+#[test]
+fn lowers_registers_after_inlining_block_instantiations() {
+    let block_ir = r#"package hierarchical
+
+block stage(data: bits[1], out: bits[1]) {
+  reg state(bits[1])
+  data: bits[1] = input_port(name=data, id=1)
+  state_q: bits[1] = register_read(register=state, id=2)
+  state_d: () = register_write(data, register=state, id=3)
+  out: () = output_port(state_q, name=out, id=4)
+}
+
+top block top(clk: clock, data: bits[1], out: bits[1]) {
+  instantiation s0(block=stage, kind=block)
+  data: bits[1] = input_port(name=data, id=11)
+  s0_out: bits[1] = instantiation_output(instantiation=s0, port_name=out, id=12)
+  s0_in: () = instantiation_input(data, instantiation=s0, port_name=data, id=13)
+  out: () = output_port(s0_out, name=out, id=14)
+}
+"#;
+
+    let sequential = lower(block_ir);
+
+    assert_eq!(sequential.registers.len(), 1);
+    assert_eq!(sequential.registers[0].name, "s0__state");
+    assert_eq!(sequential.clock.as_ref().expect("clock").name, "clk");
+    assert_eq!(
+        sequential.transition.outputs[1].name,
+        "s0__state__d".to_string()
+    );
+}
+
+#[test]
+fn lowers_inlined_register_reset_with_compatible_explicit_metadata() {
+    let block_ir = r#"package hierarchical_reset
+
+block stage(clk: clock, local_rst: bits[1], data: bits[1], out: bits[1]) {
+  #![reset(port="local_rst", asynchronous=false, active_low=true)]
+  reg state(bits[1], reset_value=0)
+  local_rst: bits[1] = input_port(name=local_rst, id=1)
+  data: bits[1] = input_port(name=data, id=2)
+  state_q: bits[1] = register_read(register=state, id=3)
+  state_d: () = register_write(data, register=state, reset=local_rst, id=4)
+  out: () = output_port(state_q, name=out, id=5)
+}
+
+top block top(clk: clock, rst: bits[1], data: bits[1], out: bits[1]) {
+  #![reset(port="rst", asynchronous=false, active_low=true)]
+  instantiation s0(block=stage, kind=block)
+  rst: bits[1] = input_port(name=rst, id=11)
+  data: bits[1] = input_port(name=data, id=12)
+  s0_out: bits[1] = instantiation_output(instantiation=s0, port_name=out, id=13)
+  s0_rst: () = instantiation_input(rst, instantiation=s0, port_name=local_rst, id=14)
+  s0_data: () = instantiation_input(data, instantiation=s0, port_name=data, id=15)
+  out: () = output_port(s0_out, name=out, id=16)
+}
+"#;
+
+    let sequential = lower(block_ir);
+
+    let reset = sequential.registers[0].reset.as_ref().expect("reset");
+    assert!(!reset.asynchronous);
+    assert!(reset.active_low);
+}
+
+#[test]
+fn rejects_inlined_registered_block_with_incompatible_explicit_clock() {
+    let block_ir = r#"package hierarchical_clock
+
+block stage(child_clk: clock, data: bits[1], out: bits[1]) {
+  reg state(bits[1])
+  data: bits[1] = input_port(name=data, id=1)
+  state_q: bits[1] = register_read(register=state, id=2)
+  state_d: () = register_write(data, register=state, id=3)
+  out: () = output_port(state_q, name=out, id=4)
+}
+
+top block top(clk: clock, data: bits[1], out: bits[1]) {
+  instantiation s0(block=stage, kind=block)
+  data: bits[1] = input_port(name=data, id=11)
+  s0_out: bits[1] = instantiation_output(instantiation=s0, port_name=out, id=12)
+  s0_data: () = instantiation_input(data, instantiation=s0, port_name=data, id=13)
+  out: () = output_port(s0_out, name=out, id=14)
+}
+"#;
+
+    let error =
+        block_ir_to_sequential_gate_fn(block_ir, GatifyOptions::all_opts_disabled()).unwrap_err();
+    assert_eq!(
+        error,
+        "block2sequential: registered instantiated block 'stage' at 'top.s0' declares clock 'child_clk' incompatible with top clock 'clk'"
+    );
+}
+
+#[test]
+fn rejects_inlined_reset_block_with_incompatible_reset_behavior() {
+    let block_ir = r#"package hierarchical_reset_mismatch
+
+block stage(clk: clock, local_rst: bits[1], data: bits[1], out: bits[1]) {
+  #![reset(port="local_rst", asynchronous=true, active_low=true)]
+  reg state(bits[1], reset_value=0)
+  local_rst: bits[1] = input_port(name=local_rst, id=1)
+  data: bits[1] = input_port(name=data, id=2)
+  state_q: bits[1] = register_read(register=state, id=3)
+  state_d: () = register_write(data, register=state, reset=local_rst, id=4)
+  out: () = output_port(state_q, name=out, id=5)
+}
+
+top block top(clk: clock, rst: bits[1], data: bits[1], out: bits[1]) {
+  #![reset(port="rst", asynchronous=false, active_low=true)]
+  instantiation s0(block=stage, kind=block)
+  rst: bits[1] = input_port(name=rst, id=11)
+  data: bits[1] = input_port(name=data, id=12)
+  s0_out: bits[1] = instantiation_output(instantiation=s0, port_name=out, id=13)
+  s0_rst: () = instantiation_input(rst, instantiation=s0, port_name=local_rst, id=14)
+  s0_data: () = instantiation_input(data, instantiation=s0, port_name=data, id=15)
+  out: () = output_port(s0_out, name=out, id=16)
+}
+"#;
+
+    let error =
+        block_ir_to_sequential_gate_fn(block_ir, GatifyOptions::all_opts_disabled()).unwrap_err();
+    assert_eq!(
+        error,
+        "block2sequential: reset-bearing instantiated block 'stage' at 'top.s0' declares reset behavior (asynchronous=true, active_low=true) incompatible with top reset behavior (asynchronous=false, active_low=true)"
+    );
+}
+
+#[test]
+fn rejects_register_reset_without_block_reset_metadata() {
+    let block_ir = r#"package invalid_reset
+
+top block top(clk: clock, rst: bits[1], data: bits[1], out: bits[1]) {
+  reg state(bits[1], reset_value=0)
+  rst: bits[1] = input_port(name=rst, id=1)
+  data: bits[1] = input_port(name=data, id=2)
+  state_q: bits[1] = register_read(register=state, id=3)
+  state_d: () = register_write(data, register=state, reset=rst, id=4)
+  out: () = output_port(state_q, name=out, id=5)
+}
+"#;
+
+    let error =
+        block_ir_to_sequential_gate_fn(block_ir, GatifyOptions::all_opts_disabled()).unwrap_err();
+    assert_eq!(
+        error,
+        "block2sequential: register 'state' has a reset write but the block has no reset metadata"
+    );
+}

--- a/xlsynth-g8r/tests/test_sequential_gate_fn.rs
+++ b/xlsynth-g8r/tests/test_sequential_gate_fn.rs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use xlsynth::IrBits;
+use xlsynth_g8r::aig::{
+    ClockPort, RegisterBinding, ResetSpec, SequentialGateFn, TransitionInputId, TransitionOutputId,
+};
+use xlsynth_g8r::aig_serdes::g8r::{decode_g8r_binary, emit_g8r, encode_g8r_binary, parse_g8r};
+use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
+use xlsynth_g8r::test_utils::structurally_equivalent;
+
+#[test]
+fn zero_register_sequential_gate_fn_may_omit_clock() {
+    let mut builder = GateBuilder::new("passthrough".to_string(), GateBuilderOptions::opt());
+    let x = builder.add_input("x".to_string(), 2);
+    builder.add_output("y".to_string(), x);
+
+    let sequential = SequentialGateFn::new(
+        "passthrough".to_string(),
+        builder.build(),
+        vec![TransitionInputId::new(0)],
+        vec![TransitionOutputId::new(0)],
+        None,
+        vec![],
+    )
+    .unwrap();
+
+    assert!(sequential.registers.is_empty());
+    assert!(sequential.clock.is_none());
+}
+
+#[test]
+fn native_g8r_stores_combinational_design_as_sequential_gate_fn() {
+    let mut builder = GateBuilder::new("passthrough".to_string(), GateBuilderOptions::opt());
+    let x = builder.add_input("x".to_string(), 2);
+    builder.add_output("y".to_string(), x);
+    let transition = builder.build();
+    let sequential = SequentialGateFn::new(
+        "transition".to_string(),
+        transition.clone(),
+        vec![TransitionInputId::new(0)],
+        vec![TransitionOutputId::new(0)],
+        None,
+        vec![],
+    )
+    .unwrap();
+
+    let text = emit_g8r(&sequential);
+    assert!(text.starts_with("g8r_v1\n"));
+    let parsed = parse_g8r(&text).unwrap();
+    assert_eq!(parsed.name, "transition");
+    assert!(parsed.registers.is_empty());
+    assert!(structurally_equivalent(&transition, &parsed.transition));
+    let binary = encode_g8r_binary(&sequential).unwrap();
+    assert!(binary.starts_with(b"g8rbin_v1\n"));
+    assert!(decode_g8r_binary(&binary).unwrap().registers.is_empty());
+
+    let wrapped = SequentialGateFn::from_gate_fn(transition.clone());
+    let extracted = parse_g8r(&emit_g8r(&wrapped))
+        .unwrap()
+        .try_into_gate_fn()
+        .unwrap();
+    assert!(structurally_equivalent(&transition, &extracted));
+}
+
+#[test]
+fn register_can_bind_data_load_enable_and_reset_transition_outputs() {
+    let mut builder =
+        GateBuilder::new("pipeline_transition".to_string(), GateBuilderOptions::opt());
+    let data = builder.add_input("data".to_string(), 8);
+    let load_enable = builder.add_input("load_enable".to_string(), 1);
+    let reset = builder.add_input("reset".to_string(), 1);
+    let state_q = builder.add_input("state_q".to_string(), 8);
+    builder.add_output("result".to_string(), state_q);
+    builder.add_output("state_d".to_string(), data);
+    builder.add_output("state_load_enable".to_string(), load_enable);
+    builder.add_output("state_reset".to_string(), reset);
+
+    let sequential = SequentialGateFn::new(
+        "pipeline".to_string(),
+        builder.build(),
+        vec![
+            TransitionInputId::new(0),
+            TransitionInputId::new(1),
+            TransitionInputId::new(2),
+        ],
+        vec![TransitionOutputId::new(0)],
+        Some(ClockPort {
+            name: "clk".to_string(),
+        }),
+        vec![RegisterBinding {
+            name: "state".to_string(),
+            q: TransitionInputId::new(3),
+            d: TransitionOutputId::new(1),
+            load_enable: Some(TransitionOutputId::new(2)),
+            reset: Some(ResetSpec {
+                signal: TransitionOutputId::new(3),
+                asynchronous: false,
+                active_low: false,
+                value: IrBits::make_ubits(8, 3).unwrap(),
+            }),
+            initial_value: None,
+        }],
+    )
+    .unwrap();
+
+    assert_eq!(sequential.registers[0].name, "state");
+    assert_eq!(
+        sequential.registers[0]
+            .reset
+            .as_ref()
+            .unwrap()
+            .value
+            .get_bit_count(),
+        8
+    );
+
+    let text = emit_g8r(&sequential);
+    assert!(text.contains("\nclock clk\n"));
+    assert!(!text.contains("\nclock posedge "));
+    assert!(!text.contains("\nclock negedge "));
+
+    for round_tripped in [
+        parse_g8r(&text).unwrap(),
+        decode_g8r_binary(&encode_g8r_binary(&sequential).unwrap()).unwrap(),
+    ] {
+        assert_eq!(round_tripped.clock, sequential.clock);
+        assert_eq!(round_tripped.inputs, sequential.inputs);
+        assert_eq!(round_tripped.outputs, sequential.outputs);
+        assert_eq!(round_tripped.registers, sequential.registers);
+        assert!(structurally_equivalent(
+            &round_tripped.transition,
+            &sequential.transition
+        ));
+    }
+
+    assert_eq!(
+        sequential.try_into_gate_fn().unwrap_err(),
+        "cannot convert design 'pipeline' to GateFn: design contains 1 register(s) and clock 'clk'"
+    );
+}
+
+#[test]
+fn combinational_conversion_restores_external_port_order() {
+    let mut builder = GateBuilder::new("transition".to_string(), GateBuilderOptions::opt());
+    let a = builder.add_input("a".to_string(), 1);
+    let b = builder.add_input("b".to_string(), 1);
+    builder.add_output("first".to_string(), a);
+    builder.add_output("second".to_string(), b);
+
+    let sequential = SequentialGateFn::new(
+        "ordered".to_string(),
+        builder.build(),
+        vec![TransitionInputId::new(1), TransitionInputId::new(0)],
+        vec![TransitionOutputId::new(1), TransitionOutputId::new(0)],
+        None,
+        vec![],
+    )
+    .unwrap();
+    let gate_fn = sequential.try_into_gate_fn().unwrap();
+
+    assert_eq!(gate_fn.name, "ordered");
+    assert_eq!(gate_fn.inputs[0].name, "b");
+    assert_eq!(gate_fn.inputs[1].name, "a");
+    assert_eq!(gate_fn.outputs[0].name, "second");
+    assert_eq!(gate_fn.outputs[1].name, "first");
+}
+
+#[test]
+fn combinational_conversion_rejects_declared_clock_without_registers() {
+    let mut builder = GateBuilder::new("clocked".to_string(), GateBuilderOptions::opt());
+    let x = builder.add_input("x".to_string(), 1);
+    builder.add_output("y".to_string(), x);
+    let sequential = SequentialGateFn::new(
+        "clocked".to_string(),
+        builder.build(),
+        vec![TransitionInputId::new(0)],
+        vec![TransitionOutputId::new(0)],
+        Some(ClockPort {
+            name: "clk".to_string(),
+        }),
+        vec![],
+    )
+    .unwrap();
+
+    assert_eq!(
+        sequential.try_into_gate_fn().unwrap_err(),
+        "cannot convert design 'clocked' to GateFn: design declares clock 'clk'"
+    );
+}
+
+#[test]
+fn registered_sequential_gate_fn_requires_clock() {
+    let mut builder =
+        GateBuilder::new("register_transition".to_string(), GateBuilderOptions::opt());
+    let state_q = builder.add_input("state_q".to_string(), 1);
+    builder.add_output("state_d".to_string(), state_q);
+
+    let error = SequentialGateFn::new(
+        "register".to_string(),
+        builder.build(),
+        vec![],
+        vec![],
+        None,
+        vec![RegisterBinding {
+            name: "state".to_string(),
+            q: TransitionInputId::new(0),
+            d: TransitionOutputId::new(0),
+            load_enable: None,
+            reset: None,
+            initial_value: None,
+        }],
+    )
+    .unwrap_err();
+
+    assert_eq!(error, "a SequentialGateFn with registers must have a clock");
+}
+
+#[test]
+fn register_data_width_must_match_state_width() {
+    let mut builder = GateBuilder::new("bad_transition".to_string(), GateBuilderOptions::opt());
+    let state_q = builder.add_input("state_q".to_string(), 8);
+    builder.add_output("state_d".to_string(), state_q.get_lsb_slice(0, 1));
+
+    let error = SequentialGateFn::new(
+        "bad".to_string(),
+        builder.build(),
+        vec![],
+        vec![],
+        Some(ClockPort {
+            name: "clk".to_string(),
+        }),
+        vec![RegisterBinding {
+            name: "state".to_string(),
+            q: TransitionInputId::new(0),
+            d: TransitionOutputId::new(0),
+            load_enable: None,
+            reset: None,
+            initial_value: None,
+        }],
+    )
+    .unwrap_err();
+
+    assert_eq!(error, "register 'state' has Q width 8 but D width 1");
+}

--- a/xlsynth-mcmc-pir/src/driver_cli.rs
+++ b/xlsynth-mcmc-pir/src/driver_cli.rs
@@ -10,7 +10,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::mpsc;
 use tempfile::Builder;
-use xlsynth_g8r::aig::gate::GateFn;
+use xlsynth_g8r::aig::{GateFn, SequentialGateFn};
+use xlsynth_g8r::aig_serdes::g8r::emit_g8r;
 use xlsynth_g8r::aig_serdes::gate2ir::GateFnInterfaceSchema;
 use xlsynth_g8r::process_ir_path::{
     CanonicalG8rOptions, canonical_ir_text_to_g8r_lowering_artifacts,
@@ -764,7 +765,7 @@ fn gatify_ir_text_to_artifacts(
     let schema = GateFnInterfaceSchema::from_pir_fn(top_fn)
         .map_err(|e| anyhow::anyhow!("failed to derive gate interface schema: {}", e))?;
     Ok(GatifiedArtifacts {
-        g8r_text: gate_fn.to_string(),
+        g8r_text: emit_g8r(&SequentialGateFn::from_gate_fn(gate_fn.clone())),
         raw_stats,
         gate_fn,
         schema,


### PR DESCRIPTION
This new representation wraps GateFn to support registers at the g8r level. Current support includes XLS block to g8r conversion and serialization to .g8r/.g8rbin.