### PR TITLE
release: prepare v0.52.0 after the partial publication

### DIFF
--- a/sample-usage/Cargo.toml
+++ b/sample-usage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sample-usage"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 publish = false
 

--- a/xlsynth-aot-runtime/Cargo.toml
+++ b/xlsynth-aot-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "xlsynth-aot-runtime"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Standalone runtime support for xlsynth AOT artifacts"

--- a/xlsynth-autocov/Cargo.toml
+++ b/xlsynth-autocov/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-autocov"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Coverage-guided corpus growth for XLS IR functions"
@@ -13,9 +13,9 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 workspace = true
 
 [dependencies]
-xlsynth = { path = "../xlsynth", version = "0.51.0" }
-xlsynth-pir = { path = "../xlsynth-pir", version = "0.51.0" }
-xlsynth-prover = { path = "../xlsynth-prover", version = "0.51.0" }
+xlsynth = { path = "../xlsynth", version = "0.52.0" }
+xlsynth-pir = { path = "../xlsynth-pir", version = "0.52.0" }
+xlsynth-prover = { path = "../xlsynth-prover", version = "0.52.0" }
 blake3 = "1.5"
 rand = "0.8"
 log = "0.4"

--- a/xlsynth-driver/Cargo.toml
+++ b/xlsynth-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-driver"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
@@ -14,12 +14,12 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 workspace = true
 
 [dependencies]
-xlsynth = { path = "../xlsynth", version = "0.51.0", features = ["clap"] }
-xlsynth-g8r = { path = "../xlsynth-g8r", version = "0.51.0" }
-xlsynth-pir = { path = "../xlsynth-pir", version = "0.51.0" }
-xlsynth-mcmc-pir = { path = "../xlsynth-mcmc-pir", version = "0.51.0" }
-xlsynth-autocov = { path = "../xlsynth-autocov", version = "0.51.0" }
-xlsynth-prover = { path = "../xlsynth-prover", version = "0.51.0" }
+xlsynth = { path = "../xlsynth", version = "0.52.0", features = ["clap"] }
+xlsynth-g8r = { path = "../xlsynth-g8r", version = "0.52.0" }
+xlsynth-pir = { path = "../xlsynth-pir", version = "0.52.0" }
+xlsynth-mcmc-pir = { path = "../xlsynth-mcmc-pir", version = "0.52.0" }
+xlsynth-autocov = { path = "../xlsynth-autocov", version = "0.52.0" }
+xlsynth-prover = { path = "../xlsynth-prover", version = "0.52.0" }
 clap = "4.5.21"
 tempfile = "3.20"
 toml = "0.8.19"
@@ -48,7 +48,7 @@ num_cpus = "1.16"
 
 [dev-dependencies]
 xlsynth-test-helpers = { path = "../xlsynth-test-helpers" }
-xlsynth-vastly = { path = "../xlsynth-vastly", version = "0.51.0", features = ["irvals"] }
+xlsynth-vastly = { path = "../xlsynth-vastly", version = "0.52.0", features = ["irvals"] }
 test-case = "3.3.1"
 pretty_assertions = "1.4.1"
 

--- a/xlsynth-driver/fuzz/Cargo.toml
+++ b/xlsynth-driver/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-driver-fuzz"
-version = "0.51.0"
+version = "0.52.0"
 publish = false
 edition = "2021"
 
