### PR TITLE
release: resume crates.io publication after transient failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,6 +84,8 @@ jobs:
       # build and test step does not consume mutable repository cache state.
 
       - name: Build and test
+        env:
+          XLSYNTH_PUBLISH_VERSION: ${{ steps.version_vars.outputs.version_no_v }}
         run: cargo test --workspace
 
       - name: Publish crates in dependency order

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
       - id: pytest-release-helper-scripts
         name: pytest (release helper scripts)
         description: Run pytest on release helper script tests
-        entry: pytest -q scripts/bump_version_numbers.py scripts/crates_io_index_test.py scripts/sleep_until_version_seen_test.py
+        entry: pytest -q scripts/bump_version_numbers.py scripts/crates_io_index_test.py scripts/sleep_until_version_seen_test.py scripts/publish_crates_test.py
         language: python
         additional_dependencies: ["pytest"]
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ This repository publishes crates to crates.io via the GitHub Actions workflow in
 1. Create and push the tag (`git tag vX.Y.Z` then `git push origin vX.Y.Z`).
 1. The publish workflow validates that the checked-in crate versions match the tag, runs tests, and publishes the crates.
 
+Treat every pushed release tag as immutable. The publish workflow is restartable after a partial release: it skips an exact crate version that is already present in the crates.io sparse index and continues with missing crates. Never move or reuse a pushed release tag for different source. Fix forward with a new patch version instead.
+
 Important: the version for the next release is often already "waiting" in the repository. After a successful mainline `.0` release, the workflow pushes two follow-up commits:
 
 - `Bump version numbers after successful publish`

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -4,17 +4,35 @@
 """Publish crates from publish_order.toml in dependency order."""
 
 import argparse
+import enum
 import json
 import os
 import re
 import subprocess
 import sys
+import time
 
-from sleep_until_version_seen import check_crate_version
+from sleep_until_version_seen import check_crate_version, wait_until_version_seen
 
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ORDER_PATH = os.path.join(REPO_ROOT, "publish_order.toml")
+MAX_PUBLISH_ATTEMPTS = 3
+RETRY_BACKOFF_SECONDS = 15
+_TRANSIENT_ERROR_PATTERNS = (
+    r"\b(?:got|status(?: code)?)\s+(?:429|5\d\d)\b",
+    r"\b(?:timed out|timeout|connection refused|connection reset|failed to connect|network failure|spurious network error)\b",
+)
+_DUPLICATE_ERROR_PATTERNS = (
+    r"\balready (?:exists|uploaded|published)\b",
+    r"\bversion .* is already uploaded\b",
+)
+
+
+class PublishFailureKind(enum.Enum):
+    TRANSIENT = "transient"
+    DUPLICATE = "duplicate"
+    FATAL = "fatal"
 
 
 def load_publish_order():
@@ -49,32 +67,103 @@ def crate_dir(package):
     return os.path.dirname(os.path.relpath(manifest_path, REPO_ROOT))
 
 
