### PR TITLE
release: prevent partial crates.io publications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,9 +86,6 @@ jobs:
       - name: Build and test
         run: cargo test --workspace
 
-      - name: Install Python dependencies for polling script
-        run: python3 -m pip install --break-system-packages requests
-
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,10 +60,10 @@ repos:
         language: system
         pass_filenames: false
 
-      - id: pytest-bump-version-script
-        name: pytest (bump_version_numbers.py)
-        description: Run pytest on inline tests in bump_version_numbers.py
-        entry: pytest -q scripts/bump_version_numbers.py
+      - id: pytest-release-helper-scripts
+        name: pytest (release helper scripts)
+        description: Run pytest on release helper script tests
+        entry: pytest -q scripts/bump_version_numbers.py scripts/crates_io_index_test.py scripts/sleep_until_version_seen_test.py
         language: python
         additional_dependencies: ["pytest"]
         pass_filenames: false

--- a/scripts/crates_io_index.py
+++ b/scripts/crates_io_index.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read crate publication state from the crates.io sparse index."""
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List
+
+
+SPARSE_INDEX_ROOT = "https://index.crates.io"
+USER_AGENT = "xlsynth-crate/release-tools (https://github.com/xlsynth/xlsynth-crate)"
+
+
+def sparse_index_path(crate_name: str) -> str:
+    """Return the sparse-index metadata path for a crates.io crate name."""
+    normalized_name = crate_name.lower()
+    if len(normalized_name) == 1:
+        return "1/{}".format(normalized_name)
+    if len(normalized_name) == 2:
+        return "2/{}".format(normalized_name)
+    if len(normalized_name) == 3:
+        return "3/{}/{}".format(normalized_name[0], normalized_name)
+    return "{}/{}/{}".format(
+        normalized_name[0:2], normalized_name[2:4], normalized_name
+    )
+
+
+def get_published_versions(crate_name: str) -> List[str]:
+    """Return all published versions in the crate's sparse-index record.
+
+    A missing record means the crate has never been published. Any other
+    lookup or parse failure is surfaced to callers so publication does not
+    continue without reliable registry state.
+    """
+    url = "{}/{}".format(SPARSE_INDEX_ROOT, sparse_index_path(crate_name))
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            index_text = response.read().decode("utf-8")
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return []
+        raise
+
+    versions: List[str] = []
+    for line_number, line in enumerate(index_text.splitlines(), start=1):
+        if not line:
+            continue
+        try:
+            entry: Dict[str, Any] = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                "Invalid sparse-index metadata for {} at line {}".format(
+                    crate_name, line_number
+                )
+            ) from error
+        version = entry.get("vers")
+        if not isinstance(version, str):
+            raise ValueError(
+                "Missing version in sparse-index metadata for {} at line {}".format(
+                    crate_name, line_number
+                )
+            )
+        versions.append(version)
+    return versions
+
+
+def crate_version_is_published(crate_name: str, version_wanted: str) -> bool:
+    """Return whether a crate version already exists in the sparse index."""
+    # A yanked release still occupies its version and cannot be republished.
+    return version_wanted in get_published_versions(crate_name)

--- a/scripts/crates_io_index_test.py
+++ b/scripts/crates_io_index_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+import urllib.error
+from unittest import mock
+
+import pytest
+
+from crates_io_index import USER_AGENT, crate_version_is_published, sparse_index_path
+
+
+class FakeResponse:
+    def __init__(self, body: str):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self) -> bytes:
+        return self.body.encode("utf-8")
+
+
+def test_sparse_index_path_uses_cargo_index_layout():
+    assert sparse_index_path("a") == "1/a"
+    assert sparse_index_path("ab") == "2/ab"
+    assert sparse_index_path("abc") == "3/a/abc"
+    assert sparse_index_path("xlsynth-sys") == "xl/sy/xlsynth-sys"
+    assert sparse_index_path("XLSynth_Aot") == "xl/sy/xlsynth_aot"
+
+
+def test_published_version_is_found_through_sparse_index():
+    response = FakeResponse(
+        '{"name":"xlsynth-sys","vers":"0.51.0","yanked":false}\n'
+        '{"name":"xlsynth-sys","vers":"0.51.1","yanked":true}\n'
+    )
+    with mock.patch(
+        "crates_io_index.urllib.request.urlopen", return_value=response
+    ) as open_url:
+        assert crate_version_is_published("xlsynth-sys", "0.51.1")
+
+    request = open_url.call_args.args[0]
+    assert request.full_url == "https://index.crates.io/xl/sy/xlsynth-sys"
+    assert request.get_header("User-agent") == USER_AGENT
+    assert open_url.call_args.kwargs["timeout"] == 15
+
+
+def test_missing_crate_is_not_published():
+    error = urllib.error.HTTPError("url", 404, "not found", {}, None)
+    with mock.patch("crates_io_index.urllib.request.urlopen", side_effect=error):
+        assert not crate_version_is_published("first-release", "0.1.0")
+
+
+def test_registry_access_failure_is_not_treated_as_absence():
+    error = urllib.error.HTTPError("url", 403, "forbidden", {}, None)
+    with mock.patch("crates_io_index.urllib.request.urlopen", side_effect=error):
+        with pytest.raises(urllib.error.HTTPError):
+            crate_version_is_published("xlsynth-sys", "0.51.1")
+
+
+def test_malformed_sparse_index_metadata_is_rejected():
+    with mock.patch(
+        "crates_io_index.urllib.request.urlopen",
+        return_value=FakeResponse('{"name":"xlsynth-sys"}\n'),
+    ):
+        with pytest.raises(ValueError):
+            crate_version_is_published("xlsynth-sys", "0.51.1")

--- a/scripts/gen_version_compat.py
+++ b/scripts/gen_version_compat.py
@@ -31,12 +31,13 @@ import re
 import os
 import subprocess
 import sys
-import urllib.request
 import json
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Tuple
 
 from datetime import datetime, timezone, tzinfo
+
+from crates_io_index import crate_version_is_published
 
 # Prefer stdlib zoneinfo (Python ≥3.9) for accurate TZ handling; fall back to a fixed offset if unavailable.
 try:
@@ -179,20 +180,8 @@ def get_all_tags() -> List[str]:
 
 
 def crate_published(crate_version: str) -> bool:
-    """Check if the given crate version is published on crates.io for xlsynth."""
-    url = "https://crates.io/api/v1/crates/xlsynth/versions"
-    try:
-        with urllib.request.urlopen(url, timeout=10) as resp:
-            data = resp.read().decode("utf-8")
-            jdata = json.loads(data)
-            versions = [v["num"] for v in jdata.get("versions", [])]
-            return crate_version in versions
-    except Exception as e:
-        print(
-            f"Error checking crates.io for version {crate_version}: {e}",
-            file=sys.stderr,
-        )
-        return False
+    """Check if the given xlsynth crate version is published on crates.io."""
+    return crate_version_is_published("xlsynth", crate_version)
 
 
 def _load_existing_mappings(json_path: str) -> Dict[str, VersionMapping]:

--- a/scripts/sleep_until_version_seen.py
+++ b/scripts/sleep_until_version_seen.py
@@ -3,39 +3,36 @@
 
 import sys
 import time
-import requests
-import json
+import urllib.error
+
+from crates_io_index import crate_version_is_published
 
 
 def check_crate_version(crate_name, version_wanted):
-    """
-    Checks crates.io API for the specified version of a crate.
-    Returns True if found, False otherwise.
-    Prints brief error messages for API or JSON issues without exiting.
-    """
-    api_url = f"https://crates.io/api/v1/crates/{crate_name}"
+    """Return whether the crate version is visible in the sparse index."""
+    return crate_version_is_published(crate_name, version_wanted)
+
+
+def check_crate_version_for_polling(crate_name, version_wanted):
+    """Return version visibility while retrying transient post-publish failures."""
     try:
-        # Set a timeout for the request itself (e.g., 15 seconds)
-        response = requests.get(api_url, timeout=15)
-        # Raise an exception for HTTP errors (4xx or 5xx)
-        response.raise_for_status()
-        data = response.json()
-        # The 'versions' key contains a list of version objects
-        versions_data = data.get("versions", [])
-        for v_info in versions_data:
-            if v_info.get("num") == version_wanted:
-                return True
-    except requests.exceptions.Timeout:
-        print("\n[API Request Timeout]", end="", flush=True)
-    except requests.exceptions.HTTPError as e:
-        # Log HTTP errors (like 404 if crate not found yet), but continue polling
-        print(f"\n[API HTTP Error: {e.response.status_code}]", end="", flush=True)
-    except requests.exceptions.RequestException as e:
-        # Other request-related errors (DNS, connection, etc.)
-        print(f"\n[API Request Error: {e}]", end="", flush=True)
-    except json.JSONDecodeError:
-        print("\n[API JSON Decode Error]", end="", flush=True)
-    return False
+        return check_crate_version(crate_name, version_wanted)
+    except urllib.error.HTTPError as error:
+        if 500 <= error.code < 600:
+            print(
+                "\n[Sparse index HTTP error: {}]".format(error.code),
+                end="",
+                flush=True,
+            )
+            return False
+        raise
+    except (urllib.error.URLError, TimeoutError) as error:
+        print(
+            "\n[Sparse index request error: {}]".format(error),
+            end="",
+            flush=True,
+        )
+        return False
 
 
 def main():
@@ -53,7 +50,7 @@ def main():
     timeout_total_seconds = 5 * 60  # Total timeout of 5 minutes
 
     print(
-        f"Waiting for {crate_name} v{version_wanted} to appear on crates.io (polling every {poll_interval_seconds}s, timeout: {timeout_total_seconds}s)...",
+        f"Waiting for {crate_name} v{version_wanted} to appear in the crates.io sparse index (polling every {poll_interval_seconds}s, timeout: {timeout_total_seconds}s)...",
         end="",
         flush=True,
     )
@@ -64,7 +61,7 @@ def main():
 
     try:
         while True:
-            if check_crate_version(crate_name, version_wanted):
+            if check_crate_version_for_polling(crate_name, version_wanted):
                 print("\nVersion found!")
                 sys.exit(0)
 

--- a/scripts/sleep_until_version_seen_test.py
+++ b/scripts/sleep_until_version_seen_test.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+import urllib.error
+from unittest import mock
+
+import pytest
+
+from sleep_until_version_seen import check_crate_version_for_polling
+
+
+def test_polling_retries_transient_server_error(capsys):
+    error = urllib.error.HTTPError("url", 503, "unavailable", {}, None)
+    with mock.patch("sleep_until_version_seen.check_crate_version", side_effect=error):
+        assert not check_crate_version_for_polling("xlsynth-sys", "0.51.1")
+
+    assert "[Sparse index HTTP error: 503]" in capsys.readouterr().out
+
+
+def test_polling_retries_transient_request_error(capsys):
+    error = urllib.error.URLError("temporarily unavailable")
+    with mock.patch("sleep_until_version_seen.check_crate_version", side_effect=error):
+        assert not check_crate_version_for_polling("xlsynth-sys", "0.51.1")
+
+    assert "[Sparse index request error:" in capsys.readouterr().out
+
+
+def test_polling_does_not_retry_policy_error():
+    error = urllib.error.HTTPError("url", 403, "forbidden", {}, None)
+    with mock.patch("sleep_until_version_seen.check_crate_version", side_effect=error):
+        with pytest.raises(urllib.error.HTTPError):
+            check_crate_version_for_polling("xlsynth-sys", "0.51.1")


### PR DESCRIPTION
Read published crate versions from the crates.io sparse index in the release tooling, so an uploaded crate is no longer stranded when crates.io rejects the REST API polling request.

## Problem Solved

The `v0.51.0` publish attempt uploaded `xlsynth-sys 0.51.0`, then `scripts/sleep_until_version_seen.py` repeatedly queried the crates.io REST API through a generic `python-requests/...` client. crates.io returned HTTP 403, and the poller treated those failures like "the version is not published yet", leaving only the first crate published.

Minimized example:

```text
old:
  upload xlsynth-sys -> succeeds
  query REST API -> HTTP 403
  treat query failure as absent -> timeout with a partial release

new:
  upload xlsynth-sys -> succeeds
  read sparse-index entry -> new version is visible
  continue publishing dependent crates
```

crates.io documents the sparse index as the preferred metadata path for a small number of crates, ahead of the REST API. This change uses that path for publish-time visibility checks and post-publish version metadata generation.

## Changes

- Add a shared standard-library sparse-index reader with Cargo index path handling.
- Use the reader in the publish poller and version compatibility generator.
- Treat first-publish index `404` as absent, fail closed before upload on other lookup errors, and retry only transient post-upload lookup failures.
- Remove the polling-only `requests` installation from the release workflow.
- Add regression tests for sparse-index paths, visibility, first publication, malformed records, and retry classification.

## Validation

- `pre-commit run --all-files`
- Live sparse-index visibility check for published `xlsynth-sys 0.51.0`
- Live version-metadata visibility check for published `xlsynth 0.49.0` and unpublished `xlsynth 0.51.0`

## Stack Note

This PR intentionally excludes the broad `0.52.0` version bump for focused review. Because the failed release already published `xlsynth-sys 0.51.0`, this lower PR's released-version CI check is expected to fail in isolation; the stacked version-bump PR moves the release candidate to the fresh `0.52.0` version line.

<!-- spr-stack:start -->
**Stack**:
-   #991
- ➡ #990

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->