@@ -12,7 +12,7 @@ libfuzzer-sys = "0.4"
 arbitrary = { version = "1.3", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11"
-xlsynth-driver = { path = "..", features = ["enable-fake-task"], version = "0.51.0" }
+xlsynth-driver = { path = "..", features = ["enable-fake-task"], version = "0.52.0" }
 
 [lib]
 name = "xlsynth_driver_fuzz"

--- a/xlsynth-dslx-routines/Cargo.toml
+++ b/xlsynth-dslx-routines/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-dslx-routines"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Reusable DSLX routine implementations and QoR tests"
@@ -18,8 +18,8 @@ name = "xlsynth_dslx_routines"
 path = "src/lib.rs"
 
 [dev-dependencies]
-xlsynth = { path = "../xlsynth", version = "0.51.0" }
-xlsynth-g8r = { path = "../xlsynth-g8r", version = "0.51.0" }
-xlsynth-test-helpers = { path = "../xlsynth-test-helpers", version = "0.51.0" }
+xlsynth = { path = "../xlsynth", version = "0.52.0" }
+xlsynth-g8r = { path = "../xlsynth-g8r", version = "0.52.0" }
+xlsynth-test-helpers = { path = "../xlsynth-test-helpers", version = "0.52.0" }
 env_logger = "0.11"
 pretty_assertions = "1.4.1"

--- a/xlsynth-estimator/Cargo.toml
+++ b/xlsynth-estimator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-estimator"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]

--- a/xlsynth-g8r/Cargo.toml
+++ b/xlsynth-g8r/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-g8r"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "XLS IR to gate mapping"
@@ -13,9 +13,9 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 workspace = true
 
 [dependencies]
-xlsynth = { path = "../xlsynth", version = "0.51.0" }
-xlsynth-pir = { path = "../xlsynth-pir", version = "0.51.0" }
-xlsynth-mcmc = { path = "../xlsynth-mcmc", version = "0.51.0" }
+xlsynth = { path = "../xlsynth", version = "0.52.0" }
+xlsynth-pir = { path = "../xlsynth-pir", version = "0.52.0" }
+xlsynth-mcmc = { path = "../xlsynth-mcmc", version = "0.52.0" }
 env_logger = "0.11"
 log = "0.4"
 clap = { version = "4.5.21", features = ["derive"] }
@@ -60,7 +60,7 @@ test-case = "3.3.1"
 maplit = "1.0.2"
 prost-build = "0.12"
 tempfile = "3.20"
-xlsynth-test-helpers = { path = "../xlsynth-test-helpers", version = "0.51.0" }
+xlsynth-test-helpers = { path = "../xlsynth-test-helpers", version = "0.52.0" }
 
 [build-dependencies]
 prost-build = "0.12"

--- a/xlsynth-g8r/fuzz/Cargo.toml
+++ b/xlsynth-g8r/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-g8r-fuzz"
-version = "0.51.0"
+version = "0.52.0"
 publish = false
 edition = "2021"
 
@@ -13,7 +13,7 @@ arbitrary = { version = "1.3", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11"
 blake3 = "1"
-xlsynth = { path = "../../xlsynth", version = "0.51.0" }
+xlsynth = { path = "../../xlsynth", version = "0.52.0" }
 rand = "0.8"
 xlsynth-test-helpers = { path = "../../xlsynth-test-helpers" }
 xlsynth-pir = { path = "../../xlsynth-pir" }

--- a/xlsynth-mcmc-pir/Cargo.toml
+++ b/xlsynth-mcmc-pir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-mcmc-pir"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "PIR-based MCMC optimization using the shared xlsynth-mcmc engine"
@@ -13,11 +13,11 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 workspace = true
 
 [dependencies]
-xlsynth-mcmc = { path = "../xlsynth-mcmc", version = "0.51.0" }
-xlsynth-pir = { path = "../xlsynth-pir", version = "0.51.0" }
-xlsynth = { path = "../xlsynth", version = "0.51.0" }
-xlsynth-g8r = { path = "../xlsynth-g8r", version = "0.51.0" }
-xlsynth-prover = { path = "../xlsynth-prover", version = "0.51.0" }
+xlsynth-mcmc = { path = "../xlsynth-mcmc", version = "0.52.0" }
+xlsynth-pir = { path = "../xlsynth-pir", version = "0.52.0" }
+xlsynth = { path = "../xlsynth", version = "0.52.0" }
+xlsynth-g8r = { path = "../xlsynth-g8r", version = "0.52.0" }
+xlsynth-prover = { path = "../xlsynth-prover", version = "0.52.0" }
 anyhow = "1.0.86"
 rand = { version = "0.8.5", features = ["std"] }
 rand_pcg = "0.3.1"

--- a/xlsynth-mcmc/Cargo.toml
+++ b/xlsynth-mcmc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-mcmc"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Shared MCMC infrastructure for xlsynth-* crates"

--- a/xlsynth-pir/Cargo.toml
+++ b/xlsynth-pir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-pir"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "partial XLS IR focused on functions"
@@ -13,7 +13,7 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 workspace = true
 
 [dependencies]
-xlsynth = { path = "../xlsynth", version = "0.51.0" }
+xlsynth = { path = "../xlsynth", version = "0.52.0" }
 env_logger = "0.11"
 log = "0.4"
 clap = { version = "4.5.21", features = ["derive"] }

--- a/xlsynth-prover/Cargo.toml
+++ b/xlsynth-prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-prover"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "XLS formal pProvers"
@@ -13,8 +13,8 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 workspace = true
 
 [dependencies]
-xlsynth = { path = "../xlsynth", version = "0.51.0" }
-xlsynth-pir = { path = "../xlsynth-pir", version = "0.51.0" }
+xlsynth = { path = "../xlsynth", version = "0.52.0" }
+xlsynth-pir = { path = "../xlsynth-pir", version = "0.52.0" }
 tempfile = "3.20"
 num_cpus = "1.16"
 clap = { version = "4.5.21", features = ["derive"] }

--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-sys"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust (Native Library)"

--- a/xlsynth-test-helpers/Cargo.toml
+++ b/xlsynth-test-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-test-helpers"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "xlsynth test helpers"
@@ -17,8 +17,8 @@ slang-rs = "0.12.0"
 tempfile = "3.20"
 log = "0.4"
 env_logger = "0.11"
-xlsynth = { version = "0.51.0", path = "../xlsynth" }
-xlsynth-prover = { version = "0.51.0", path = "../xlsynth-prover" }
+xlsynth = { version = "0.52.0", path = "../xlsynth" }
+xlsynth-prover = { version = "0.52.0", path = "../xlsynth-prover" }
 arbitrary = { version = "1.3", features = ["derive"] }
 pretty_assertions = "1.4.1"
 

--- a/xlsynth-vastly/Cargo.toml
+++ b/xlsynth-vastly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-vastly"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Simulation and VCD-oriented utilities for generated Verilog/SystemVerilog"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = { version = "4.5.21", features = ["derive"] }
-xlsynth = { path = "../xlsynth", version = "0.51.0", optional = true }
+xlsynth = { path = "../xlsynth", version = "0.52.0", optional = true }
 
 [features]
 default = []

--- a/xlsynth-vastly/fuzz/Cargo.toml
+++ b/xlsynth-vastly/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth-vastly-fuzz"
-version = "0.51.0"
+version = "0.52.0"
 publish = false
 edition = "2021"
 
@@ -11,9 +11,9 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1.3", features = ["derive"] }
 wait-timeout = "0.2"
-xlsynth = { path = "../../xlsynth", version = "0.51.0" }
-xlsynth-pir = { path = "../../xlsynth-pir", version = "0.51.0" }
-xlsynth-autocov = { path = "../../xlsynth-autocov", version = "0.51.0" }
+xlsynth = { path = "../../xlsynth", version = "0.52.0" }
+xlsynth-pir = { path = "../../xlsynth-pir", version = "0.52.0" }
+xlsynth-autocov = { path = "../../xlsynth-autocov", version = "0.52.0" }
 xlsynth-vastly = { path = "..", package = "xlsynth-vastly" }
 
 [lib]

--- a/xlsynth/Cargo.toml
+++ b/xlsynth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlsynth"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>"]
 description = "Accelerated Hardware Synthesis (XLS/XLSynth) via Rust"
@@ -21,8 +21,8 @@ clap = ["dep:clap"]
 standalone-aot = ["dep:xlsynth-aot-runtime"]
 
 [dependencies]
-xlsynth-aot-runtime = {path = "../xlsynth-aot-runtime", version = "0.51.0", optional = true}
-xlsynth-sys = {path = "../xlsynth-sys", version = "0.51.0"}
+xlsynth-aot-runtime = {path = "../xlsynth-aot-runtime", version = "0.52.0", optional = true}
+xlsynth-sys = {path = "../xlsynth-sys", version = "0.52.0"}
 cargo_metadata = "0.18"
 thiserror = "1"
 clap = { version = "4.5.21", features = ["derive"], optional = true }

--- a/xlsynth/tests/aot-standalone-test-crate/Cargo.toml
+++ b/xlsynth/tests/aot-standalone-test-crate/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "xlsynth-aot-standalone-test-crate"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>", "Mark Heffernan <meheff@gmail.com>"]
 description = "Runtime-dependency smoke tests for standalone xlsynth AOT artifacts"

--- a/xlsynth/tests/aot-test-crate/Cargo.toml
+++ b/xlsynth/tests/aot-test-crate/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "xlsynth-aot-test-crate"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2018"
 authors = ["Christopher D. Leary <cdleary@gmail.com>", "Mark Heffernan <meheff@gmail.com>"]
 description = "Integration tests for xlsynth build.rs AOT workflow"


### PR DESCRIPTION
Advance the lockstep Rust crate versions from `0.51.0` to `0.52.0` for the next release.

<!-- spr-stack:start -->
**Stack**:
- ➡ #991

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