-def publish_crates(version):
-    cargo_registry_token = os.environ["CARGO_REGISTRY_TOKEN"]
-    packages = load_workspace_packages()
-    for crate_name in load_publish_order():
-        package = packages[crate_name]
-        package_dir = crate_dir(package)
+def _run_cargo_publish(package_dir):
+    result = subprocess.run(
+        ["cargo", "publish"],
+        cwd=os.path.join(REPO_ROOT, package_dir),
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout:
+        print(result.stdout, end="", flush=True)
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr, flush=True)
+    return result
+
+
+def _classify_publish_failure(result):
+    """Classify cargo's unstructured publish output at the subprocess boundary."""
+    output = "{}\n{}".format(result.stdout, result.stderr)
+    if any(
+        re.search(pattern, output, re.IGNORECASE)
+        for pattern in _DUPLICATE_ERROR_PATTERNS
+    ):
+        return PublishFailureKind.DUPLICATE
+    if any(
+        re.search(pattern, output, re.IGNORECASE)
+        for pattern in _TRANSIENT_ERROR_PATTERNS
+    ):
+        return PublishFailureKind.TRANSIENT
+    return PublishFailureKind.FATAL
+
+
+def _publish_error(result):
+    return subprocess.CalledProcessError(
+        result.returncode,
+        ["cargo", "publish"],
+        output=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+def publish_crate_with_retries(crate_name, version, package_dir):
+    """Publish one crate, retrying failed uploads that remain absent from crates.io."""
+    for attempt in range(1, MAX_PUBLISH_ATTEMPTS + 1):
         if check_crate_version(crate_name, version):
             print(
                 "{} {} is already on crates.io; skipping.".format(crate_name, version),
                 flush=True,
             )
-            continue
-        print("Publishing {}...".format(crate_name), flush=True)
-        subprocess.check_call(
-            ["cargo", "publish", "--token", cargo_registry_token],
-            cwd=os.path.join(REPO_ROOT, package_dir),
+            return
+        print(
+            "Publishing {} (attempt {}/{})...".format(
+                crate_name, attempt, MAX_PUBLISH_ATTEMPTS
+            ),
+            flush=True,
         )
-        subprocess.check_call(
-            [
-                sys.executable,
-                os.path.join(REPO_ROOT, "scripts", "sleep_until_version_seen.py"),
-                crate_name,
-                version,
-            ],
-            cwd=REPO_ROOT,
-        )
+        result = _run_cargo_publish(package_dir)
+        if result.returncode == 0:
+            if not wait_until_version_seen(crate_name, version):
+                raise RuntimeError(
+                    "{} {} did not appear in the crates.io sparse index".format(
+                        crate_name, version
+                    )
+                )
+            return
+
+        failure_kind = _classify_publish_failure(result)
+        if check_crate_version(crate_name, version):
+            return
+        if failure_kind in (PublishFailureKind.TRANSIENT, PublishFailureKind.DUPLICATE):
+            if wait_until_version_seen(crate_name, version):
+                return
+        if failure_kind == PublishFailureKind.TRANSIENT:
+            if attempt == MAX_PUBLISH_ATTEMPTS:
+                raise _publish_error(result)
+            print(
+                "cargo publish failed for {}; retrying.".format(crate_name),
+                flush=True,
+            )
+            time.sleep(RETRY_BACKOFF_SECONDS)
+        elif failure_kind == PublishFailureKind.DUPLICATE:
+            raise RuntimeError(
+                "cargo publish reported that {} {} already exists, but the version did not appear in the crates.io sparse index".format(
+                    crate_name, version
+                )
+            )
+        else:
+            raise _publish_error(result)
+
+
+def publish_crates(version):
+    # Validate configuration early. Cargo reads the token from the environment,
+    # which avoids exposing it in the process argument list and exceptions.
+    os.environ["CARGO_REGISTRY_TOKEN"]
+    packages = load_workspace_packages()
+    for crate_name in load_publish_order():
+        package = packages[crate_name]
+        package_dir = crate_dir(package)
+        publish_crate_with_retries(crate_name, version, package_dir)
 
 
 def main():

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -12,7 +12,11 @@ import subprocess
 import sys
 import time
 
-from sleep_until_version_seen import check_crate_version, wait_until_version_seen
+from sleep_until_version_seen import (
+    check_crate_version,
+    check_crate_version_for_polling,
+    wait_until_version_seen,
+)
 
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -71,8 +75,9 @@ def _run_cargo_publish(package_dir):
     result = subprocess.run(
         ["cargo", "publish"],
         cwd=os.path.join(REPO_ROOT, package_dir),
-        capture_output=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
     )
     if result.stdout:
         print(result.stdout, end="", flush=True)
@@ -132,7 +137,7 @@ def publish_crate_with_retries(crate_name, version, package_dir):
             return
 
         failure_kind = _classify_publish_failure(result)
-        if check_crate_version(crate_name, version):
+        if check_crate_version_for_polling(crate_name, version):
             return
         if failure_kind in (PublishFailureKind.TRANSIENT, PublishFailureKind.DUPLICATE):
             if wait_until_version_seen(crate_name, version):

--- a/scripts/publish_crates_test.py
+++ b/scripts/publish_crates_test.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import subprocess
+import urllib.error
 from unittest import mock
 
 import pytest
 
 from publish_crates import (
     MAX_PUBLISH_ATTEMPTS,
+    REPO_ROOT,
     PublishFailureKind,
     _classify_publish_failure,
+    _run_cargo_publish,
     publish_crate_with_retries,
 )
 
@@ -32,12 +36,29 @@ def publish_crate():
     publish_crate_with_retries(CRATE_NAME, VERSION, PACKAGE_DIR)
 
 
+def test_run_cargo_publish_uses_python_3_6_compatible_keywords():
+    result = cargo_result()
+    with mock.patch("publish_crates.subprocess.run", return_value=result) as run:
+        assert _run_cargo_publish(PACKAGE_DIR) == result
+
+    run.assert_called_once_with(
+        ["cargo", "publish"],
+        cwd=os.path.join(REPO_ROOT, PACKAGE_DIR),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+
 def test_publish_retries_transient_failure():
     failure = cargo_result(101, "failed to get a 200 OK response, got 503")
     with (
         mock.patch(
             "publish_crates.check_crate_version",
-            side_effect=[False, False, False],
+            side_effect=[False, False],
+        ),
+        mock.patch(
+            "publish_crates.check_crate_version_for_polling", return_value=False
         ),
         mock.patch(
             "publish_crates._run_cargo_publish", side_effect=[failure, cargo_result()]
@@ -57,10 +78,43 @@ def test_publish_retries_transient_failure():
     sleep.assert_called_once()
 
 
+def test_publish_retries_when_post_failure_sparse_index_lookup_is_transient():
+    failure = cargo_result(101, "failed to get a 200 OK response, got 503")
+    index_error = urllib.error.HTTPError(
+        "https://index.crates.io/xl/sy/xlsynth-mcmc-pir",
+        503,
+        "Service Unavailable",
+        {},
+        None,
+    )
+    with (
+        mock.patch("publish_crates.check_crate_version", side_effect=[False, False]),
+        mock.patch(
+            "sleep_until_version_seen.check_crate_version",
+            side_effect=index_error,
+        ),
+        mock.patch(
+            "publish_crates._run_cargo_publish", side_effect=[failure, cargo_result()]
+        ) as run_publish,
+        mock.patch(
+            "publish_crates.wait_until_version_seen", side_effect=[False, True]
+        ) as wait_until_seen,
+        mock.patch("publish_crates.time.sleep"),
+    ):
+        publish_crate()
+
+    assert run_publish.call_count == 2
+    assert wait_until_seen.call_args_list == [
+        mock.call(CRATE_NAME, VERSION),
+        mock.call(CRATE_NAME, VERSION),
+    ]
+
+
 def test_publish_stops_retrying_when_failed_upload_becomes_visible():
     failure = cargo_result(101, "failed to get a 200 OK response, got 503")
     with (
-        mock.patch("publish_crates.check_crate_version", side_effect=[False, True]),
+        mock.patch("publish_crates.check_crate_version", return_value=False),
+        mock.patch("publish_crates.check_crate_version_for_polling", return_value=True),
         mock.patch(
             "publish_crates._run_cargo_publish", return_value=failure
         ) as run_publish,
@@ -77,7 +131,10 @@ def test_publish_raises_after_retry_limit():
     with (
         mock.patch(
             "publish_crates.check_crate_version",
-            side_effect=[False] * (MAX_PUBLISH_ATTEMPTS * 2),
+            return_value=False,
+        ),
+        mock.patch(
+            "publish_crates.check_crate_version_for_polling", return_value=False
         ),
         mock.patch(
             "publish_crates._run_cargo_publish", return_value=failure
@@ -100,7 +157,10 @@ def test_publish_accepts_final_failed_upload_that_becomes_visible():
     with (
         mock.patch(
             "publish_crates.check_crate_version",
-            side_effect=[False] * (MAX_PUBLISH_ATTEMPTS * 2),
+            return_value=False,
+        ),
+        mock.patch(
+            "publish_crates.check_crate_version_for_polling", return_value=False
         ),
         mock.patch(
             "publish_crates._run_cargo_publish", return_value=failure
@@ -146,7 +206,10 @@ def test_publish_fails_when_successful_upload_never_becomes_visible():
 def test_publish_fails_fast_for_fatal_error():
     failure = cargo_result(101, "authentication failed")
     with (
-        mock.patch("publish_crates.check_crate_version", side_effect=[False, False]),
+        mock.patch("publish_crates.check_crate_version", return_value=False),
+        mock.patch(
+            "publish_crates.check_crate_version_for_polling", return_value=False
+        ),
         mock.patch("publish_crates._run_cargo_publish", return_value=failure),
         mock.patch("publish_crates.wait_until_version_seen") as wait_until_seen,
         mock.patch("publish_crates.time.sleep") as sleep,
@@ -161,7 +224,10 @@ def test_publish_fails_fast_for_fatal_error():
 def test_publish_accepts_duplicate_failure_that_becomes_visible():
     failure = cargo_result(101, "crate version is already uploaded")
     with (
-        mock.patch("publish_crates.check_crate_version", side_effect=[False, False]),
+        mock.patch("publish_crates.check_crate_version", return_value=False),
+        mock.patch(
+            "publish_crates.check_crate_version_for_polling", return_value=False
+        ),
         mock.patch("publish_crates._run_cargo_publish", return_value=failure),
         mock.patch(
             "publish_crates.wait_until_version_seen", return_value=True
@@ -175,7 +241,10 @@ def test_publish_accepts_duplicate_failure_that_becomes_visible():
 def test_publish_rejects_duplicate_failure_that_remains_absent():
     failure = cargo_result(101, "crate version is already uploaded")
     with (
-        mock.patch("publish_crates.check_crate_version", side_effect=[False, False]),
+        mock.patch("publish_crates.check_crate_version", return_value=False),
+        mock.patch(
+            "publish_crates.check_crate_version_for_polling", return_value=False
+        ),
         mock.patch("publish_crates._run_cargo_publish", return_value=failure),
         mock.patch("publish_crates.wait_until_version_seen", return_value=False),
     ):

--- a/scripts/publish_crates_test.py
+++ b/scripts/publish_crates_test.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+from unittest import mock
+
+import pytest
+
+from publish_crates import (
+    MAX_PUBLISH_ATTEMPTS,
+    PublishFailureKind,
+    _classify_publish_failure,
+    publish_crate_with_retries,
+)
+
+
+CRATE_NAME = "xlsynth-mcmc-pir"
+VERSION = "0.52.0"
+PACKAGE_DIR = "xlsynth-mcmc-pir"
+
+
+def cargo_result(returncode=0, stderr=""):
+    return subprocess.CompletedProcess(
+        ["cargo", "publish"],
+        returncode,
+        stdout="",
+        stderr=stderr,
+    )
+
+
+def publish_crate():
+    publish_crate_with_retries(CRATE_NAME, VERSION, PACKAGE_DIR)
+
+
+def test_publish_retries_transient_failure():
+    failure = cargo_result(101, "failed to get a 200 OK response, got 503")
+    with (
+        mock.patch(
+            "publish_crates.check_crate_version",
+            side_effect=[False, False, False],
+        ),
+        mock.patch(
+            "publish_crates._run_cargo_publish", side_effect=[failure, cargo_result()]
+        ) as run_publish,
+        mock.patch(
+            "publish_crates.wait_until_version_seen", side_effect=[False, True]
+        ) as wait_until_seen,
+        mock.patch("publish_crates.time.sleep") as sleep,
+    ):
+        publish_crate()
+
+    assert run_publish.call_count == 2
+    assert wait_until_seen.call_args_list == [
+        mock.call(CRATE_NAME, VERSION),
+        mock.call(CRATE_NAME, VERSION),
+    ]
+    sleep.assert_called_once()
+
+
+def test_publish_stops_retrying_when_failed_upload_becomes_visible():
+    failure = cargo_result(101, "failed to get a 200 OK response, got 503")
+    with (
+        mock.patch("publish_crates.check_crate_version", side_effect=[False, True]),
+        mock.patch(
+            "publish_crates._run_cargo_publish", return_value=failure
+        ) as run_publish,
+        mock.patch("publish_crates.wait_until_version_seen") as wait_until_seen,
+    ):
+        publish_crate()
+
+    run_publish.assert_called_once_with(PACKAGE_DIR)
+    wait_until_seen.assert_not_called()
+
+
+def test_publish_raises_after_retry_limit():
+    failure = cargo_result(101, "failed to get a 200 OK response, got 503")
+    with (
+        mock.patch(
+            "publish_crates.check_crate_version",
+            side_effect=[False] * (MAX_PUBLISH_ATTEMPTS * 2),
+        ),
+        mock.patch(
+            "publish_crates._run_cargo_publish", return_value=failure
+        ) as run_publish,
+        mock.patch(
+            "publish_crates.wait_until_version_seen", return_value=False
+        ) as wait_until_seen,
+        mock.patch("publish_crates.time.sleep") as sleep,
+    ):
+        with pytest.raises(subprocess.CalledProcessError):
+            publish_crate()
+
+    assert run_publish.call_count == MAX_PUBLISH_ATTEMPTS
+    assert wait_until_seen.call_count == MAX_PUBLISH_ATTEMPTS
+    assert sleep.call_count == MAX_PUBLISH_ATTEMPTS - 1
+
+
+def test_publish_accepts_final_failed_upload_that_becomes_visible():
+    failure = cargo_result(101, "failed to get a 200 OK response, got 503")
+    with (
+        mock.patch(
+            "publish_crates.check_crate_version",
+            side_effect=[False] * (MAX_PUBLISH_ATTEMPTS * 2),
+        ),
+        mock.patch(
+            "publish_crates._run_cargo_publish", return_value=failure
+        ) as run_publish,
+        mock.patch(
+            "publish_crates.wait_until_version_seen",
+            side_effect=[False, False, True],
+        ) as wait_until_seen,
+        mock.patch("publish_crates.time.sleep"),
+    ):
+        publish_crate()
+
+    assert run_publish.call_count == MAX_PUBLISH_ATTEMPTS
+    assert wait_until_seen.call_count == MAX_PUBLISH_ATTEMPTS
+
+
+def test_publish_skips_version_already_on_crates_io():
+    with (
+        mock.patch("publish_crates.check_crate_version", return_value=True),
+        mock.patch("publish_crates._run_cargo_publish") as run_publish,
+        mock.patch("publish_crates.wait_until_version_seen") as wait_until_seen,
+    ):
+        publish_crate()
+
+    run_publish.assert_not_called()
+    wait_until_seen.assert_not_called()
+
+
+def test_publish_fails_when_successful_upload_never_becomes_visible():
+    with (
+        mock.patch("publish_crates.check_crate_version", return_value=False),
+        mock.patch(
+            "publish_crates._run_cargo_publish", return_value=cargo_result()
+        ) as run_publish,
+        mock.patch("publish_crates.wait_until_version_seen", return_value=False),
+    ):
+        with pytest.raises(RuntimeError):
+            publish_crate()
+
+    run_publish.assert_called_once_with(PACKAGE_DIR)
+
+
+def test_publish_fails_fast_for_fatal_error():
+    failure = cargo_result(101, "authentication failed")
+    with (
+        mock.patch("publish_crates.check_crate_version", side_effect=[False, False]),
+        mock.patch("publish_crates._run_cargo_publish", return_value=failure),
+        mock.patch("publish_crates.wait_until_version_seen") as wait_until_seen,
+        mock.patch("publish_crates.time.sleep") as sleep,
+    ):
+        with pytest.raises(subprocess.CalledProcessError):
+            publish_crate()
+
+    wait_until_seen.assert_not_called()
+    sleep.assert_not_called()
+
+
+def test_publish_accepts_duplicate_failure_that_becomes_visible():
+    failure = cargo_result(101, "crate version is already uploaded")
+    with (
+        mock.patch("publish_crates.check_crate_version", side_effect=[False, False]),
+        mock.patch("publish_crates._run_cargo_publish", return_value=failure),
+        mock.patch(
+            "publish_crates.wait_until_version_seen", return_value=True
+        ) as wait_until_seen,
+    ):
+        publish_crate()
+
+    wait_until_seen.assert_called_once_with(CRATE_NAME, VERSION)
+
+
+def test_publish_rejects_duplicate_failure_that_remains_absent():
+    failure = cargo_result(101, "crate version is already uploaded")
+    with (
+        mock.patch("publish_crates.check_crate_version", side_effect=[False, False]),
+        mock.patch("publish_crates._run_cargo_publish", return_value=failure),
+        mock.patch("publish_crates.wait_until_version_seen", return_value=False),
+    ):
+        with pytest.raises(RuntimeError):
+            publish_crate()
+
+
+@pytest.mark.parametrize(
+    ("stderr", "expected"),
+    [
+        ("failed to get a 200 OK response, got 503", PublishFailureKind.TRANSIENT),
+        ("failed to get a 200 OK response, got 429", PublishFailureKind.TRANSIENT),
+        ("spurious network error: connection reset", PublishFailureKind.TRANSIENT),
+        ("crate version is already uploaded", PublishFailureKind.DUPLICATE),
+        ("authentication failed", PublishFailureKind.FATAL),
+    ],
+)
+def test_publish_failure_classification(stderr, expected):
+    assert _classify_publish_failure(cargo_result(101, stderr)) == expected

--- a/scripts/sleep_until_version_seen.py
+++ b/scripts/sleep_until_version_seen.py
@@ -8,6 +8,11 @@ import urllib.error
 from crates_io_index import crate_version_is_published
 
 
+POLL_INTERVAL_SECONDS = 15
+TIMEOUT_TOTAL_SECONDS = 5 * 60
+MAX_DOTS_BEFORE_NEWLINE = 60
+
+
 def check_crate_version(crate_name, version_wanted):
     """Return whether the crate version is visible in the sparse index."""
     return crate_version_is_published(crate_name, version_wanted)
@@ -35,6 +40,41 @@ def check_crate_version_for_polling(crate_name, version_wanted):
         return False
 
 
+def wait_until_version_seen(
+    crate_name,
+    version_wanted,
+    poll_interval_seconds=POLL_INTERVAL_SECONDS,
+    timeout_total_seconds=TIMEOUT_TOTAL_SECONDS,
+):
+    """Return whether a crate version becomes visible before the timeout."""
+    print(
+        f"Waiting for {crate_name} v{version_wanted} to appear in the crates.io sparse index (polling every {poll_interval_seconds}s, timeout: {timeout_total_seconds}s)...",
+        end="",
+        flush=True,
+    )
+
+    start_time = time.time()
+    iteration_count = 0
+    while True:
+        if check_crate_version_for_polling(crate_name, version_wanted):
+            print("\nVersion found!")
+            return True
+
+        current_time = time.time()
+        if current_time - start_time > timeout_total_seconds:
+            print(
+                f"\nTimeout reached after {int(current_time - start_time)} seconds. Version {version_wanted} of {crate_name} not found."
+            )
+            return False
+
+        time.sleep(poll_interval_seconds)
+        print(".", end="", flush=True)
+        iteration_count += 1
+        if iteration_count % MAX_DOTS_BEFORE_NEWLINE == 0:
+            print(f" [{int(time.time() - start_time)}s elapsed]", end="", flush=True)
+            print("\n", end="", flush=True)
+
+
 def main():
     if len(sys.argv) != 3:
         print(
@@ -45,42 +85,9 @@ def main():
     crate_name = sys.argv[1]
     version_wanted = sys.argv[2]
 
-    # Polling parameters
-    poll_interval_seconds = 15  # Check every 15 seconds
-    timeout_total_seconds = 5 * 60  # Total timeout of 5 minutes
-
-    print(
-        f"Waiting for {crate_name} v{version_wanted} to appear in the crates.io sparse index (polling every {poll_interval_seconds}s, timeout: {timeout_total_seconds}s)...",
-        end="",
-        flush=True,
-    )
-
-    start_time = time.time()
-    iteration_count = 0
-    max_dots_before_newline = 60  # Print a newline after this many dots
-
     try:
-        while True:
-            if check_crate_version_for_polling(crate_name, version_wanted):
-                print("\nVersion found!")
-                sys.exit(0)
-
-            current_time = time.time()
-            if current_time - start_time > timeout_total_seconds:
-                print(
-                    f"\nTimeout reached after {int(current_time - start_time)} seconds. Version {version_wanted} of {crate_name} not found."
-                )
-                sys.exit(1)
-
-            time.sleep(poll_interval_seconds)
-            print(".", end="", flush=True)
-            iteration_count += 1
-            if iteration_count % max_dots_before_newline == 0:
-                print(
-                    f" [{int(time.time() - start_time)}s elapsed]", end="", flush=True
-                )  # Optional: print elapsed time periodically
-                print("\n", end="", flush=True)  # Start new line for dots
-
+        if not wait_until_version_seen(crate_name, version_wanted):
+            sys.exit(1)
     except KeyboardInterrupt:
         print("\nPolling interrupted by user.")
         sys.exit(3)

--- a/scripts/sleep_until_version_seen_test.py
+++ b/scripts/sleep_until_version_seen_test.py
@@ -6,7 +6,10 @@ from unittest import mock
 
 import pytest
 
-from sleep_until_version_seen import check_crate_version_for_polling
+from sleep_until_version_seen import (
+    check_crate_version_for_polling,
+    wait_until_version_seen,
+)
 
 
 def test_polling_retries_transient_server_error(capsys):
@@ -30,3 +33,37 @@ def test_polling_does_not_retry_policy_error():
     with mock.patch("sleep_until_version_seen.check_crate_version", side_effect=error):
         with pytest.raises(urllib.error.HTTPError):
             check_crate_version_for_polling("xlsynth-sys", "0.51.1")
+
+
+def test_wait_until_version_seen_returns_when_version_appears():
+    with (
+        mock.patch(
+            "sleep_until_version_seen.check_crate_version_for_polling",
+            side_effect=[False, True],
+        ),
+        mock.patch("sleep_until_version_seen.time.sleep") as sleep,
+    ):
+        assert wait_until_version_seen(
+            "xlsynth-sys",
+            "0.51.1",
+            poll_interval_seconds=2,
+            timeout_total_seconds=10,
+        )
+
+    sleep.assert_called_once_with(2)
+
+
+def test_wait_until_version_seen_returns_false_after_timeout():
+    with (
+        mock.patch(
+            "sleep_until_version_seen.check_crate_version_for_polling",
+            return_value=False,
+        ),
+        mock.patch("sleep_until_version_seen.time.time", side_effect=[10, 21]),
+    ):
+        assert not wait_until_version_seen(
+            "xlsynth-sys",
+            "0.51.1",
+            poll_interval_seconds=2,
+            timeout_total_seconds=10,
+        )

--- a/xlsynth-test-helpers/tests/version_test.rs
+++ b/xlsynth-test-helpers/tests/version_test.rs
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Test that the current package version reflected in Cargo.toml is more than
-//! the released version -- this help make sure we bump the version
-//! appropriately after a release is performed.
+//! the released version -- this helps make sure we bump the version
+//! appropriately after a release is performed. A tagged publish workflow may
+//! allow equality for an exact version so a partial release can be resumed.
 //!
 //! This is done for all released crates in the workspace.
 
 use std::collections::BTreeMap;
 
 const USER_AGENT: &str = "xlsynth_crate_unit_test";
+const XLSYNTH_PUBLISH_VERSION: &str = "XLSYNTH_PUBLISH_VERSION";
 
 fn get_workspace_root() -> std::path::PathBuf {
     let workspace_dir = cargo_metadata::MetadataCommand::new()
@@ -104,13 +106,27 @@ fn validate_local_version_is_latest_patch_version(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Fetch the newest version for logging continuity with previous behavior.
     let local_version = fetch_local_version(workspace_path)?;
-    let local_semver = semver::Version::parse(&local_version)?;
 
     log::info!("crate: {crate_name} local_version: {local_version}");
     let latest_patches = get_latest_patch_versions(crate_name)?;
+    let publish_version = std::env::var(XLSYNTH_PUBLISH_VERSION).ok();
+    validate_local_version_against_latest_patches(
+        &local_version,
+        &latest_patches,
+        publish_version.as_deref(),
+    )
+}
 
+fn validate_local_version_against_latest_patches(
+    local_version: &str,
+    latest_patches: &BTreeMap<(u64, u64), u64>,
+    publish_version: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let local_semver = semver::Version::parse(local_version)?;
     if let Some(max_patch) = latest_patches.get(&(local_semver.major, local_semver.minor)) {
-        if local_semver.patch > *max_patch {
+        if local_semver.patch > *max_patch
+            || (local_semver.patch == *max_patch && publish_version == Some(local_version))
+        {
             Ok(())
         } else {
             Err(Box::new(std::io::Error::other(format!(
@@ -124,6 +140,51 @@ fn validate_local_version_is_latest_patch_version(
         // No released versions for this major.minor; vacuously the latest patch.
         Ok(())
     }
+}
+
+fn latest_patches(major: u64, minor: u64, patch: u64) -> BTreeMap<(u64, u64), u64> {
+    BTreeMap::from([((major, minor), patch)])
+}
+
+#[test]
+fn test_equal_patch_is_rejected_without_publish_version() {
+    let error =
+        validate_local_version_against_latest_patches("0.52.0", &latest_patches(0, 52, 0), None)
+            .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("Local version 0.52.0 must have a patch greater"));
+}
+
+#[test]
+fn test_equal_patch_is_accepted_for_exact_publish_version() {
+    validate_local_version_against_latest_patches(
+        "0.52.0",
+        &latest_patches(0, 52, 0),
+        Some("0.52.0"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_equal_patch_is_rejected_for_mismatched_publish_version() {
+    validate_local_version_against_latest_patches(
+        "0.52.0",
+        &latest_patches(0, 52, 0),
+        Some("0.52.1"),
+    )
+    .unwrap_err();
+}
+
+#[test]
+fn test_older_patch_is_rejected_for_exact_publish_version() {
+    validate_local_version_against_latest_patches(
+        "0.52.0",
+        &latest_patches(0, 52, 1),
+        Some("0.52.0"),
+    )
+    .unwrap_err();
 }
 
 #[test]


### PR DESCRIPTION
Make tag-triggered publication restartable after a partial crates.io release. The publisher skips exact crate versions already visible in the sparse index, retries recognized transient upload failures only after reconciling sparse-index visibility, and permits the exact tag version during the workflow version test.

For example, if crates A 0.52.1 and B 0.52.1 publish, then uploading C 0.52.1 returns HTTP 503, a rerun skips A and B and continues with C. If C became visible despite the 503, the publisher observes it and continues without uploading C again.

Pushed release tags are immutable: a rerun may skip an already-visible exact crate version based on sparse-index presence alone. Fix forward with a new patch tag instead of moving an existing tag.

Tests: release-helper pytest suite; xlsynth-test-helpers version tests.

<!-- spr-stack:start -->
**Stack**:
- ➡ #993

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->