### PR TITLE
Add support for cover/trace/assert to the ir compiler.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "xlsynth-driver",
     "xlsynth-estimator",
     "xlsynth-g8r",
+    "xlsynth-pir-compiler-runtime",
     "xlsynth-pir-compiler",
     "xlsynth-pir",
     "xlsynth-prover",

--- a/publish_order.toml
+++ b/publish_order.toml
@@ -6,6 +6,7 @@ crates = [
     "xlsynth",
     "xlsynth-vastly",
     "xlsynth-pir",
+    "xlsynth-pir-compiler-runtime",
     "xlsynth-pir-compiler",
     "xlsynth-mcmc",
     "xlsynth-prover",

--- a/xlsynth-pir-compiler-runtime/Cargo.toml
+++ b/xlsynth-pir-compiler-runtime/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "xlsynth-pir-compiler-runtime"
+version = "0.53.0"
+edition = "2024"
+authors = ["Christopher D. Leary <cdleary@gmail.com>"]
+description = "Runtime support for native compiled xlsynth PIR functions"
+license = "Apache-2.0"
+repository = "https://github.com/xlsynth/xlsynth-crate"
+documentation = "https://docs.rs/xlsynth"
+homepage = "https://github.com/xlsynth/xlsynth-crate"
+
+[lints]
+workspace = true
+
+[lib]
+name = "xlsynth_pir_compiler_runtime"
+path = "src/lib.rs"

--- a/xlsynth-pir-compiler-runtime/Cargo.toml
+++ b/xlsynth-pir-compiler-runtime/Cargo.toml
@@ -12,6 +12,9 @@ homepage = "https://github.com/xlsynth/xlsynth-crate"
 [lints]
 workspace = true
 
+[dependencies]
+num-bigint = "0.4.6"
+
 [lib]
 name = "xlsynth_pir_compiler_runtime"
 path = "src/lib.rs"

--- a/xlsynth-pir-compiler-runtime/src/lib.rs
+++ b/xlsynth-pir-compiler-runtime/src/lib.rs
@@ -6,6 +6,8 @@ use std::ffi::c_void;
 use std::marker::PhantomData;
 use std::ptr;
 
+use num_bigint::{BigInt, BigUint, Sign};
+
 /// Native compiled-function entrypoint shared by in-memory and AOT execution.
 pub type CompiledEntrypoint = unsafe extern "C" fn(
     inputs: *const *const u8,
@@ -101,6 +103,31 @@ pub struct ExecutionResult {
     pub trace_messages: Vec<TraceMessage>,
     pub cover_counts: Vec<CoverCount>,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TraceFormatPreference {
+    Default,
+    UnsignedDecimal,
+    SignedDecimal,
+    PlainHex,
+    ZeroPaddedHex,
+    Hex,
+    PlainBinary,
+    ZeroPaddedBinary,
+    Binary,
+}
+
+const TRACE_FORMAT_SPECIFIERS: [(&str, TraceFormatPreference); 9] = [
+    ("{}", TraceFormatPreference::Default),
+    ("{:u}", TraceFormatPreference::UnsignedDecimal),
+    ("{:d}", TraceFormatPreference::SignedDecimal),
+    ("{:x}", TraceFormatPreference::PlainHex),
+    ("{:0x}", TraceFormatPreference::ZeroPaddedHex),
+    ("{:#x}", TraceFormatPreference::Hex),
+    ("{:b}", TraceFormatPreference::PlainBinary),
+    ("{:0b}", TraceFormatPreference::ZeroPaddedBinary),
+    ("{:#b}", TraceFormatPreference::Binary),
+];
 
 struct ContextState {
     metadata: *const CompiledFunctionMetadata,
@@ -260,59 +287,84 @@ pub unsafe extern "C" fn xlsynth_pir_record_trace(
     if !site.operand_layouts.is_empty() && operand_ptrs.is_null() {
         return;
     }
-    let values = site
-        .operand_layouts
-        .iter()
-        .enumerate()
-        .map(|(index, layout)| {
-            // SAFETY: the generated caller supplies one pointer per metadata operand.
-            let pointer = unsafe { *operand_ptrs.add(index) };
-            // SAFETY: the pointer and recursively described native layout match.
-            unsafe { format_native_value(pointer, layout) }
-        })
-        .collect::<Vec<_>>();
     state.trace_messages.push(TraceMessage {
         node_text_id: site.node_text_id,
-        message: substitute_trace_values(site.format.as_deref().unwrap_or(""), &values),
+        // SAFETY: the generated caller supplies one pointer per metadata operand.
+        message: unsafe {
+            format_trace_message(
+                site.format.as_deref().unwrap_or(""),
+                &site.operand_layouts,
+                operand_ptrs,
+            )
+        },
         verbosity: 0,
     });
 }
 
-fn substitute_trace_values(format: &str, values: &[String]) -> String {
+/// Formats a trace message according to the XLS trace-format string syntax.
+unsafe fn format_trace_message(
+    format: &str,
+    layouts: &[TraceValueLayout],
+    operand_ptrs: *const *const u8,
+) -> String {
     let mut output = String::new();
-    let mut remainder = format;
-    let mut value_index = 0usize;
-    while let Some(index) = remainder.find("{}") {
-        output.push_str(&remainder[..index]);
-        if let Some(value) = values.get(value_index) {
-            output.push_str(value);
+    let mut offset = 0usize;
+    let mut operand_index = 0usize;
+    while offset < format.len() {
+        let remainder = &format[offset..];
+        if remainder.starts_with("{{") || remainder.starts_with("}}") {
+            // XLS preserves escaped braces in trace output; Verilog emission
+            // performs the collapse to single braces separately.
+            output.push_str(&remainder[..2]);
+            offset += 2;
+            continue;
         }
-        value_index += 1;
-        remainder = &remainder[index + 2..];
-    }
-    output.push_str(remainder);
-    if value_index < values.len() {
-        output.push_str(" [");
-        output.push_str(&values[value_index..].join(", "));
-        output.push(']');
+        if let Some((specifier, preference)) = TRACE_FORMAT_SPECIFIERS
+            .iter()
+            .find(|(specifier, _)| remainder.starts_with(specifier))
+        {
+            if let Some(layout) = layouts.get(operand_index) {
+                // SAFETY: callback ABI provides one matching pointer per layout.
+                let pointer = unsafe { *operand_ptrs.add(operand_index) };
+                // SAFETY: callback ABI specifies readable storage matching `layout`.
+                output.push_str(&unsafe { format_native_value(pointer, layout, *preference) });
+            }
+            operand_index += 1;
+            offset += specifier.len();
+            continue;
+        }
+        let character = remainder
+            .chars()
+            .next()
+            .expect("offset is within trace format string");
+        output.push(character);
+        offset += character.len_utf8();
     }
     output
 }
 
-unsafe fn format_native_value(pointer: *const u8, layout: &TraceValueLayout) -> String {
+/// Formats one caller-owned native value without constructing an XLS value.
+unsafe fn format_native_value(
+    pointer: *const u8,
+    layout: &TraceValueLayout,
+    preference: TraceFormatPreference,
+) -> String {
     match layout {
         TraceValueLayout::Bits {
             bit_count,
             byte_count,
         } => {
-            let mut bytes = [0u8; std::mem::size_of::<u64>()];
-            // SAFETY: callback ABI provides native scalar storage of this size.
-            unsafe { ptr::copy_nonoverlapping(pointer, bytes.as_mut_ptr(), *byte_count) };
-            let mut value = u64::from_ne_bytes(bytes);
-            if *bit_count < 64 {
-                value &= (1u64 << *bit_count) - 1;
+            let mut bytes = vec![0u8; *byte_count];
+            if *byte_count != 0 {
+                // SAFETY: callback ABI provides native scalar storage of this size.
+                unsafe { ptr::copy_nonoverlapping(pointer, bytes.as_mut_ptr(), *byte_count) };
             }
-            format!("bits[{bit_count}]:{value}")
+            let value = if cfg!(target_endian = "little") {
+                BigUint::from_bytes_le(&bytes)
+            } else {
+                BigUint::from_bytes_be(&bytes)
+            };
+            format_trace_bits(value, *bit_count, preference)
         }
         TraceValueLayout::Array {
             element,
@@ -325,6 +377,7 @@ unsafe fn format_native_value(pointer: *const u8, layout: &TraceValueLayout) -> 
                         format_native_value(
                             pointer.wrapping_add(index * element.byte_count()),
                             element,
+                            preference,
                         )
                     }
                 })
@@ -337,7 +390,11 @@ unsafe fn format_native_value(pointer: *const u8, layout: &TraceValueLayout) -> 
                 .map(|field| {
                     // SAFETY: each field offset is prescribed by native tuple metadata.
                     unsafe {
-                        format_native_value(pointer.wrapping_add(field.offset), &field.layout)
+                        format_native_value(
+                            pointer.wrapping_add(field.offset),
+                            &field.layout,
+                            preference,
+                        )
                     }
                 })
                 .collect::<Vec<_>>();
@@ -345,6 +402,81 @@ unsafe fn format_native_value(pointer: *const u8, layout: &TraceValueLayout) -> 
         }
         TraceValueLayout::Token => "token".to_string(),
     }
+}
+
+fn format_trace_bits(
+    mut value: BigUint,
+    bit_count: usize,
+    preference: TraceFormatPreference,
+) -> String {
+    if bit_count == 0 {
+        value = BigUint::from(0u8);
+    } else {
+        value &= (BigUint::from(1u8) << bit_count) - BigUint::from(1u8);
+    }
+    match preference {
+        TraceFormatPreference::Default => {
+            if bit_count <= 64 {
+                value.to_str_radix(10)
+            } else {
+                format_trace_bits(value, bit_count, TraceFormatPreference::Hex)
+            }
+        }
+        TraceFormatPreference::UnsignedDecimal => value.to_str_radix(10),
+        TraceFormatPreference::SignedDecimal => {
+            if bit_count != 0
+                && (&value & (BigUint::from(1u8) << (bit_count - 1))) != BigUint::from(0u8)
+            {
+                (BigInt::from_biguint(Sign::Plus, value)
+                    - BigInt::from_biguint(Sign::Plus, BigUint::from(1u8) << bit_count))
+                .to_string()
+            } else {
+                value.to_str_radix(10)
+            }
+        }
+        TraceFormatPreference::PlainHex => value.to_str_radix(16),
+        TraceFormatPreference::ZeroPaddedHex => {
+            zero_padded_grouped_digits(&value, bit_count, 4, 16)
+        }
+        TraceFormatPreference::Hex => {
+            format!("0x{}", grouped_digits(&value.to_str_radix(16)))
+        }
+        TraceFormatPreference::PlainBinary => value.to_str_radix(2),
+        TraceFormatPreference::ZeroPaddedBinary => {
+            zero_padded_grouped_digits(&value, bit_count, 1, 2)
+        }
+        TraceFormatPreference::Binary => {
+            format!("0b{}", grouped_digits(&value.to_str_radix(2)))
+        }
+    }
+}
+
+fn zero_padded_grouped_digits(
+    value: &BigUint,
+    bit_count: usize,
+    bits_per_digit: usize,
+    radix: u32,
+) -> String {
+    let digit_count = bit_count.div_ceil(bits_per_digit).max(1);
+    let digits = format!(
+        "{:0>width$}",
+        value.to_str_radix(radix),
+        width = digit_count
+    );
+    grouped_digits(&digits)
+}
+
+fn grouped_digits(digits: &str) -> String {
+    let first_group_width = match digits.len() % 4 {
+        0 => 4,
+        remainder => remainder,
+    };
+    let mut result = digits[..first_group_width].to_string();
+    for group_start in (first_group_width..digits.len()).step_by(4) {
+        result.push('_');
+        result.push_str(&digits[group_start..group_start + 4]);
+    }
+    result
 }
 
 impl TraceValueLayout {
@@ -443,9 +575,71 @@ mod tests {
         array[0] = 91;
         assert_eq!(scalar, 90);
         assert_eq!(array[0], 91);
+        assert_eq!(context.result().trace_messages[0].message, "x=7 arr=[2, 3]");
+    }
+
+    #[test]
+    fn trace_callback_formats_all_specifiers_and_wide_decimal_without_xls() {
+        let twelve_bits = TraceValueLayout::Bits {
+            bit_count: 12,
+            byte_count: 2,
+        };
+        let metadata = CompiledFunctionMetadata {
+            event_sites: vec![EventSiteMetadata {
+                node_text_id: 20,
+                kind: EventKind::Trace,
+                label: None,
+                message: None,
+                format: Some(
+                    "literal={{ default={} u={:u} d={:d} x={:x} 0x={:0x} #x={:#x} b={:b} 0b={:0b} #b={:#b} wide={} wide_u={:u}".to_string(),
+                ),
+                operand_layouts: vec![
+                    twelve_bits.clone(),
+                    twelve_bits.clone(),
+                    TraceValueLayout::Bits {
+                        bit_count: 8,
+                        byte_count: 1,
+                    },
+                    twelve_bits.clone(),
+                    twelve_bits.clone(),
+                    twelve_bits.clone(),
+                    twelve_bits.clone(),
+                    twelve_bits.clone(),
+                    twelve_bits,
+                    TraceValueLayout::Bits {
+                        bit_count: 72,
+                        byte_count: 9,
+                    },
+                    TraceValueLayout::Bits {
+                        bit_count: 72,
+                        byte_count: 9,
+                    },
+                ],
+            }],
+        };
+        let mut context = ExecutionContext::new(&metadata);
+        let mut raw = context.raw_context();
+        let twelve = 43u16;
+        let negative = 251u8;
+        let wide = [1u8, 0, 0, 0, 0, 0, 0, 0, 1];
+        let operands = [
+            ptr::from_ref(&twelve).cast::<u8>(),
+            ptr::from_ref(&twelve).cast::<u8>(),
+            ptr::from_ref(&negative).cast::<u8>(),
+            ptr::from_ref(&twelve).cast::<u8>(),
+            ptr::from_ref(&twelve).cast::<u8>(),
+            ptr::from_ref(&twelve).cast::<u8>(),
+            ptr::from_ref(&twelve).cast::<u8>(),
+            ptr::from_ref(&twelve).cast::<u8>(),
+            ptr::from_ref(&twelve).cast::<u8>(),
+            ptr::from_ref(&wide).cast::<u8>(),
+            ptr::from_ref(&wide).cast::<u8>(),
+        ];
+        // SAFETY: operands use the native layouts specified by trace metadata.
+        unsafe { xlsynth_pir_record_trace(&mut raw, 0, operands.as_ptr()) };
         assert_eq!(
             context.result().trace_messages[0].message,
-            "x=bits[8]:7 arr=[bits[8]:2, bits[8]:3]"
+            "literal={{ default=43 u=43 d=-5 x=2b 0x=02b #x=0x2b b=101011 0b=0000_0010_1011 #b=0b10_1011 wide=0x1_0000_0000_0000_0001 wide_u=18446744073709551617"
         );
     }
 

--- a/xlsynth-pir-compiler-runtime/src/lib.rs
+++ b/xlsynth-pir-compiler-runtime/src/lib.rs
@@ -1,0 +1,465 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runtime ABI and observable-event collection for compiled PIR functions.
+
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::ptr;
+
+/// Native compiled-function entrypoint shared by in-memory and AOT execution.
+pub type CompiledEntrypoint = unsafe extern "C" fn(
+    inputs: *const *const u8,
+    output: *mut u8,
+    scratch: *mut u8,
+    context: *mut RawExecutionContext,
+) -> i32;
+
+/// Opaque execution context forwarded by compiled code to runtime callbacks.
+#[repr(C)]
+pub struct RawExecutionContext {
+    private_state: *mut c_void,
+}
+
+/// Kind of observable PIR event described by an event site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventKind {
+    Assert,
+    Cover,
+    Trace,
+}
+
+/// Native data description sufficient for immediate trace-value decoding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TraceValueLayout {
+    Bits {
+        bit_count: usize,
+        byte_count: usize,
+    },
+    Array {
+        element: Box<TraceValueLayout>,
+        element_count: usize,
+    },
+    Tuple {
+        fields: Vec<TraceTupleFieldLayout>,
+        byte_count: usize,
+    },
+    Token,
+}
+
+/// Description of one tuple field supplied as a trace operand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceTupleFieldLayout {
+    pub layout: Box<TraceValueLayout>,
+    pub offset: usize,
+}
+
+/// Static information attached to one observable node in compiled code.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventSiteMetadata {
+    pub node_text_id: usize,
+    pub kind: EventKind,
+    pub label: Option<String>,
+    pub message: Option<String>,
+    pub format: Option<String>,
+    pub operand_layouts: Vec<TraceValueLayout>,
+}
+
+/// Runtime metadata for all observable sites in one compiled function.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CompiledFunctionMetadata {
+    pub event_sites: Vec<EventSiteMetadata>,
+}
+
+/// A failed compiled assertion, resolved to its source-site metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssertionFailure {
+    pub node_text_id: usize,
+    pub message: String,
+    pub label: String,
+}
+
+/// One emitted compiled trace statement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceMessage {
+    pub node_text_id: usize,
+    pub message: String,
+    pub verbosity: i64,
+}
+
+/// Accumulated execution count for a compiled `cover` site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoverCount {
+    pub node_text_id: usize,
+    pub label: String,
+    pub count: u64,
+}
+
+/// Rust-owned observable results recorded while executing compiled code.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ExecutionResult {
+    pub assertion_failures: Vec<AssertionFailure>,
+    pub trace_messages: Vec<TraceMessage>,
+    pub cover_counts: Vec<CoverCount>,
+}
+
+struct ContextState {
+    metadata: *const CompiledFunctionMetadata,
+    assertion_failures: Vec<AssertionFailure>,
+    trace_messages: Vec<TraceMessage>,
+    event_counts: Vec<u64>,
+}
+
+/// Rust-owned event collector used for one or more compiled executions.
+///
+/// Cover counts accumulate until [`Self::clear`] is called. Assertion and
+/// trace messages also accumulate, permitting callers to consume a batch of
+/// invocations through one context.
+pub struct ExecutionContext<'metadata> {
+    state: Box<ContextState>,
+    marker: PhantomData<&'metadata CompiledFunctionMetadata>,
+}
+
+impl<'metadata> ExecutionContext<'metadata> {
+    /// Creates an empty collector for the supplied function metadata.
+    pub fn new(metadata: &'metadata CompiledFunctionMetadata) -> Self {
+        Self {
+            state: Box::new(ContextState {
+                metadata,
+                assertion_failures: Vec::new(),
+                trace_messages: Vec::new(),
+                event_counts: vec![0; metadata.event_sites.len()],
+            }),
+            marker: PhantomData,
+        }
+    }
+
+    /// Returns an opaque ABI object valid while this context is mutably
+    /// borrowed.
+    pub fn raw_context(&mut self) -> RawExecutionContext {
+        RawExecutionContext {
+            private_state: ptr::from_mut(self.state.as_mut()).cast(),
+        }
+    }
+
+    /// Resolves all currently recorded events into ordinary Rust values.
+    pub fn result(&self) -> ExecutionResult {
+        let metadata = self.metadata();
+        let cover_counts = metadata
+            .event_sites
+            .iter()
+            .zip(&self.state.event_counts)
+            .filter(|(site, _)| site.kind == EventKind::Cover)
+            .map(|(site, count)| CoverCount {
+                node_text_id: site.node_text_id,
+                label: site.label.clone().unwrap_or_default(),
+                count: *count,
+            })
+            .collect();
+        ExecutionResult {
+            assertion_failures: self.state.assertion_failures.clone(),
+            trace_messages: self.state.trace_messages.clone(),
+            cover_counts,
+        }
+    }
+
+    /// Clears all event records and accumulated cover counters.
+    pub fn clear(&mut self) {
+        self.state.assertion_failures.clear();
+        self.state.trace_messages.clear();
+        self.state.event_counts.fill(0);
+    }
+
+    fn metadata(&self) -> &CompiledFunctionMetadata {
+        // SAFETY: the context's lifetime guarantees metadata remains alive.
+        unsafe { &*self.state.metadata }
+    }
+}
+
+unsafe fn state_from_raw<'a>(context: *mut RawExecutionContext) -> &'a mut ContextState {
+    assert!(
+        !context.is_null(),
+        "compiled PIR callback requires an execution context"
+    );
+    // SAFETY: generated entrypoints receive a `RawExecutionContext` produced
+    // by `ExecutionContext::raw_context` for the duration of the call.
+    unsafe {
+        (*context)
+            .private_state
+            .cast::<ContextState>()
+            .as_mut()
+            .expect("compiled PIR callback received an invalid execution context")
+    }
+}
+
+fn site(state: &ContextState, site_id: u32, kind: EventKind) -> Option<&EventSiteMetadata> {
+    // SAFETY: the owning `ExecutionContext` keeps metadata alive.
+    let metadata = unsafe { state.metadata.as_ref()? };
+    let site = metadata.event_sites.get(site_id as usize)?;
+    (site.kind == kind).then_some(site)
+}
+
+/// Records a failed assertion from generated code.
+///
+/// # Safety
+///
+/// `context` must point to an active raw context created by
+/// [`ExecutionContext::raw_context`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xlsynth_pir_record_assert(
+    context: *mut RawExecutionContext,
+    site_id: u32,
+) {
+    // SAFETY: forwarded from the caller's ABI contract.
+    let state = unsafe { state_from_raw(context) };
+    let Some(site) = site(state, site_id, EventKind::Assert).cloned() else {
+        return;
+    };
+    state.assertion_failures.push(AssertionFailure {
+        node_text_id: site.node_text_id,
+        message: site.message.unwrap_or_default(),
+        label: site.label.unwrap_or_default(),
+    });
+}
+
+/// Records one active cover occurrence from generated code.
+///
+/// # Safety
+///
+/// `context` must point to an active raw context created by
+/// [`ExecutionContext::raw_context`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xlsynth_pir_record_cover(context: *mut RawExecutionContext, site_id: u32) {
+    // SAFETY: forwarded from the caller's ABI contract.
+    let state = unsafe { state_from_raw(context) };
+    if site(state, site_id, EventKind::Cover).is_some() {
+        if let Some(count) = state.event_counts.get_mut(site_id as usize) {
+            *count = count.saturating_add(1);
+        }
+    }
+}
+
+/// Records and formats one active trace occurrence from generated code.
+///
+/// # Safety
+///
+/// `context` must point to an active raw context created by
+/// [`ExecutionContext::raw_context`]. Each operand pointer must describe
+/// readable native storage matching the corresponding site's operand layout
+/// for the duration of this callback.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xlsynth_pir_record_trace(
+    context: *mut RawExecutionContext,
+    site_id: u32,
+    operand_ptrs: *const *const u8,
+) {
+    // SAFETY: forwarded from the caller's ABI contract.
+    let state = unsafe { state_from_raw(context) };
+    let Some(site) = site(state, site_id, EventKind::Trace).cloned() else {
+        return;
+    };
+    if !site.operand_layouts.is_empty() && operand_ptrs.is_null() {
+        return;
+    }
+    let values = site
+        .operand_layouts
+        .iter()
+        .enumerate()
+        .map(|(index, layout)| {
+            // SAFETY: the generated caller supplies one pointer per metadata operand.
+            let pointer = unsafe { *operand_ptrs.add(index) };
+            // SAFETY: the pointer and recursively described native layout match.
+            unsafe { format_native_value(pointer, layout) }
+        })
+        .collect::<Vec<_>>();
+    state.trace_messages.push(TraceMessage {
+        node_text_id: site.node_text_id,
+        message: substitute_trace_values(site.format.as_deref().unwrap_or(""), &values),
+        verbosity: 0,
+    });
+}
+
+fn substitute_trace_values(format: &str, values: &[String]) -> String {
+    let mut output = String::new();
+    let mut remainder = format;
+    let mut value_index = 0usize;
+    while let Some(index) = remainder.find("{}") {
+        output.push_str(&remainder[..index]);
+        if let Some(value) = values.get(value_index) {
+            output.push_str(value);
+        }
+        value_index += 1;
+        remainder = &remainder[index + 2..];
+    }
+    output.push_str(remainder);
+    if value_index < values.len() {
+        output.push_str(" [");
+        output.push_str(&values[value_index..].join(", "));
+        output.push(']');
+    }
+    output
+}
+
+unsafe fn format_native_value(pointer: *const u8, layout: &TraceValueLayout) -> String {
+    match layout {
+        TraceValueLayout::Bits {
+            bit_count,
+            byte_count,
+        } => {
+            let mut bytes = [0u8; std::mem::size_of::<u64>()];
+            // SAFETY: callback ABI provides native scalar storage of this size.
+            unsafe { ptr::copy_nonoverlapping(pointer, bytes.as_mut_ptr(), *byte_count) };
+            let mut value = u64::from_ne_bytes(bytes);
+            if *bit_count < 64 {
+                value &= (1u64 << *bit_count) - 1;
+            }
+            format!("bits[{bit_count}]:{value}")
+        }
+        TraceValueLayout::Array {
+            element,
+            element_count,
+        } => {
+            let elements = (0..*element_count)
+                .map(|index| {
+                    // SAFETY: each element is within the caller-provided array region.
+                    unsafe {
+                        format_native_value(
+                            pointer.wrapping_add(index * element.byte_count()),
+                            element,
+                        )
+                    }
+                })
+                .collect::<Vec<_>>();
+            format!("[{}]", elements.join(", "))
+        }
+        TraceValueLayout::Tuple { fields, .. } => {
+            let fields = fields
+                .iter()
+                .map(|field| {
+                    // SAFETY: each field offset is prescribed by native tuple metadata.
+                    unsafe {
+                        format_native_value(pointer.wrapping_add(field.offset), &field.layout)
+                    }
+                })
+                .collect::<Vec<_>>();
+            format!("({})", fields.join(", "))
+        }
+        TraceValueLayout::Token => "token".to_string(),
+    }
+}
+
+impl TraceValueLayout {
+    fn byte_count(&self) -> usize {
+        match self {
+            Self::Bits { byte_count, .. } => *byte_count,
+            Self::Array {
+                element,
+                element_count,
+            } => element.byte_count() * element_count,
+            Self::Tuple { byte_count, .. } => *byte_count,
+            Self::Token => 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata() -> CompiledFunctionMetadata {
+        CompiledFunctionMetadata {
+            event_sites: vec![
+                EventSiteMetadata {
+                    node_text_id: 10,
+                    kind: EventKind::Cover,
+                    label: Some("covered".to_string()),
+                    message: None,
+                    format: None,
+                    operand_layouts: Vec::new(),
+                },
+                EventSiteMetadata {
+                    node_text_id: 11,
+                    kind: EventKind::Assert,
+                    label: Some("assert_label".to_string()),
+                    message: Some("failed".to_string()),
+                    format: None,
+                    operand_layouts: Vec::new(),
+                },
+                EventSiteMetadata {
+                    node_text_id: 12,
+                    kind: EventKind::Trace,
+                    label: None,
+                    message: None,
+                    format: Some("x={} arr={}".to_string()),
+                    operand_layouts: vec![
+                        TraceValueLayout::Bits {
+                            bit_count: 8,
+                            byte_count: 1,
+                        },
+                        TraceValueLayout::Array {
+                            element: Box::new(TraceValueLayout::Bits {
+                                bit_count: 8,
+                                byte_count: 1,
+                            }),
+                            element_count: 2,
+                        },
+                    ],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn cover_and_assert_callbacks_collect_rust_owned_results() {
+        let metadata = metadata();
+        let mut context = ExecutionContext::new(&metadata);
+        let mut raw = context.raw_context();
+        // SAFETY: `raw` points into `context` for these immediate calls.
+        unsafe {
+            xlsynth_pir_record_cover(&mut raw, 0);
+            xlsynth_pir_record_cover(&mut raw, 0);
+            xlsynth_pir_record_assert(&mut raw, 1);
+        }
+        let result = context.result();
+        assert_eq!(result.cover_counts[0].count, 2);
+        assert_eq!(result.cover_counts[0].label, "covered");
+        assert_eq!(result.assertion_failures[0].message, "failed");
+        assert_eq!(result.assertion_failures[0].label, "assert_label");
+    }
+
+    #[test]
+    fn trace_callback_decodes_values_before_native_storage_changes() {
+        let metadata = metadata();
+        let mut context = ExecutionContext::new(&metadata);
+        let mut raw = context.raw_context();
+        let mut scalar = 7u8;
+        let mut array = [2u8, 3u8];
+        let operands = [
+            ptr::from_ref(&scalar).cast::<u8>(),
+            ptr::from_ref(&array).cast::<u8>(),
+        ];
+        // SAFETY: operands use the native layouts specified by trace metadata.
+        unsafe { xlsynth_pir_record_trace(&mut raw, 2, operands.as_ptr()) };
+        scalar = 90;
+        array[0] = 91;
+        assert_eq!(scalar, 90);
+        assert_eq!(array[0], 91);
+        assert_eq!(
+            context.result().trace_messages[0].message,
+            "x=bits[8]:7 arr=[bits[8]:2, bits[8]:3]"
+        );
+    }
+
+    #[test]
+    fn clear_resets_accumulated_event_results() {
+        let metadata = metadata();
+        let mut context = ExecutionContext::new(&metadata);
+        let mut raw = context.raw_context();
+        // SAFETY: `raw` points into `context` for this immediate call.
+        unsafe { xlsynth_pir_record_cover(&mut raw, 0) };
+        context.clear();
+        let result = context.result();
+        assert!(result.assertion_failures.is_empty());
+        assert!(result.trace_messages.is_empty());
+        assert_eq!(result.cover_counts[0].count, 0);
+    }
+}

--- a/xlsynth-pir-compiler/Cargo.toml
+++ b/xlsynth-pir-compiler/Cargo.toml
@@ -20,6 +20,7 @@ cranelift-module = "0.132.0"
 thiserror = "1"
 xlsynth = { path = "../xlsynth", version = "0.53.0" }
 xlsynth-pir = { path = "../xlsynth-pir", version = "0.53.0" }
+xlsynth-pir-compiler-runtime = { path = "../xlsynth-pir-compiler-runtime", version = "0.53.0" }
 
 [lib]
 name = "xlsynth_pir_compiler"

--- a/xlsynth-pir-compiler/fuzz/FUZZ.md
+++ b/xlsynth-pir-compiler/fuzz/FUZZ.md
@@ -34,15 +34,19 @@ Run:
 cargo fuzz run fuzz_pir_function_jit_aggregate_eval_equiv
 ```
 
-This target expands the same differential property to native aggregates,
+This target expands the same differential property to native aggregates and
+observable function events,
 including multidimensional arrays, nested tuples, aggregate construction and
 indexing, aggregate equality/inequality, aggregate-valued gate or selection
 results, and default-only `sel` nodes. It also exercises tuple-valued
 extension results such as `ext_normalize_left` and XLS partial-product
-multiply tuples.
+multiply tuples, along with `after_all`, `cover`, `assert`, and `trace`.
+Observable event results are compared as unordered multisets because independent
+event nodes are not semantically ordered unless their token dependencies require it.
 
 Main additional failure modes surfaced:
 
 - Incorrect native array stride or `#[repr(C)]`-compatible tuple field layout.
 - Incorrect scratch materialization or recursive copying of aggregate values.
 - Incorrect out-of-bounds semantics for native array slice/update/index nodes.
+- Divergent assertion, trace, or cover callback behavior.

--- a/xlsynth-pir-compiler/fuzz/fuzz_targets/fuzz_pir_function_jit_aggregate_eval_equiv.rs
+++ b/xlsynth-pir-compiler/fuzz/fuzz_targets/fuzz_pir_function_jit_aggregate_eval_equiv.rs
@@ -10,6 +10,11 @@ use xlsynth_pir::ir_random::{
 };
 use xlsynth_pir_compiler::PirFunctionJit;
 
+fn sorted<T: Ord>(mut values: Vec<T>) -> Vec<T> {
+    values.sort();
+    values
+}
+
 fn options() -> RandomFnOptions {
     RandomFnOptions {
         max_params: 5,
@@ -21,6 +26,7 @@ fn options() -> RandomFnOptions {
         allow_extension_ops: true,
         allow_arbitrary_width_multiply: true,
         allow_empty_case_sel: true,
+        allow_events: true,
         enabled_operations: OperationSet::new([
             RandomOperation::Literal,
             RandomOperation::Identity,
@@ -84,6 +90,10 @@ fn options() -> RandomFnOptions {
             RandomOperation::ExtNormalizeLeft,
             RandomOperation::ExtMaskLow,
             RandomOperation::ExtNaryAdd,
+            RandomOperation::AfterAll,
+            RandomOperation::Cover,
+            RandomOperation::Assert,
+            RandomOperation::Trace,
         ]),
         ..RandomFnOptions::default()
     }
@@ -103,15 +113,112 @@ fuzz_target!(|data: &[u8]| {
         .unwrap_or_else(|error| panic!("JIT compilation failed for generated IR:\n{ir_text}\n{error}"));
     let mut argument_entropy = DepletableBytes::new(data);
     let args = generate_arguments(&mut argument_entropy, function);
-    let expected = match eval_fn(function, &args) {
-        FnEvalResult::Success(success) => success.value,
-        other => panic!("PIR evaluator failed for generated IR:\n{ir_text}\n{other:?}"),
-    };
+    let expected = eval_fn(function, &args);
     let actual = jit
-        .run_ir_values(&args)
+        .run_ir_values_with_events(&args)
         .unwrap_or_else(|error| panic!("JIT execution failed:\n{ir_text}\n{error}"));
-    assert_eq!(
-        actual, expected,
-        "PIR JIT/evaluator mismatch\nIR:\n{ir_text}\nargs={args:?}"
-    );
+    match expected {
+        FnEvalResult::Success(expected) => {
+            assert_eq!(
+                actual.value, expected.value,
+                "PIR compiler/evaluator value mismatch\nIR:\n{ir_text}\nargs={args:?}"
+            );
+            assert!(
+                actual.events.assertion_failures.is_empty(),
+                "compiler unexpectedly reported assertions\nIR:\n{ir_text}\nargs={args:?}"
+            );
+            assert_eq!(
+                sorted(
+                    actual
+                        .events
+                        .trace_messages
+                        .iter()
+                        .map(|trace| (trace.message.clone(), trace.verbosity))
+                        .collect()
+                ),
+                sorted(
+                    expected
+                        .trace_messages
+                        .iter()
+                        .map(|trace| (trace.message.clone(), trace.verbosity))
+                        .collect()
+                ),
+                "PIR compiler/evaluator trace mismatch\nIR:\n{ir_text}\nargs={args:?}"
+            );
+            assert_eq!(
+                sorted(
+                    actual
+                        .events
+                        .cover_counts
+                        .iter()
+                        .map(|cover| (cover.node_text_id, cover.label.clone(), cover.count))
+                        .collect()
+                ),
+                sorted(
+                    expected
+                        .cover_counts
+                        .iter()
+                        .map(|cover| (cover.node_text_id, cover.label.clone(), cover.count))
+                        .collect()
+                ),
+                "PIR compiler/evaluator cover mismatch\nIR:\n{ir_text}\nargs={args:?}"
+            );
+        }
+        FnEvalResult::Failure(expected) => {
+            assert_eq!(
+                sorted(
+                    actual
+                        .events
+                        .assertion_failures
+                        .iter()
+                        .map(|failure| (failure.message.clone(), failure.label.clone()))
+                        .collect()
+                ),
+                sorted(
+                    expected
+                        .assertion_failures
+                        .iter()
+                        .map(|failure| (failure.message.clone(), failure.label.clone()))
+                        .collect()
+                ),
+                "PIR compiler/evaluator assertion mismatch\nIR:\n{ir_text}\nargs={args:?}"
+            );
+            assert_eq!(
+                sorted(
+                    actual
+                        .events
+                        .trace_messages
+                        .iter()
+                        .map(|trace| (trace.message.clone(), trace.verbosity))
+                        .collect()
+                ),
+                sorted(
+                    expected
+                        .trace_messages
+                        .iter()
+                        .map(|trace| (trace.message.clone(), trace.verbosity))
+                        .collect()
+                ),
+                "PIR compiler/evaluator failing-trace mismatch\nIR:\n{ir_text}\nargs={args:?}"
+            );
+            assert_eq!(
+                sorted(
+                    actual
+                        .events
+                        .cover_counts
+                        .iter()
+                        .map(|cover| (cover.node_text_id, cover.label.clone(), cover.count))
+                        .collect()
+                ),
+                sorted(
+                    expected
+                        .cover_counts
+                        .iter()
+                        .map(|cover| (cover.node_text_id, cover.label.clone(), cover.count))
+                        .collect()
+                ),
+                "PIR compiler/evaluator failing-cover mismatch\nIR:\n{ir_text}\nargs={args:?}"
+            );
+        }
+    }
 });

--- a/xlsynth-pir-compiler/src/lib.rs
+++ b/xlsynth-pir-compiler/src/lib.rs
@@ -6,17 +6,26 @@ use std::collections::{HashMap, HashSet};
 use std::ptr;
 
 use cranelift_codegen::ir::condcodes::IntCC;
-use cranelift_codegen::ir::{AbiParam, InstBuilder, MemFlags, Type as ClifType, Value, types};
+use cranelift_codegen::ir::{
+    AbiParam, FuncRef, InstBuilder, MemFlags, Type as ClifType, Value, types,
+};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{Linkage, Module, default_libcall_names};
 use thiserror::Error;
 use xlsynth::IrValue;
 use xlsynth_pir::ir::{self, Binop, NaryOp, NodePayload, NodeRef, Type, Unop};
-use xlsynth_pir::ir_utils::{get_topological, operands};
+use xlsynth_pir::ir_utils::{get_topological, is_observable_effect_root, operands};
+pub use xlsynth_pir_compiler_runtime::{
+    AssertionFailure, CompiledEntrypoint, CompiledFunctionMetadata, CoverCount, EventKind,
+    EventSiteMetadata, ExecutionContext, ExecutionResult, RawExecutionContext, TraceMessage,
+    TraceTupleFieldLayout, TraceValueLayout,
+};
+use xlsynth_pir_compiler_runtime::{
+    xlsynth_pir_record_assert, xlsynth_pir_record_cover, xlsynth_pir_record_trace,
+};
 
-type NativeEntrypoint =
-    unsafe extern "C" fn(inputs: *const *const u8, output: *mut u8, scratch: *mut u8) -> i32;
+type NativeEntrypoint = CompiledEntrypoint;
 
 /// Describes the native scalar carrier used for one bits-typed PIR value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -110,6 +119,8 @@ pub enum NativeValueLayout {
         /// Required alignment for the struct.
         alignment: usize,
     },
+    /// A zero-sized token used only for event ordering.
+    Token,
 }
 
 /// Describes one field in a native C-compatible PIR tuple layout.
@@ -169,7 +180,7 @@ impl NativeValueLayout {
                     alignment,
                 })
             }
-            Type::Token => Err(JitError::UnsupportedType(ty.to_string())),
+            Type::Token => Ok(Self::Token),
         }
     }
 
@@ -182,6 +193,7 @@ impl NativeValueLayout {
                 element_count,
             } => element.byte_count() * element_count,
             Self::Tuple { byte_count, .. } => *byte_count,
+            Self::Token => 0,
         }
     }
 
@@ -191,6 +203,7 @@ impl NativeValueLayout {
             Self::Scalar(layout) => layout.byte_count,
             Self::Array { element, .. } => element.alignment(),
             Self::Tuple { alignment, .. } => *alignment,
+            Self::Token => 1,
         }
     }
 
@@ -198,7 +211,7 @@ impl NativeValueLayout {
     pub fn element_stride(&self) -> Option<usize> {
         match self {
             Self::Array { element, .. } => Some(element.byte_count()),
-            Self::Scalar(_) | Self::Tuple { .. } => None,
+            Self::Scalar(_) | Self::Tuple { .. } | Self::Token => None,
         }
     }
 
@@ -206,7 +219,7 @@ impl NativeValueLayout {
     pub fn as_scalar(&self) -> Option<ScalarLayout> {
         match self {
             Self::Scalar(layout) => Some(*layout),
-            Self::Array { .. } | Self::Tuple { .. } => None,
+            Self::Array { .. } | Self::Tuple { .. } | Self::Token => None,
         }
     }
 }
@@ -256,8 +269,16 @@ pub struct PirFunctionJit {
     entrypoint: NativeEntrypoint,
     param_layouts: Vec<NativeValueLayout>,
     result_layout: NativeValueLayout,
+    metadata: CompiledFunctionMetadata,
     scratch_byte_count: usize,
     scratch_alignment: usize,
+}
+
+/// Value and observable events produced by one dynamic-value execution.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IrExecutionResult {
+    pub value: IrValue,
+    pub events: ExecutionResult,
 }
 
 impl PirFunctionJit {
@@ -280,12 +301,26 @@ impl PirFunctionJit {
             NativeValueLayout::from_type(&function.get_node(*node_ref).ty)?;
         }
         let scratch_plan = ScratchPlan::for_function(function, &order)?;
+        let (metadata, event_sites) = build_event_metadata(function, &order)?;
 
-        let builder = JITBuilder::new(default_libcall_names())
+        let mut builder = JITBuilder::new(default_libcall_names())
             .map_err(|error| JitError::Backend(error.to_string()))?;
+        builder.symbol(
+            "xlsynth_pir_record_assert",
+            xlsynth_pir_record_assert as *const u8,
+        );
+        builder.symbol(
+            "xlsynth_pir_record_cover",
+            xlsynth_pir_record_cover as *const u8,
+        );
+        builder.symbol(
+            "xlsynth_pir_record_trace",
+            xlsynth_pir_record_trace as *const u8,
+        );
         let mut module = JITModule::new(builder);
         let pointer_type = module.target_config().pointer_type();
         let mut signature = module.make_signature();
+        signature.params.push(AbiParam::new(pointer_type));
         signature.params.push(AbiParam::new(pointer_type));
         signature.params.push(AbiParam::new(pointer_type));
         signature.params.push(AbiParam::new(pointer_type));
@@ -296,6 +331,8 @@ impl PirFunctionJit {
             .map_err(|error| JitError::Backend(error.to_string()))?;
         let mut context = module.make_context();
         context.func.signature = signature;
+        let runtime_callbacks =
+            declare_runtime_callbacks(&mut module, &mut context.func, pointer_type)?;
 
         let mut function_builder_context = FunctionBuilderContext::new();
         {
@@ -306,6 +343,8 @@ impl PirFunctionJit {
                 &order,
                 &param_layouts,
                 &scratch_plan,
+                &event_sites,
+                runtime_callbacks,
                 pointer_type,
                 &mut function_builder,
             )?;
@@ -329,6 +368,7 @@ impl PirFunctionJit {
             entrypoint,
             param_layouts,
             result_layout,
+            metadata,
             scratch_byte_count: scratch_plan.byte_count,
             scratch_alignment: scratch_plan.alignment,
         })
@@ -342,6 +382,11 @@ impl PirFunctionJit {
     /// Returns the native layout for the function result.
     pub fn result_layout(&self) -> &NativeValueLayout {
         &self.result_layout
+    }
+
+    /// Returns static metadata for observable event sites in this function.
+    pub fn metadata(&self) -> &CompiledFunctionMetadata {
+        &self.metadata
     }
 
     /// Returns the required size of the aggregate-intermediate scratch slab.
@@ -372,6 +417,23 @@ impl PirFunctionJit {
     /// When an aggregate result is copied from an input aggregate, input and
     /// output storage must not partially overlap.
     pub unsafe fn run_native(&self, inputs: &[*const u8], output: *mut u8) -> Result<(), JitError> {
+        let mut context = ExecutionContext::new(&self.metadata);
+        // SAFETY: this method forwards the caller's storage contract and owns
+        // an active execution context for the duration of generated execution.
+        unsafe { self.run_native_with_context(inputs, output, &mut context) }
+    }
+
+    /// Runs generated code with a caller-owned observable-event collector.
+    ///
+    /// # Safety
+    ///
+    /// Input and output pointer requirements match [`Self::run_native`].
+    pub unsafe fn run_native_with_context(
+        &self,
+        inputs: &[*const u8],
+        output: *mut u8,
+        context: &mut ExecutionContext<'_>,
+    ) -> Result<(), JitError> {
         debug_assert!(self.scratch_alignment <= std::mem::align_of::<u64>());
         let mut scratch_words =
             vec![0u64; self.scratch_byte_count.div_ceil(std::mem::size_of::<u64>())];
@@ -383,11 +445,12 @@ impl PirFunctionJit {
         // SAFETY: the caller upholds the native argument/result contract; the
         // scratch vector is aligned and remains alive for this call.
         unsafe {
-            self.run_native_with_scratch(
+            self.run_native_with_scratch_and_context(
                 inputs,
                 output,
                 scratch,
                 scratch_words.len() * std::mem::size_of::<u64>(),
+                context,
             )
         }
     }
@@ -414,6 +477,34 @@ impl PirFunctionJit {
         scratch: *mut u8,
         scratch_byte_count: usize,
     ) -> Result<(), JitError> {
+        let mut context = ExecutionContext::new(&self.metadata);
+        // SAFETY: this method forwards the caller's native-storage contract
+        // while owning an active context for the generated call.
+        unsafe {
+            self.run_native_with_scratch_and_context(
+                inputs,
+                output,
+                scratch,
+                scratch_byte_count,
+                &mut context,
+            )
+        }
+    }
+
+    /// Runs generated code with caller-owned storage and an event collector.
+    ///
+    /// # Safety
+    ///
+    /// Input, output, and scratch pointer requirements match
+    /// [`Self::run_native_with_scratch`].
+    pub unsafe fn run_native_with_scratch_and_context(
+        &self,
+        inputs: &[*const u8],
+        output: *mut u8,
+        scratch: *mut u8,
+        scratch_byte_count: usize,
+        context: &mut ExecutionContext<'_>,
+    ) -> Result<(), JitError> {
         if inputs.len() != self.param_layouts.len() {
             return Err(JitError::InvalidArgument(format!(
                 "expected {} input pointers, got {}",
@@ -421,9 +512,14 @@ impl PirFunctionJit {
                 inputs.len()
             )));
         }
-        if inputs.iter().any(|pointer| pointer.is_null()) || output.is_null() {
+        if inputs
+            .iter()
+            .zip(&self.param_layouts)
+            .any(|(pointer, layout)| layout.byte_count() != 0 && pointer.is_null())
+            || (self.result_layout.byte_count() != 0 && output.is_null())
+        {
             return Err(JitError::InvalidArgument(
-                "native input/output pointers must be non-null".to_string(),
+                "nonempty native input/output pointers must be non-null".to_string(),
             ));
         }
         if scratch_byte_count < self.scratch_byte_count {
@@ -442,7 +538,9 @@ impl PirFunctionJit {
         }
         // SAFETY: the caller upholds the pointer and layout contract stated
         // above; the function was finalized with this exact ABI.
-        let status = unsafe { (self.entrypoint)(inputs.as_ptr(), output, scratch) };
+        let mut raw_context = context.raw_context();
+        let status =
+            unsafe { (self.entrypoint)(inputs.as_ptr(), output, scratch, &mut raw_context) };
         if status == 0 {
             Ok(())
         } else {
@@ -481,6 +579,14 @@ impl PirFunctionJit {
     /// Transitional dynamic-value adapter used by differential tests and
     /// fuzzing.
     pub fn run_ir_values(&self, args: &[IrValue]) -> Result<IrValue, JitError> {
+        Ok(self.run_ir_values_with_events(args)?.value)
+    }
+
+    /// Runs dynamic PIR values and returns the value plus observable events.
+    pub fn run_ir_values_with_events(
+        &self,
+        args: &[IrValue],
+    ) -> Result<IrExecutionResult, JitError> {
         if args.len() != self.param_layouts.len() {
             return Err(JitError::InvalidArgument(format!(
                 "expected {} arguments, got {}",
@@ -498,10 +604,14 @@ impl PirFunctionJit {
             .map(NativeValueStorage::as_ptr)
             .collect::<Vec<_>>();
         let mut output = NativeValueStorage::zeroed(&self.result_layout);
+        let mut context = ExecutionContext::new(&self.metadata);
         // SAFETY: each `NativeValueStorage` owns aligned storage with exactly
         // the corresponding published native layout and lives across the call.
-        unsafe { self.run_native(&pointers, output.as_mut_ptr())? };
-        output.to_ir_value(&self.result_layout)
+        unsafe { self.run_native_with_context(&pointers, output.as_mut_ptr(), &mut context)? };
+        Ok(IrExecutionResult {
+            value: output.to_ir_value(&self.result_layout)?,
+            events: context.result(),
+        })
     }
 }
 
@@ -606,7 +716,7 @@ unsafe fn write_ir_value_to_native(
                 // SAFETY: each child lies in its recursively described region.
                 unsafe {
                     write_ir_value_to_native(
-                        destination.add(index * element.byte_count()),
+                        destination.wrapping_add(index * element.byte_count()),
                         element,
                         child,
                     )?;
@@ -628,12 +738,15 @@ unsafe fn write_ir_value_to_native(
                 // SAFETY: each field lies at its published C-compatible offset.
                 unsafe {
                     write_ir_value_to_native(
-                        destination.add(field.offset),
+                        destination.wrapping_add(field.offset),
                         field.layout.as_ref(),
                         child,
                     )?;
                 }
             }
+        }
+        NativeValueLayout::Token => {
+            // A token has no native bytes to write or inspect.
         }
     }
     Ok(())
@@ -661,7 +774,10 @@ unsafe fn read_ir_value_from_native(
             for index in 0..*element_count {
                 // SAFETY: each child lies in its recursively described region.
                 elements.push(unsafe {
-                    read_ir_value_from_native(source.add(index * element.byte_count()), element)?
+                    read_ir_value_from_native(
+                        source.wrapping_add(index * element.byte_count()),
+                        element,
+                    )?
                 });
             }
             IrValue::make_array(&elements).map_err(|error| JitError::Value(error.to_string()))
@@ -671,11 +787,15 @@ unsafe fn read_ir_value_from_native(
             for field in fields {
                 // SAFETY: each field lies at its published C-compatible offset.
                 elements.push(unsafe {
-                    read_ir_value_from_native(source.add(field.offset), field.layout.as_ref())?
+                    read_ir_value_from_native(
+                        source.wrapping_add(field.offset),
+                        field.layout.as_ref(),
+                    )?
                 });
             }
             Ok(IrValue::make_tuple(&elements))
         }
+        NativeValueLayout::Token => Ok(IrValue::make_token()),
     }
 }
 
@@ -722,14 +842,22 @@ impl NativeScalar {
 #[derive(Debug)]
 struct ScratchPlan {
     offsets: HashMap<NodeRef, usize>,
+    trace_sites: HashMap<NodeRef, TraceScratchPlan>,
     byte_count: usize,
     alignment: usize,
+}
+
+#[derive(Debug)]
+struct TraceScratchPlan {
+    pointer_array_offset: usize,
+    scalar_operand_offsets: Vec<Option<usize>>,
 }
 
 impl ScratchPlan {
     /// Assigns native scratch slots for materialized intermediate aggregates.
     fn for_function(function: &ir::Fn, order: &[NodeRef]) -> Result<Self, JitError> {
         let mut offsets = HashMap::new();
+        let mut trace_sites = HashMap::new();
         let mut byte_count = 0usize;
         let mut alignment = 1usize;
         for node_ref in order {
@@ -749,8 +877,42 @@ impl ScratchPlan {
             })?;
             alignment = alignment.max(layout.alignment());
         }
+        for node_ref in order {
+            let NodePayload::Trace { operands, .. } = &function.get_node(*node_ref).payload else {
+                continue;
+            };
+            let mut scalar_operand_offsets = Vec::with_capacity(operands.len());
+            for operand in operands {
+                let layout = NativeValueLayout::from_type(&function.get_node(*operand).ty)?;
+                if matches!(layout, NativeValueLayout::Scalar(_)) {
+                    byte_count = align_up(byte_count, layout.alignment())?;
+                    scalar_operand_offsets.push(Some(byte_count));
+                    byte_count = byte_count.checked_add(layout.byte_count()).ok_or_else(|| {
+                        JitError::UnsupportedType("trace scratch size overflow".into())
+                    })?;
+                    alignment = alignment.max(layout.alignment());
+                } else {
+                    scalar_operand_offsets.push(None);
+                }
+            }
+            let pointer_alignment = std::mem::align_of::<*const u8>();
+            byte_count = align_up(byte_count, pointer_alignment)?;
+            let pointer_array_offset = byte_count;
+            byte_count = byte_count
+                .checked_add(operands.len() * std::mem::size_of::<*const u8>())
+                .ok_or_else(|| JitError::UnsupportedType("trace pointer size overflow".into()))?;
+            alignment = alignment.max(pointer_alignment);
+            trace_sites.insert(
+                *node_ref,
+                TraceScratchPlan {
+                    pointer_array_offset,
+                    scalar_operand_offsets,
+                },
+            );
+        }
         Ok(Self {
             offsets,
+            trace_sites,
             byte_count,
             alignment,
         })
@@ -787,6 +949,96 @@ fn needs_aggregate_destination(node: &ir::Node) -> bool {
 enum ComputedValue {
     Scalar(Value),
     Address(Value),
+    ZeroSized,
+}
+
+#[derive(Clone, Copy)]
+struct RuntimeCallbacks {
+    record_assert: FuncRef,
+    record_cover: FuncRef,
+    record_trace: FuncRef,
+}
+
+fn trace_layout_from_native(layout: &NativeValueLayout) -> TraceValueLayout {
+    match layout {
+        NativeValueLayout::Scalar(scalar) => TraceValueLayout::Bits {
+            bit_count: scalar.bit_count,
+            byte_count: scalar.byte_count,
+        },
+        NativeValueLayout::Array {
+            element,
+            element_count,
+        } => TraceValueLayout::Array {
+            element: Box::new(trace_layout_from_native(element)),
+            element_count: *element_count,
+        },
+        NativeValueLayout::Tuple {
+            fields, byte_count, ..
+        } => TraceValueLayout::Tuple {
+            fields: fields
+                .iter()
+                .map(|field| TraceTupleFieldLayout {
+                    layout: Box::new(trace_layout_from_native(&field.layout)),
+                    offset: field.offset,
+                })
+                .collect(),
+            byte_count: *byte_count,
+        },
+        NativeValueLayout::Token => TraceValueLayout::Token,
+    }
+}
+
+fn build_event_metadata(
+    function: &ir::Fn,
+    order: &[NodeRef],
+) -> Result<(CompiledFunctionMetadata, HashMap<NodeRef, u32>), JitError> {
+    let mut event_sites = Vec::new();
+    let mut site_ids = HashMap::new();
+    for node_ref in order {
+        let node = function.get_node(*node_ref);
+        let site = match &node.payload {
+            NodePayload::Cover { label, .. } => Some(EventSiteMetadata {
+                node_text_id: node.text_id,
+                kind: EventKind::Cover,
+                label: Some(label.clone()),
+                message: None,
+                format: None,
+                operand_layouts: Vec::new(),
+            }),
+            NodePayload::Assert { message, label, .. } => Some(EventSiteMetadata {
+                node_text_id: node.text_id,
+                kind: EventKind::Assert,
+                label: Some(label.clone()),
+                message: Some(message.clone()),
+                format: None,
+                operand_layouts: Vec::new(),
+            }),
+            NodePayload::Trace {
+                format, operands, ..
+            } => Some(EventSiteMetadata {
+                node_text_id: node.text_id,
+                kind: EventKind::Trace,
+                label: None,
+                message: None,
+                format: Some(format.clone()),
+                operand_layouts: operands
+                    .iter()
+                    .map(|operand| {
+                        NativeValueLayout::from_type(&function.get_node(*operand).ty)
+                            .map(|layout| trace_layout_from_native(&layout))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            }),
+            _ => None,
+        };
+        if let Some(site) = site {
+            let site_id = u32::try_from(event_sites.len())
+                .map_err(|_| JitError::UnsupportedType("too many event sites".into()))?;
+            site_ids.insert(*node_ref, site_id);
+            event_sites.push(site);
+        }
+    }
+    Ok((CompiledFunctionMetadata { event_sites }, site_ids))
 }
 
 fn reachable_topological_order(function: &ir::Fn) -> Result<Vec<NodeRef>, JitError> {
@@ -794,6 +1046,14 @@ fn reachable_topological_order(function: &ir::Fn) -> Result<Vec<NodeRef>, JitErr
         JitError::InvalidFunction(format!("function '{}' has no return node", function.name))
     })?;
     let mut stack = vec![return_node];
+    stack.extend(
+        function
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| is_observable_effect_root(&node.payload))
+            .map(|(index, _)| NodeRef { index }),
+    );
     let mut reachable = HashSet::new();
     while let Some(node_ref) = stack.pop() {
         if node_ref.index >= function.nodes.len() {
@@ -812,11 +1072,48 @@ fn reachable_topological_order(function: &ir::Fn) -> Result<Vec<NodeRef>, JitErr
         .collect())
 }
 
+fn declare_runtime_callbacks(
+    module: &mut JITModule,
+    function: &mut cranelift_codegen::ir::Function,
+    pointer_type: ClifType,
+) -> Result<RuntimeCallbacks, JitError> {
+    let mut site_signature = module.make_signature();
+    site_signature.params.push(AbiParam::new(pointer_type));
+    site_signature.params.push(AbiParam::new(types::I32));
+    let assert_id = module
+        .declare_function(
+            "xlsynth_pir_record_assert",
+            Linkage::Import,
+            &site_signature,
+        )
+        .map_err(|error| JitError::Backend(error.to_string()))?;
+    let cover_id = module
+        .declare_function("xlsynth_pir_record_cover", Linkage::Import, &site_signature)
+        .map_err(|error| JitError::Backend(error.to_string()))?;
+
+    let mut trace_signature = site_signature;
+    trace_signature.params.push(AbiParam::new(pointer_type));
+    let trace_id = module
+        .declare_function(
+            "xlsynth_pir_record_trace",
+            Linkage::Import,
+            &trace_signature,
+        )
+        .map_err(|error| JitError::Backend(error.to_string()))?;
+    Ok(RuntimeCallbacks {
+        record_assert: module.declare_func_in_func(assert_id, function),
+        record_cover: module.declare_func_in_func(cover_id, function),
+        record_trace: module.declare_func_in_func(trace_id, function),
+    })
+}
+
 fn lower_function(
     function: &ir::Fn,
     order: &[NodeRef],
     param_layouts: &[NativeValueLayout],
     scratch_plan: &ScratchPlan,
+    event_sites: &HashMap<NodeRef, u32>,
+    runtime_callbacks: RuntimeCallbacks,
     pointer_type: ClifType,
     builder: &mut FunctionBuilder<'_>,
 ) -> Result<(), JitError> {
@@ -827,6 +1124,7 @@ fn lower_function(
     let inputs_pointer = builder.block_params(entry)[0];
     let output_pointer = builder.block_params(entry)[1];
     let scratch_pointer = builder.block_params(entry)[2];
+    let execution_context = builder.block_params(entry)[3];
     let return_node = function.ret_node_ref.ok_or_else(|| {
         JitError::InvalidFunction(format!("function '{}' has no return node", function.name))
     })?;
@@ -859,6 +1157,12 @@ fn lower_function(
                 NativeValueLayout::Scalar(scalar) => {
                     ComputedValue::Scalar(lower_scalar_literal(builder, literal, *scalar)?)
                 }
+                NativeValueLayout::Token => ComputedValue::ZeroSized,
+                NativeValueLayout::Array { .. } | NativeValueLayout::Tuple { .. }
+                    if layout.byte_count() == 0 =>
+                {
+                    ComputedValue::ZeroSized
+                }
                 NativeValueLayout::Array { .. } | NativeValueLayout::Tuple { .. } => {
                     let destination = materialized_destination(
                         builder,
@@ -872,6 +1176,63 @@ fn lower_function(
                     ComputedValue::Address(destination)
                 }
             },
+            NodePayload::AfterAll(_) => ComputedValue::ZeroSized,
+            NodePayload::Cover { predicate, .. } => {
+                let site_id = event_site_id(event_sites, *node_ref, node)?;
+                emit_conditional_site_call(
+                    builder,
+                    scalar_value_for(&values, *predicate)?,
+                    runtime_callbacks.record_cover,
+                    execution_context,
+                    site_id,
+                );
+                ComputedValue::ZeroSized
+            }
+            NodePayload::Assert {
+                activate,
+                token: _,
+                message: _,
+                label: _,
+            } => {
+                let site_id = event_site_id(event_sites, *node_ref, node)?;
+                let condition = scalar_value_for(&values, *activate)?;
+                let failed = builder.ins().icmp_imm(IntCC::Equal, condition, 0);
+                emit_conditional_site_call(
+                    builder,
+                    failed,
+                    runtime_callbacks.record_assert,
+                    execution_context,
+                    site_id,
+                );
+                ComputedValue::ZeroSized
+            }
+            NodePayload::Trace {
+                activated,
+                operands,
+                token: _,
+                format: _,
+            } => {
+                let site_id = event_site_id(event_sites, *node_ref, node)?;
+                let operand_pointers = lower_trace_operand_pointers(
+                    builder,
+                    function,
+                    *node_ref,
+                    operands,
+                    &values,
+                    scratch_pointer,
+                    scratch_plan,
+                    pointer_type,
+                )?;
+                emit_conditional_trace_call(
+                    builder,
+                    scalar_value_for(&values, *activated)?,
+                    runtime_callbacks.record_trace,
+                    execution_context,
+                    site_id,
+                    operand_pointers,
+                );
+                ComputedValue::ZeroSized
+            }
             NodePayload::Unop(Unop::Identity, arg)
                 if matches!(
                     layout,
@@ -924,16 +1285,20 @@ fn lower_function(
                 )?)
             }
             NodePayload::ArrayConcat(args) => {
-                let destination = materialized_destination(
-                    builder,
-                    *node_ref,
-                    return_node,
-                    output_pointer,
-                    scratch_pointer,
-                    scratch_plan,
-                )?;
-                lower_array_concat(builder, function, destination, args, &values, &layout)?;
-                ComputedValue::Address(destination)
+                if layout.byte_count() == 0 {
+                    ComputedValue::ZeroSized
+                } else {
+                    let destination = materialized_destination(
+                        builder,
+                        *node_ref,
+                        return_node,
+                        output_pointer,
+                        scratch_pointer,
+                        scratch_plan,
+                    )?;
+                    lower_array_concat(builder, function, destination, args, &values, &layout)?;
+                    ComputedValue::Address(destination)
+                }
             }
             NodePayload::Binop(Binop::Gate, predicate, gated) => lower_gate(
                 builder,
@@ -1148,28 +1513,36 @@ fn lower_function(
                 )?)
             }
             NodePayload::Array(args) => {
-                let destination = materialized_destination(
-                    builder,
-                    *node_ref,
-                    return_node,
-                    output_pointer,
-                    scratch_pointer,
-                    scratch_plan,
-                )?;
-                lower_array_construction(builder, destination, args, &values, &layout)?;
-                ComputedValue::Address(destination)
+                if layout.byte_count() == 0 {
+                    ComputedValue::ZeroSized
+                } else {
+                    let destination = materialized_destination(
+                        builder,
+                        *node_ref,
+                        return_node,
+                        output_pointer,
+                        scratch_pointer,
+                        scratch_plan,
+                    )?;
+                    lower_array_construction(builder, destination, args, &values, &layout)?;
+                    ComputedValue::Address(destination)
+                }
             }
             NodePayload::Tuple(args) => {
-                let destination = materialized_destination(
-                    builder,
-                    *node_ref,
-                    return_node,
-                    output_pointer,
-                    scratch_pointer,
-                    scratch_plan,
-                )?;
-                lower_tuple_construction(builder, destination, args, &values, &layout)?;
-                ComputedValue::Address(destination)
+                if layout.byte_count() == 0 {
+                    ComputedValue::ZeroSized
+                } else {
+                    let destination = materialized_destination(
+                        builder,
+                        *node_ref,
+                        return_node,
+                        output_pointer,
+                        scratch_pointer,
+                        scratch_plan,
+                    )?;
+                    lower_tuple_construction(builder, destination, args, &values, &layout)?;
+                    ComputedValue::Address(destination)
+                }
             }
             NodePayload::TupleIndex { tuple, index } => {
                 lower_tuple_index(builder, *tuple, *index, &values, &layout, function, node)?
@@ -1194,48 +1567,58 @@ fn lower_function(
                 start,
                 width: _,
             } => {
-                let destination = materialized_destination(
-                    builder,
-                    *node_ref,
-                    return_node,
-                    output_pointer,
-                    scratch_pointer,
-                    scratch_plan,
-                )?;
-                lower_array_slice(
-                    builder,
-                    function,
-                    destination,
-                    *array,
-                    *start,
-                    &values,
-                    &layout,
-                    pointer_type,
-                )?;
-                ComputedValue::Address(destination)
+                if layout.byte_count() == 0 {
+                    ComputedValue::ZeroSized
+                } else {
+                    let destination = materialized_destination(
+                        builder,
+                        *node_ref,
+                        return_node,
+                        output_pointer,
+                        scratch_pointer,
+                        scratch_plan,
+                    )?;
+                    lower_array_slice(
+                        builder,
+                        function,
+                        destination,
+                        *array,
+                        *start,
+                        &values,
+                        &layout,
+                        pointer_type,
+                    )?;
+                    ComputedValue::Address(destination)
+                }
             }
             NodePayload::ArrayUpdate {
                 array,
                 value,
                 indices,
                 assumed_in_bounds,
-            } => lower_array_update(
-                builder,
-                function,
-                node,
-                *node_ref,
-                return_node,
-                output_pointer,
-                scratch_pointer,
-                scratch_plan,
-                *array,
-                *value,
-                indices,
-                *assumed_in_bounds,
-                &values,
-                &layout,
-                pointer_type,
-            )?,
+            } => {
+                if layout.byte_count() == 0 {
+                    ComputedValue::ZeroSized
+                } else {
+                    lower_array_update(
+                        builder,
+                        function,
+                        node,
+                        *node_ref,
+                        return_node,
+                        output_pointer,
+                        scratch_pointer,
+                        scratch_plan,
+                        *array,
+                        *value,
+                        indices,
+                        *assumed_in_bounds,
+                        &values,
+                        &layout,
+                        pointer_type,
+                    )?
+                }
+            }
             NodePayload::Sel {
                 selector,
                 cases,
@@ -1323,15 +1706,107 @@ fn lower_function(
     }
 
     let result = computed_value_for(&values, return_node)?;
-    store_value_to_storage(
-        builder,
-        output_pointer,
-        result,
-        &NativeValueLayout::from_type(&function.ret_ty)?,
-    )?;
+    let result_layout = NativeValueLayout::from_type(&function.ret_ty)?;
+    if result_layout.byte_count() != 0 {
+        store_value_to_storage(builder, output_pointer, result, &result_layout)?;
+    }
     let success = builder.ins().iconst(types::I32, 0);
     builder.ins().return_(&[success]);
     Ok(())
+}
+
+fn event_site_id(
+    event_sites: &HashMap<NodeRef, u32>,
+    node_ref: NodeRef,
+    node: &ir::Node,
+) -> Result<u32, JitError> {
+    event_sites.get(&node_ref).copied().ok_or_else(|| {
+        JitError::InvalidFunction(format!("missing event metadata for node {}", node.text_id))
+    })
+}
+
+fn emit_conditional_site_call(
+    builder: &mut FunctionBuilder<'_>,
+    condition: Value,
+    callback: FuncRef,
+    execution_context: Value,
+    site_id: u32,
+) {
+    let invoke = builder.create_block();
+    let after = builder.create_block();
+    builder.ins().brif(condition, invoke, &[], after, &[]);
+    builder.switch_to_block(invoke);
+    builder.seal_block(invoke);
+    let site_id = builder.ins().iconst(types::I32, i64::from(site_id));
+    builder.ins().call(callback, &[execution_context, site_id]);
+    builder.ins().jump(after, &[]);
+    builder.switch_to_block(after);
+    builder.seal_block(after);
+}
+
+fn emit_conditional_trace_call(
+    builder: &mut FunctionBuilder<'_>,
+    condition: Value,
+    callback: FuncRef,
+    execution_context: Value,
+    site_id: u32,
+    operand_pointers: Value,
+) {
+    let invoke = builder.create_block();
+    let after = builder.create_block();
+    builder.ins().brif(condition, invoke, &[], after, &[]);
+    builder.switch_to_block(invoke);
+    builder.seal_block(invoke);
+    let site_id = builder.ins().iconst(types::I32, i64::from(site_id));
+    builder
+        .ins()
+        .call(callback, &[execution_context, site_id, operand_pointers]);
+    builder.ins().jump(after, &[]);
+    builder.switch_to_block(after);
+    builder.seal_block(after);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn lower_trace_operand_pointers(
+    builder: &mut FunctionBuilder<'_>,
+    function: &ir::Fn,
+    trace_node: NodeRef,
+    operands: &[NodeRef],
+    values: &[Option<ComputedValue>],
+    scratch_pointer: Value,
+    scratch_plan: &ScratchPlan,
+    pointer_type: ClifType,
+) -> Result<Value, JitError> {
+    if operands.is_empty() {
+        return Ok(builder.ins().iconst(pointer_type, 0));
+    }
+    let plan = scratch_plan
+        .trace_sites
+        .get(&trace_node)
+        .ok_or_else(|| JitError::InvalidFunction("missing trace scratch allocation".to_string()))?;
+    let pointer_array = pointer_at_offset(builder, scratch_pointer, plan.pointer_array_offset);
+    for (index, operand) in operands.iter().enumerate() {
+        let layout = NativeValueLayout::from_type(&function.get_node(*operand).ty)?;
+        let pointer = match computed_value_for(values, *operand)? {
+            ComputedValue::Scalar(value) => {
+                let offset = plan.scalar_operand_offsets[index].ok_or_else(|| {
+                    JitError::InvalidFunction("missing trace scalar scratch allocation".into())
+                })?;
+                let pointer = pointer_at_offset(builder, scratch_pointer, offset);
+                store_value_to_storage(builder, pointer, ComputedValue::Scalar(value), &layout)?;
+                pointer
+            }
+            ComputedValue::Address(pointer) => pointer,
+            ComputedValue::ZeroSized => builder.ins().iconst(pointer_type, 0),
+        };
+        builder.ins().store(
+            MemFlags::new(),
+            pointer,
+            pointer_array,
+            (index * std::mem::size_of::<*const u8>()) as i32,
+        );
+    }
+    Ok(pointer_array)
 }
 
 fn lower_nary(
@@ -1977,6 +2452,9 @@ fn lower_array_index(
         }
         return Ok(value);
     }
+    if layout.byte_count() == 0 {
+        return Ok(ComputedValue::ZeroSized);
+    }
     let mut pointer = address_value_for(values, array)?;
     let mut current_layout = NativeValueLayout::from_type(&function.get_node(array).ty)?;
     for index in indices {
@@ -2080,6 +2558,7 @@ fn lower_literal_to_storage(
                 lower_literal_to_storage(builder, pointer, child, field.layout.as_ref())?;
             }
         }
+        NativeValueLayout::Token => {}
     }
     Ok(())
 }
@@ -2171,6 +2650,9 @@ fn lower_tuple_index(
             node.text_id
         )));
     }
+    if result_layout.byte_count() == 0 {
+        return Ok(ComputedValue::ZeroSized);
+    }
     let tuple_pointer = address_value_for(values, tuple)?;
     let field_pointer = pointer_at_offset(builder, tuple_pointer, field.offset);
     Ok(load_value_from_storage(
@@ -2234,6 +2716,9 @@ fn lower_value_equality(
     rhs: ComputedValue,
     layout: &NativeValueLayout,
 ) -> Result<Value, JitError> {
+    if layout.byte_count() == 0 {
+        return Ok(builder.ins().iconst(types::I8, 1));
+    }
     match layout {
         NativeValueLayout::Scalar(_) => {
             Ok(builder
@@ -2275,6 +2760,7 @@ fn lower_value_equality(
             }
             Ok(equal)
         }
+        NativeValueLayout::Token => Ok(builder.ins().iconst(types::I8, 1)),
     }
 }
 
@@ -2574,6 +3060,9 @@ fn lower_one_hot_sel(
     }
     let selector_value = scalar_value_for(values, selector)?;
     let selector_layout = ScalarLayout::from_type(&function.get_node(selector).ty)?;
+    if layout.byte_count() == 0 {
+        return Ok(ComputedValue::ZeroSized);
+    }
     match layout {
         NativeValueLayout::Scalar(scalar) => {
             let mut result = builder.ins().iconst(scalar.clif_type(), 0);
@@ -2606,6 +3095,7 @@ fn lower_one_hot_sel(
             }
             Ok(ComputedValue::Address(destination))
         }
+        NativeValueLayout::Token => Ok(ComputedValue::ZeroSized),
     }
 }
 
@@ -2697,6 +3187,9 @@ fn selected_value(
     when_false: Option<ComputedValue>,
     layout: &NativeValueLayout,
 ) -> Result<ComputedValue, JitError> {
+    if layout.byte_count() == 0 {
+        return Ok(ComputedValue::ZeroSized);
+    }
     match layout {
         NativeValueLayout::Scalar(scalar) => {
             let true_value = expect_scalar(when_true)?;
@@ -2729,6 +3222,7 @@ fn selected_value(
             )?;
             Ok(ComputedValue::Address(destination))
         }
+        NativeValueLayout::Token => Ok(ComputedValue::ZeroSized),
     }
 }
 
@@ -2740,6 +3234,9 @@ fn write_selected_value_to_storage(
     when_false: Option<ComputedValue>,
     layout: &NativeValueLayout,
 ) -> Result<(), JitError> {
+    if layout.byte_count() == 0 {
+        return Ok(());
+    }
     match layout {
         NativeValueLayout::Scalar(scalar) => {
             let false_value = match when_false {
@@ -2800,6 +3297,7 @@ fn write_selected_value_to_storage(
                 )?;
             }
         }
+        NativeValueLayout::Token => {}
     }
     Ok(())
 }
@@ -2829,6 +3327,7 @@ fn write_zero_value_to_storage(
                 write_zero_value_to_storage(builder, child, field.layout.as_ref());
             }
         }
+        NativeValueLayout::Token => {}
     }
 }
 
@@ -2839,6 +3338,9 @@ fn write_selected_or_value_to_storage(
     value: ComputedValue,
     layout: &NativeValueLayout,
 ) -> Result<(), JitError> {
+    if layout.byte_count() == 0 {
+        return Ok(());
+    }
     match layout {
         NativeValueLayout::Scalar(scalar) => {
             let current = builder
@@ -2884,6 +3386,7 @@ fn write_selected_or_value_to_storage(
                 )?;
             }
         }
+        NativeValueLayout::Token => {}
     }
     Ok(())
 }
@@ -3071,6 +3574,9 @@ fn load_value_from_storage(
     pointer: Value,
     layout: &NativeValueLayout,
 ) -> ComputedValue {
+    if layout.byte_count() == 0 {
+        return ComputedValue::ZeroSized;
+    }
     match layout {
         NativeValueLayout::Scalar(scalar) => {
             let value = builder
@@ -3081,6 +3587,7 @@ fn load_value_from_storage(
         NativeValueLayout::Array { .. } | NativeValueLayout::Tuple { .. } => {
             ComputedValue::Address(pointer)
         }
+        NativeValueLayout::Token => ComputedValue::ZeroSized,
     }
 }
 
@@ -3090,6 +3597,9 @@ fn store_value_to_storage(
     value: ComputedValue,
     layout: &NativeValueLayout,
 ) -> Result<(), JitError> {
+    if layout.byte_count() == 0 {
+        return Ok(());
+    }
     match layout {
         NativeValueLayout::Scalar(_) => {
             builder
@@ -3118,6 +3628,7 @@ fn store_value_to_storage(
                 store_value_to_storage(builder, destination_field, child, field.layout.as_ref())?;
             }
         }
+        NativeValueLayout::Token => {}
     }
     Ok(())
 }
@@ -3155,7 +3666,7 @@ fn address_value_for(
 fn expect_scalar(value: ComputedValue) -> Result<Value, JitError> {
     match value {
         ComputedValue::Scalar(value) => Ok(value),
-        ComputedValue::Address(_) => Err(JitError::InvalidFunction(
+        ComputedValue::Address(_) | ComputedValue::ZeroSized => Err(JitError::InvalidFunction(
             "array value used as a scalar".into(),
         )),
     }
@@ -3164,7 +3675,7 @@ fn expect_scalar(value: ComputedValue) -> Result<Value, JitError> {
 fn expect_address(value: ComputedValue) -> Result<Value, JitError> {
     match value {
         ComputedValue::Address(value) => Ok(value),
-        ComputedValue::Scalar(_) => Err(JitError::InvalidFunction(
+        ComputedValue::Scalar(_) | ComputedValue::ZeroSized => Err(JitError::InvalidFunction(
             "scalar value used as an array".into(),
         )),
     }

--- a/xlsynth-pir-compiler/tests/function_jit.rs
+++ b/xlsynth-pir-compiler/tests/function_jit.rs
@@ -348,6 +348,52 @@ fn f(emit: bits[1] id=1) -> token {
 }
 
 #[test]
+fn compiled_trace_formats_match_evaluator_and_xls_syntax() {
+    let ir = r#"package test
+
+fn f(x: bits[12] id=1, neg: bits[8] id=2) -> token {
+  t: token = after_all(id=3)
+  one: bits[1] = literal(value=1, id=4)
+  ret tr: token = trace(t, one, format="literal={{ default={} u={:u} d={:d} x={:x} 0x={:0x} #x={:#x} b={:b} 0b={:0b} #b={:#b}", data_operands=[x, x, neg, x, x, x, x, x, x], id=5)
+}
+"#;
+    let package = Parser::new(ir)
+        .parse_and_validate_package()
+        .expect("test PIR should parse and validate");
+    let function = package.get_fn("f").expect("function f should exist");
+    let jit = PirFunctionJit::compile(function).expect("function should compile");
+    let args = vec![bits(12, 43), bits(8, 251)];
+    let actual = jit
+        .run_ir_values_with_events(&args)
+        .expect("compiled execution should succeed");
+    let expected = match eval_fn(function, &args) {
+        FnEvalResult::Success(success) => success,
+        FnEvalResult::Failure(_) => panic!("trace should not cause evaluation failure"),
+    };
+    let actual_messages = actual
+        .events
+        .trace_messages
+        .iter()
+        .map(|message| message.message.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        actual_messages,
+        expected
+            .trace_messages
+            .iter()
+            .map(|message| message.message.clone())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        actual_messages,
+        vec![
+            "literal={{ default=43 u=43 d=-5 x=2b 0x=02b #x=0x2b b=101011 0b=0000_0010_1011 #b=0b10_1011"
+                .to_string()
+        ]
+    );
+}
+
+#[test]
 fn odd_width_arithmetic_masks_to_pir_width() {
     let jit = compile(
         r#"package test

--- a/xlsynth-pir-compiler/tests/function_jit.rs
+++ b/xlsynth-pir-compiler/tests/function_jit.rs
@@ -4,7 +4,8 @@ use xlsynth::IrValue;
 use xlsynth_pir::ir_eval::{FnEvalResult, eval_fn};
 use xlsynth_pir::ir_parser::Parser;
 use xlsynth_pir_compiler::{
-    JitError, NativeTupleFieldLayout, NativeValueLayout, PirFunctionJit, ScalarLayout,
+    ExecutionContext, JitError, NativeTupleFieldLayout, NativeValueLayout, PirFunctionJit,
+    ScalarLayout,
 };
 
 fn compile(ir: &str) -> PirFunctionJit {
@@ -49,6 +50,15 @@ fn array(width: usize, values: &[u64]) -> IrValue {
 
 fn tuple(elements: &[IrValue]) -> IrValue {
     IrValue::make_tuple(elements)
+}
+
+fn unit_array(element_count: usize) -> IrValue {
+    IrValue::make_array(&vec![tuple(&[]); element_count]).unwrap()
+}
+
+fn sorted<T: Ord>(mut values: Vec<T>) -> Vec<T> {
+    values.sort();
+    values
 }
 
 #[test]
@@ -98,6 +108,243 @@ fn f(x: bits[8] id=1, y: bits[8] id=2) -> bits[8] {
             .expect("native execution should succeed");
     }
     assert_eq!(output, 16);
+}
+
+#[test]
+fn compiles_zero_sized_token_and_cover_unit_results() {
+    let token_jit = compile(
+        r#"package test
+
+fn f() -> token {
+  ret t: token = after_all(id=1)
+}
+"#,
+    );
+    assert_eq!(token_jit.result_layout(), &NativeValueLayout::Token);
+    assert_eq!(
+        token_jit.run_ir_values(&[]).expect("token execution"),
+        IrValue::make_token()
+    );
+
+    let cover_jit = compile(
+        r#"package test
+
+fn f(x: bits[1] id=1) -> () {
+  ret cv: () = cover(x, label="hit", id=2)
+}
+"#,
+    );
+    assert_eq!(
+        cover_jit.result_layout(),
+        &NativeValueLayout::Tuple {
+            fields: vec![],
+            byte_count: 0,
+            alignment: 1,
+        }
+    );
+    let execution = cover_jit
+        .run_ir_values_with_events(&[bits(1, 1)])
+        .expect("unit-valued cover execution");
+    assert_eq!(execution.value, IrValue::make_tuple(&[]));
+    assert_eq!(execution.events.cover_counts.len(), 1);
+    assert_eq!(execution.events.cover_counts[0].label, "hit");
+    assert_eq!(execution.events.cover_counts[0].count, 1);
+}
+
+#[test]
+fn caller_owned_context_accumulates_cover_counts() {
+    let jit = compile(
+        r#"package test
+
+fn f(x: bits[1] id=1) -> bits[1] {
+  cv: () = cover(x, label="observed", id=2)
+  ret identity.3: bits[1] = identity(x, id=3)
+}
+"#,
+    );
+    let mut context = ExecutionContext::new(jit.metadata());
+    let mut output: u8 = 0;
+    for input in [1u8, 1u8, 0u8] {
+        let inputs = [std::ptr::from_ref(&input).cast::<u8>()];
+        // SAFETY: input and output carry `bits[1]` in the published native
+        // scalar layout, and `context` was created for this compiled function.
+        unsafe {
+            jit.run_native_with_context(
+                &inputs,
+                std::ptr::from_mut(&mut output).cast(),
+                &mut context,
+            )
+            .expect("native execution with context");
+        }
+    }
+    assert_eq!(context.result().cover_counts[0].count, 2);
+    context.clear();
+    assert_eq!(context.result().cover_counts[0].count, 0);
+}
+
+#[test]
+fn compiled_events_match_pir_evaluator_for_cover_assert_and_trace() {
+    let ir = r#"package test
+
+fn f(x: bits[8] id=1, ok: bits[1] id=2, emit: bits[1] id=3) -> bits[8] {
+  t: token = after_all(id=4)
+  cv: () = cover(emit, label="covered", id=5)
+  a: token = assert(t, ok, message="bad condition", label="A", id=6)
+  tr: token = trace(a, emit, format="x={}", data_operands=[x], id=7)
+  ret identity.8: bits[8] = identity(x, id=8)
+}
+"#;
+    let package = Parser::new(ir)
+        .parse_and_validate_package()
+        .expect("test PIR should parse and validate");
+    let function = package.get_fn("f").expect("function f should exist");
+    let jit = PirFunctionJit::compile(function).expect("function should compile");
+
+    for args in [
+        vec![bits(8, 0xa5), bits(1, 1), bits(1, 1)],
+        vec![bits(8, 0x3c), bits(1, 0), bits(1, 1)],
+        vec![bits(8, 0x12), bits(1, 1), bits(1, 0)],
+    ] {
+        let expected = eval_fn(function, &args);
+        let actual = jit
+            .run_ir_values_with_events(&args)
+            .expect("compiled execution should succeed");
+        match expected {
+            FnEvalResult::Success(expected) => {
+                assert_eq!(actual.value, expected.value);
+                assert!(actual.events.assertion_failures.is_empty());
+                assert_eq!(
+                    sorted(
+                        actual
+                            .events
+                            .trace_messages
+                            .iter()
+                            .map(|message| (message.message.clone(), message.verbosity))
+                            .collect()
+                    ),
+                    sorted(
+                        expected
+                            .trace_messages
+                            .iter()
+                            .map(|message| (message.message.clone(), message.verbosity))
+                            .collect()
+                    )
+                );
+                assert_eq!(
+                    sorted(
+                        actual
+                            .events
+                            .cover_counts
+                            .iter()
+                            .map(|cover| (cover.node_text_id, cover.label.clone(), cover.count))
+                            .collect()
+                    ),
+                    sorted(
+                        expected
+                            .cover_counts
+                            .iter()
+                            .map(|cover| (cover.node_text_id, cover.label.clone(), cover.count))
+                            .collect()
+                    )
+                );
+            }
+            FnEvalResult::Failure(expected) => {
+                assert_eq!(
+                    sorted(
+                        actual
+                            .events
+                            .assertion_failures
+                            .iter()
+                            .map(|failure| (failure.message.clone(), failure.label.clone()))
+                            .collect()
+                    ),
+                    sorted(
+                        expected
+                            .assertion_failures
+                            .iter()
+                            .map(|failure| (failure.message.clone(), failure.label.clone()))
+                            .collect()
+                    )
+                );
+                assert_eq!(
+                    sorted(
+                        actual
+                            .events
+                            .trace_messages
+                            .iter()
+                            .map(|message| (message.message.clone(), message.verbosity))
+                            .collect()
+                    ),
+                    sorted(
+                        expected
+                            .trace_messages
+                            .iter()
+                            .map(|message| (message.message.clone(), message.verbosity))
+                            .collect()
+                    )
+                );
+                assert_eq!(
+                    sorted(
+                        actual
+                            .events
+                            .cover_counts
+                            .iter()
+                            .map(|cover| (cover.node_text_id, cover.label.clone(), cover.count))
+                            .collect()
+                    ),
+                    sorted(
+                        expected
+                            .cover_counts
+                            .iter()
+                            .map(|cover| (cover.node_text_id, cover.label.clone(), cover.count))
+                            .collect()
+                    )
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn compiled_trace_matches_evaluator_for_zero_through_three_operands() {
+    let ir = r#"package test
+
+fn f(emit: bits[1] id=1) -> token {
+  unit: () = tuple(id=2)
+  units: ()[1] = array(unit, id=3)
+  t: token = after_all(id=4)
+  tr0: token = trace(t, emit, format="zero", data_operands=[], id=5)
+  tr1: token = trace(tr0, emit, format="one={}", data_operands=[unit], id=6)
+  tr2: token = trace(tr1, emit, format="two={},{}", data_operands=[unit, units], id=7)
+  ret tr3: token = trace(tr2, emit, format="three={},{},{}", data_operands=[unit, units, emit], id=8)
+}
+"#;
+    let package = Parser::new(ir)
+        .parse_and_validate_package()
+        .expect("test PIR should parse and validate");
+    let function = package.get_fn("f").expect("function f should exist");
+    let jit = PirFunctionJit::compile(function).expect("function should compile");
+    let args = vec![bits(1, 1)];
+    let expected = match eval_fn(function, &args) {
+        FnEvalResult::Success(success) => success,
+        FnEvalResult::Failure(_) => panic!("traces should not cause evaluation failure"),
+    };
+    let actual = jit
+        .run_ir_values_with_events(&args)
+        .expect("compiled execution should succeed");
+    assert_eq!(
+        actual
+            .events
+            .trace_messages
+            .iter()
+            .map(|message| message.message.clone())
+            .collect::<Vec<_>>(),
+        expected
+            .trace_messages
+            .iter()
+            .map(|message| message.message.clone())
+            .collect::<Vec<_>>()
+    );
 }
 
 #[test]
@@ -671,6 +918,46 @@ fn f(values: bits[8][2][2] id=1, replacement: bits[8] id=2, i: bits[2] id=3, j: 
                 })
             })
             .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn zero_sized_aggregates_flow_through_array_operations() {
+    assert_matches_evaluator(
+        r#"package test
+
+fn f(values: ()[1] id=1) -> ()[1] {
+  ret joined: ()[1] = array_concat(values, id=2)
+}
+"#,
+        &[vec![unit_array(1)]],
+    );
+    assert_matches_evaluator(
+        r#"package test
+
+fn f(values: ()[2] id=1, index: bits[1] id=2) -> () {
+  ret selected: () = array_index(values, indices=[index], id=3)
+}
+"#,
+        &[vec![unit_array(2), bits(1, 1)]],
+    );
+    assert_matches_evaluator(
+        r#"package test
+
+fn f(values: ()[1] id=1, start: bits[1] id=2) -> ()[2] {
+  ret sliced: ()[2] = array_slice(values, start, width=2, id=3)
+}
+"#,
+        &[vec![unit_array(1), bits(1, 0)]],
+    );
+    assert_matches_evaluator(
+        r#"package test
+
+fn f(values: ()[2] id=1, replacement: () id=2, index: bits[1] id=3) -> ()[2] {
+  ret updated: ()[2] = array_update(values, replacement, indices=[index], id=4)
+}
+"#,
+        &[vec![unit_array(2), tuple(&[]), bits(1, 1)]],
     );
 }
 

--- a/xlsynth-pir/Cargo.toml
+++ b/xlsynth-pir/Cargo.toml
@@ -24,6 +24,7 @@ tempfile = "3.20"
 bitvec = "1.0.1"
 sha2 = "0.10"
 smallvec = "1.13.2"
+num-bigint = "0.4.6"
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/xlsynth-pir/src/ir_eval.rs
+++ b/xlsynth-pir/src/ir_eval.rs
@@ -1295,6 +1295,26 @@ pub struct CoverCount {
     pub count: u64,
 }
 
+/// Accumulates cover hits by package-unique static site while preserving
+/// discovery order.
+fn accumulate_cover_count(
+    cover_counts: &mut Vec<CoverCount>,
+    cover_index_by_text_id: &mut HashMap<usize, usize>,
+    incoming: CoverCount,
+) {
+    if let Some(index) = cover_index_by_text_id.get(&incoming.node_text_id) {
+        let existing = &mut cover_counts[*index];
+        debug_assert_eq!(
+            existing.label, incoming.label,
+            "one cover text id should refer to one static site"
+        );
+        existing.count = existing.count.saturating_add(incoming.count);
+    } else {
+        cover_index_by_text_id.insert(incoming.node_text_id, cover_counts.len());
+        cover_counts.push(incoming);
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct FnEvalSuccess {
     pub value: IrValue,
@@ -1941,6 +1961,7 @@ fn eval_fn_impl<'a>(
     let mut trace_messages: Vec<TraceMessage> = Vec::new();
     let mut assertion_failures: Vec<AssertionFailure> = Vec::new();
     let mut cover_counts: Vec<CoverCount> = Vec::new();
+    let mut cover_index_by_text_id: HashMap<usize, usize> = HashMap::new();
     for nr in eval_order(f, order_policy) {
         let node = f.get_node(nr);
         let value: IrValue = match &node.payload {
@@ -2012,11 +2033,15 @@ fn eval_fn_impl<'a>(
                     .expect("cover predicate operand must be evaluated")
                     .to_bool()
                     .expect("cover predicate must be bits[1]");
-                cover_counts.push(CoverCount {
-                    node_text_id: node.text_id,
-                    label: label.clone(),
-                    count: u64::from(active),
-                });
+                accumulate_cover_count(
+                    &mut cover_counts,
+                    &mut cover_index_by_text_id,
+                    CoverCount {
+                        node_text_id: node.text_id,
+                        label: label.clone(),
+                        count: u64::from(active),
+                    },
+                );
                 // XLS cover produces the zero-sized unit value.
                 IrValue::make_tuple(&[])
             }
@@ -2043,13 +2068,25 @@ fn eval_fn_impl<'a>(
                 match callee_result {
                     FnEvalResult::Success(success) => {
                         trace_messages.extend(success.trace_messages);
-                        cover_counts.extend(success.cover_counts);
+                        for cover_count in success.cover_counts {
+                            accumulate_cover_count(
+                                &mut cover_counts,
+                                &mut cover_index_by_text_id,
+                                cover_count,
+                            );
+                        }
                         success.value
                     }
                     FnEvalResult::Failure(fail) => {
                         assertion_failures.extend(fail.assertion_failures);
                         trace_messages.extend(fail.trace_messages);
-                        cover_counts.extend(fail.cover_counts);
+                        for cover_count in fail.cover_counts {
+                            accumulate_cover_count(
+                                &mut cover_counts,
+                                &mut cover_index_by_text_id,
+                                cover_count,
+                            );
+                        }
                         return FnEvalResult::Failure(FnEvalFailure {
                             assertion_failures,
                             trace_messages,
@@ -3973,6 +4010,73 @@ fn f(x: bits[1] id=1) -> bits[1] {
                     count: 0,
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn test_eval_fn_in_package_invoke_accumulates_repeated_cover_site() {
+        let ir_text = r#"package test
+
+fn g(x: bits[1] id=1) -> bits[1] {
+  _covered: () = cover(x, label="hit", id=2)
+  ret identity.3: bits[1] = identity(x, id=3)
+}
+
+fn f(x: bits[1] id=10) -> bits[1] {
+  first: bits[1] = invoke(x, to_apply=g, id=11)
+  second: bits[1] = invoke(x, to_apply=g, id=12)
+  ret and.13: bits[1] = and(first, second, id=13)
+}
+"#;
+        let mut p = Parser::new(ir_text);
+        let pkg = p.parse_and_validate_package().expect("parse ok");
+        let f = pkg.get_fn("f").expect("f");
+        let result = eval_fn_in_package(&pkg, f, &[IrValue::make_ubits(1, 1).unwrap()]);
+        let FnEvalResult::Success(success) = result else {
+            panic!("unexpected result: {result:?}");
+        };
+        assert_eq!(
+            success.cover_counts,
+            vec![CoverCount {
+                node_text_id: 2,
+                label: "hit".to_string(),
+                count: 2,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_eval_fn_in_package_failure_accumulates_repeated_cover_site() {
+        let ir_text = r#"package test
+
+fn g(x: bits[1] id=1) -> bits[1] {
+  t: token = after_all(id=2)
+  _covered: () = cover(x, label="hit", id=3)
+  _asserted: token = assert(t, x, message="not set", label="asserted", id=4)
+  ret identity.5: bits[1] = identity(x, id=5)
+}
+
+fn f() -> bits[1] {
+  one: bits[1] = literal(value=1, id=10)
+  first: bits[1] = invoke(one, to_apply=g, id=11)
+  zero: bits[1] = not(first, id=12)
+  ret second: bits[1] = invoke(zero, to_apply=g, id=13)
+}
+"#;
+        let mut p = Parser::new(ir_text);
+        let pkg = p.parse_and_validate_package().expect("parse ok");
+        let f = pkg.get_fn("f").expect("f");
+        let result = eval_fn_in_package(&pkg, f, &[]);
+        let FnEvalResult::Failure(failure) = result else {
+            panic!("unexpected result: {result:?}");
+        };
+        assert_eq!(
+            failure.cover_counts,
+            vec![CoverCount {
+                node_text_id: 3,
+                label: "hit".to_string(),
+                count: 1,
+            }]
         );
     }
 

--- a/xlsynth-pir/src/ir_eval.rs
+++ b/xlsynth-pir/src/ir_eval.rs
@@ -1287,16 +1287,25 @@ pub struct AssertionFailure {
     pub label: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoverCount {
+    pub node_text_id: usize,
+    pub label: String,
+    pub count: u64,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct FnEvalSuccess {
     pub value: IrValue,
     pub trace_messages: Vec<TraceMessage>,
+    pub cover_counts: Vec<CoverCount>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FnEvalFailure {
     pub assertion_failures: Vec<AssertionFailure>,
     pub trace_messages: Vec<TraceMessage>,
+    pub cover_counts: Vec<CoverCount>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1668,8 +1677,8 @@ fn observe_select_like_node(
 ///
 /// - Produces `TraceMessage`s for `trace` nodes whose `activated` predicate is
 ///   true.
-/// - Records `AssertionFailure`s for `assert` nodes whose `activate` predicate
-///   is true.
+/// - Records `AssertionFailure`s for `assert` nodes whose predicate is false.
+/// - Records `CoverCount`s for `cover` nodes, including inactive sites.
 /// - Returns the value of the function's return node on success.
 pub fn eval_fn_with_observer(
     f: &ir::Fn,
@@ -1742,6 +1751,7 @@ fn eval_fn_impl<'a>(
     let mut env = DenseEvalEnv::new(f.nodes.len());
     let mut trace_messages: Vec<TraceMessage> = Vec::new();
     let mut assertion_failures: Vec<AssertionFailure> = Vec::new();
+    let mut cover_counts: Vec<CoverCount> = Vec::new();
     for nr in eval_order(f, order_policy) {
         let node = f.get_node(nr);
         let value: IrValue = match &node.payload {
@@ -1761,12 +1771,12 @@ fn eval_fn_impl<'a>(
                 label,
             } => {
                 let _token_val = env.get(token).cloned().unwrap_or_else(IrValue::make_token);
-                let active = env
+                let condition = env
                     .get(activate)
                     .expect("assert activate operand must be evaluated")
                     .to_bool()
                     .expect("activate must be bits[1]");
-                if active {
+                if !condition {
                     if let Some(observer) = observer {
                         unsafe {
                             (&mut *observer).on_failure_event(FailureEvent {
@@ -1842,6 +1852,20 @@ fn eval_fn_impl<'a>(
                 // The result of trace is a token.
                 IrValue::make_token()
             }
+            P::Cover { predicate, label } => {
+                let active = env
+                    .get(predicate)
+                    .expect("cover predicate operand must be evaluated")
+                    .to_bool()
+                    .expect("cover predicate must be bits[1]");
+                cover_counts.push(CoverCount {
+                    node_text_id: node.text_id,
+                    label: label.clone(),
+                    count: u64::from(active),
+                });
+                // XLS cover produces the zero-sized unit value.
+                IrValue::make_tuple(&[])
+            }
             P::AfterAll(_deps) => {
                 // Tokens have no payload; produce a fresh token value.
                 IrValue::make_token()
@@ -1865,14 +1889,17 @@ fn eval_fn_impl<'a>(
                 match callee_result {
                     FnEvalResult::Success(success) => {
                         trace_messages.extend(success.trace_messages);
+                        cover_counts.extend(success.cover_counts);
                         success.value
                     }
                     FnEvalResult::Failure(fail) => {
                         assertion_failures.extend(fail.assertion_failures);
                         trace_messages.extend(fail.trace_messages);
+                        cover_counts.extend(fail.cover_counts);
                         return FnEvalResult::Failure(FnEvalFailure {
                             assertion_failures,
                             trace_messages,
+                            cover_counts,
                         });
                     }
                 }
@@ -1899,6 +1926,7 @@ fn eval_fn_impl<'a>(
                     return FnEvalResult::Failure(FnEvalFailure {
                         assertion_failures,
                         trace_messages,
+                        cover_counts,
                     });
                 }
                 let r = arg_bits.width_slice(*start as i64, *width as i64);
@@ -2050,6 +2078,7 @@ fn eval_fn_impl<'a>(
                             return FnEvalResult::Failure(FnEvalFailure {
                                 assertion_failures,
                                 trace_messages,
+                                cover_counts,
                             });
                         }
                         clamped_any = true;
@@ -2139,6 +2168,7 @@ fn eval_fn_impl<'a>(
                             return FnEvalResult::Failure(FnEvalFailure {
                                 assertion_failures,
                                 trace_messages,
+                                cover_counts,
                             });
                         } else {
                             // OOB but not assumed in-bounds: return the original array unchanged.
@@ -2223,11 +2253,13 @@ fn eval_fn_impl<'a>(
         FnEvalResult::Success(FnEvalSuccess {
             value: ret_value,
             trace_messages,
+            cover_counts,
         })
     } else {
         FnEvalResult::Failure(FnEvalFailure {
             assertion_failures,
             trace_messages,
+            cover_counts,
         })
     }
 }
@@ -3698,30 +3730,68 @@ fn f(x: bits[1] id=1) -> bits[1] {
             _ => unreachable!(),
         };
 
-        // Case 1: x = 0 => no assert triggered, one trace inactive, success
+        // Case 1: x = 0 => assert fails and trace is inactive.
         let x0 = IrValue::make_ubits(1, 0).unwrap();
         let res0 = eval_fn(&f, &[x0]);
         match res0 {
-            FnEvalResult::Success(success) => {
-                assert_eq!(success.value, IrValue::make_ubits(1, 1).unwrap());
-                assert!(success.trace_messages.is_empty());
-            }
-            other => panic!("unexpected result: {:?}", other),
-        }
-
-        // Case 2: x = 1 => assert fires and trace emits
-        let x1 = IrValue::make_ubits(1, 1).unwrap();
-        let res1 = eval_fn(&f, &[x1]);
-        match res1 {
             FnEvalResult::Failure(fail) => {
                 assert_eq!(fail.assertion_failures.len(), 1);
                 assert_eq!(fail.assertion_failures[0].message, "boom");
                 assert_eq!(fail.assertion_failures[0].label, "L");
-                assert_eq!(fail.trace_messages.len(), 1);
-                assert_eq!(fail.trace_messages[0].message, "x=bits[1]:1 done");
+                assert!(fail.trace_messages.is_empty());
             }
             other => panic!("unexpected result: {:?}", other),
         }
+
+        // Case 2: x = 1 => assert passes and trace emits.
+        let x1 = IrValue::make_ubits(1, 1).unwrap();
+        let res1 = eval_fn(&f, &[x1]);
+        match res1 {
+            FnEvalResult::Success(success) => {
+                assert_eq!(success.value, IrValue::make_ubits(1, 1).unwrap());
+                assert_eq!(success.trace_messages.len(), 1);
+                assert_eq!(success.trace_messages[0].message, "x=bits[1]:1 done");
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_eval_fn_cover_records_active_and_inactive_sites() {
+        let ir_text = r#"package test
+
+fn f(x: bits[1] id=1) -> bits[1] {
+  nx: bits[1] = not(x, id=2)
+  _active: () = cover(x, label="active", id=3)
+  _inactive: () = cover(nx, label="inactive", id=4)
+  ret identity.5: bits[1] = identity(x, id=5)
+}
+"#;
+        let mut p = Parser::new(ir_text);
+        let pkg = p.parse_and_validate_package().expect("parse ok");
+        let f = match &pkg.members[0] {
+            ir::PackageMember::Function(f) => f.clone(),
+            _ => unreachable!(),
+        };
+        let result = eval_fn(&f, &[IrValue::make_ubits(1, 1).unwrap()]);
+        let FnEvalResult::Success(success) = result else {
+            panic!("unexpected result: {result:?}");
+        };
+        assert_eq!(
+            success.cover_counts,
+            vec![
+                CoverCount {
+                    node_text_id: 3,
+                    label: "active".to_string(),
+                    count: 1,
+                },
+                CoverCount {
+                    node_text_id: 4,
+                    label: "inactive".to_string(),
+                    count: 0,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/xlsynth-pir/src/ir_eval.rs
+++ b/xlsynth-pir/src/ir_eval.rs
@@ -13,6 +13,7 @@ use crate::ir_value_utils::{
     deep_or_ir_values_for_type, ir_bits_to_usize, ir_bits_to_usize_in_range, zero_ir_value_for_type,
 };
 use crate::math::ceil_log2;
+use num_bigint::{BigInt, BigUint, Sign};
 use smallvec::SmallVec;
 use std::collections::HashMap;
 use xlsynth::{IrBits, IrValue};
@@ -1314,6 +1315,194 @@ pub enum FnEvalResult {
     Failure(FnEvalFailure),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TraceFormatPreference {
+    Default,
+    UnsignedDecimal,
+    SignedDecimal,
+    PlainHex,
+    ZeroPaddedHex,
+    Hex,
+    PlainBinary,
+    ZeroPaddedBinary,
+    Binary,
+}
+
+const TRACE_FORMAT_SPECIFIERS: [(&str, TraceFormatPreference); 9] = [
+    ("{}", TraceFormatPreference::Default),
+    ("{:u}", TraceFormatPreference::UnsignedDecimal),
+    ("{:d}", TraceFormatPreference::SignedDecimal),
+    ("{:x}", TraceFormatPreference::PlainHex),
+    ("{:0x}", TraceFormatPreference::ZeroPaddedHex),
+    ("{:#x}", TraceFormatPreference::Hex),
+    ("{:b}", TraceFormatPreference::PlainBinary),
+    ("{:0b}", TraceFormatPreference::ZeroPaddedBinary),
+    ("{:#b}", TraceFormatPreference::Binary),
+];
+
+/// Formats one trace operand using the XLS trace human-value convention.
+fn format_trace_value(value: &IrValue, ty: &ir::Type, preference: TraceFormatPreference) -> String {
+    match ty {
+        ir::Type::Bits(bit_count) => {
+            let bytes = value
+                .to_bits()
+                .expect("trace bits value must have bits representation")
+                .to_le_bytes()
+                .expect("trace bits payload must convert to bytes");
+            format_trace_bits(BigUint::from_bytes_le(&bytes), *bit_count, preference)
+        }
+        ir::Type::Tuple(fields) => {
+            let elements = fields
+                .iter()
+                .enumerate()
+                .map(|(index, field_ty)| {
+                    format_trace_value(
+                        &value
+                            .get_element(index)
+                            .expect("trace tuple value must have expected field"),
+                        field_ty,
+                        preference,
+                    )
+                })
+                .collect::<Vec<_>>();
+            format!("({})", elements.join(", "))
+        }
+        ir::Type::Array(array) => {
+            let elements = (0..array.element_count)
+                .map(|index| {
+                    format_trace_value(
+                        &value
+                            .get_element(index)
+                            .expect("trace array value must have expected element"),
+                        &array.element_type,
+                        preference,
+                    )
+                })
+                .collect::<Vec<_>>();
+            format!("[{}]", elements.join(", "))
+        }
+        ir::Type::Token => "token".to_string(),
+    }
+}
+
+fn format_trace_bits(
+    mut value: BigUint,
+    bit_count: usize,
+    preference: TraceFormatPreference,
+) -> String {
+    if bit_count == 0 {
+        value = BigUint::from(0u8);
+    } else {
+        value &= (BigUint::from(1u8) << bit_count) - BigUint::from(1u8);
+    }
+    match preference {
+        TraceFormatPreference::Default => {
+            if bit_count <= 64 {
+                value.to_str_radix(10)
+            } else {
+                format_trace_bits(value, bit_count, TraceFormatPreference::Hex)
+            }
+        }
+        TraceFormatPreference::UnsignedDecimal => value.to_str_radix(10),
+        TraceFormatPreference::SignedDecimal => {
+            if bit_count != 0
+                && (&value & (BigUint::from(1u8) << (bit_count - 1))) != BigUint::from(0u8)
+            {
+                (BigInt::from_biguint(Sign::Plus, value)
+                    - BigInt::from_biguint(Sign::Plus, BigUint::from(1u8) << bit_count))
+                .to_string()
+            } else {
+                value.to_str_radix(10)
+            }
+        }
+        TraceFormatPreference::PlainHex => value.to_str_radix(16),
+        TraceFormatPreference::ZeroPaddedHex => {
+            zero_padded_grouped_digits(&value, bit_count, 4, 16)
+        }
+        TraceFormatPreference::Hex => {
+            format!("0x{}", grouped_digits(&value.to_str_radix(16)))
+        }
+        TraceFormatPreference::PlainBinary => value.to_str_radix(2),
+        TraceFormatPreference::ZeroPaddedBinary => {
+            zero_padded_grouped_digits(&value, bit_count, 1, 2)
+        }
+        TraceFormatPreference::Binary => {
+            format!("0b{}", grouped_digits(&value.to_str_radix(2)))
+        }
+    }
+}
+
+fn zero_padded_grouped_digits(
+    value: &BigUint,
+    bit_count: usize,
+    bits_per_digit: usize,
+    radix: u32,
+) -> String {
+    let digit_count = bit_count.div_ceil(bits_per_digit).max(1);
+    let digits = format!(
+        "{:0>width$}",
+        value.to_str_radix(radix),
+        width = digit_count
+    );
+    grouped_digits(&digits)
+}
+
+fn grouped_digits(digits: &str) -> String {
+    let first_group_width = match digits.len() % 4 {
+        0 => 4,
+        remainder => remainder,
+    };
+    let mut result = digits[..first_group_width].to_string();
+    for group_start in (first_group_width..digits.len()).step_by(4) {
+        result.push('_');
+        result.push_str(&digits[group_start..group_start + 4]);
+    }
+    result
+}
+
+/// Applies a verified XLS trace format string to evaluated operand values.
+fn format_trace_message(
+    format: &str,
+    operands: &[ir::NodeRef],
+    f: &ir::Fn,
+    env: &DenseEvalEnv,
+) -> String {
+    let mut output = String::new();
+    let mut offset = 0usize;
+    let mut operand_index = 0usize;
+    while offset < format.len() {
+        let remainder = &format[offset..];
+        if remainder.starts_with("{{") || remainder.starts_with("}}") {
+            // XLS preserves escaped braces in IR trace output.
+            output.push_str(&remainder[..2]);
+            offset += 2;
+            continue;
+        }
+        if let Some((specifier, preference)) = TRACE_FORMAT_SPECIFIERS
+            .iter()
+            .find(|(specifier, _)| remainder.starts_with(specifier))
+        {
+            if let Some(operand) = operands.get(operand_index) {
+                output.push_str(&format_trace_value(
+                    env.get(operand).expect("trace operand must be evaluated"),
+                    &f.get_node(*operand).ty,
+                    *preference,
+                ));
+            }
+            operand_index += 1;
+            offset += specifier.len();
+            continue;
+        }
+        let character = remainder
+            .chars()
+            .next()
+            .expect("offset is within trace format string");
+        output.push(character);
+        offset += character.len_utf8();
+    }
+    output
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SelectKind {
     CaseIndex,
@@ -1808,43 +1997,8 @@ fn eval_fn_impl<'a>(
                     .to_bool()
                     .expect("activated must be bits[1]");
                 if is_active {
-                    // Build a message by replacing sequential `{}` occurrences with operand values
-                    // in default formatting. If placeholders are fewer than operands, extra
-                    // operands are appended in bracketed list for visibility.
-                    let mut msg = String::new();
-                    let mut parts = format.split("{}");
-                    let mut first = true;
-                    let mut op_iter = operands.iter();
-                    loop {
-                        let part = parts.next();
-                        if part.is_none() {
-                            break;
-                        }
-                        let part = part.unwrap();
-                        if !first {
-                            if let Some(op_ref) = op_iter.next() {
-                                let v = env.get(op_ref).expect("trace operand must be evaluated");
-                                msg.push_str(&v.to_string());
-                            }
-                        }
-                        first = false;
-                        msg.push_str(part);
-                    }
-                    // Append any remaining operands if there were more operands than `{}`.
-                    let remaining: Vec<String> = op_iter
-                        .map(|r| {
-                            env.get(r)
-                                .expect("trace operand must be evaluated")
-                                .to_string()
-                        })
-                        .collect();
-                    if !remaining.is_empty() {
-                        msg.push_str(" [");
-                        msg.push_str(&remaining.join(", "));
-                        msg.push(']');
-                    }
                     trace_messages.push(TraceMessage {
-                        message: msg,
+                        message: format_trace_message(format, operands, f, &env),
                         // XLS trace nodes in this IR do not carry verbosity; use 0.
                         verbosity: 0,
                     });
@@ -3750,10 +3904,38 @@ fn f(x: bits[1] id=1) -> bits[1] {
             FnEvalResult::Success(success) => {
                 assert_eq!(success.value, IrValue::make_ubits(1, 1).unwrap());
                 assert_eq!(success.trace_messages.len(), 1);
-                assert_eq!(success.trace_messages[0].message, "x=bits[1]:1 done");
+                assert_eq!(success.trace_messages[0].message, "x=1 done");
             }
             other => panic!("unexpected result: {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_eval_fn_trace_formats_match_xls_human_value_syntax() {
+        let ir_text = r#"package test
+
+fn f(x: bits[12] id=1, neg: bits[8] id=2, wide: bits[72] id=3) -> token {
+  t: token = after_all(id=4)
+  one: bits[1] = literal(value=1, id=5)
+  ret tr: token = trace(t, one, format="literal={{ default={} u={:u} d={:d} x={:x} 0x={:0x} #x={:#x} b={:b} 0b={:0b} #b={:#b} wide={} wide_u={:u}", data_operands=[x, x, neg, x, x, x, x, x, x, wide, wide], id=6)
+}
+"#;
+        let mut p = Parser::new(ir_text);
+        let pkg = p.parse_and_validate_package().expect("parse ok");
+        let f = pkg.get_fn("f").expect("f");
+        let args = vec![
+            IrValue::make_ubits(12, 43).unwrap(),
+            IrValue::make_ubits(8, 251).unwrap(),
+            IrValue::parse_typed("bits[72]:0x1_0000_0000_0000_0001").unwrap(),
+        ];
+        let res = eval_fn(f, &args);
+        let FnEvalResult::Success(success) = res else {
+            panic!("trace should not fail: {res:?}");
+        };
+        assert_eq!(
+            success.trace_messages[0].message,
+            "literal={{ default=43 u=43 d=-5 x=2b 0x=02b #x=0x2b b=101011 0b=0000_0010_1011 #b=0b10_1011 wide=0x1_0000_0000_0000_0001 wide_u=18446744073709551617"
+        );
     }
 
     #[test]
@@ -3975,7 +4157,7 @@ fn f(x: bits[8] id=10) -> bits[8] {
             FnEvalResult::Success(success) => {
                 assert_eq!(success.value, IrValue::make_ubits(8, 7).unwrap());
                 let want = vec![TraceMessage {
-                    message: "in g x=bits[8]:7".to_string(),
+                    message: "in g x=7".to_string(),
                     verbosity: 0,
                 }];
                 assert_eq!(success.trace_messages, want);

--- a/xlsynth-pir/src/ir_random.rs
+++ b/xlsynth-pir/src/ir_random.rs
@@ -1738,15 +1738,24 @@ impl<'a> FunctionGenerator<'a> {
             RandomOperation::Trace => {
                 let token = self.choose_token_ref(source);
                 let activated = self.choose_ref_for_type(source, &Type::Bits(1));
-                let operand_ty = self.choose_selectable_type(source);
-                let operand = self.choose_ref_for_type(source, &operand_ty);
+                let operand_count = choose_between(source, 0, 3);
+                let operands = (0..operand_count)
+                    .map(|_| {
+                        let operand_ty = self.choose_selectable_type(source);
+                        self.choose_ref_for_type(source, &operand_ty)
+                    })
+                    .collect();
+                let format = match operand_count {
+                    0 => "random_trace".to_string(),
+                    count => format!("random_trace={}", vec!["{}"; count].join(",")),
+                };
                 Ok(self.add_node(
                     Type::Token,
                     NodePayload::Trace {
                         token,
                         activated,
-                        format: "random_trace={}".to_string(),
-                        operands: vec![operand],
+                        format,
+                        operands,
                     },
                     None,
                 ))

--- a/xlsynth-pir/src/ir_random.rs
+++ b/xlsynth-pir/src/ir_random.rs
@@ -16,6 +16,10 @@ use crate::ir::{
 use crate::ir_utils::{is_observable_effect_root, operands};
 use crate::math::ceil_log2;
 
+const TRACE_FORMAT_SPECIFIERS: [&str; 9] = [
+    "{}", "{:u}", "{:d}", "{:x}", "{:0x}", "{:#x}", "{:b}", "{:0b}", "{:#b}",
+];
+
 /// Operations that the random generator can introduce into a function body.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum RandomOperation {
@@ -1745,10 +1749,21 @@ impl<'a> FunctionGenerator<'a> {
                         self.choose_ref_for_type(source, &operand_ty)
                     })
                     .collect();
-                let format = match operand_count {
-                    0 => "random_trace".to_string(),
-                    count => format!("random_trace={}", vec!["{}"; count].join(",")),
+                let mut format = if choose_count(source, 4) == 0 {
+                    "random_trace={{".to_string()
+                } else {
+                    "random_trace".to_string()
                 };
+                if operand_count != 0 {
+                    let specifiers = (0..operand_count)
+                        .map(|_| {
+                            TRACE_FORMAT_SPECIFIERS
+                                [choose_count(source, TRACE_FORMAT_SPECIFIERS.len())]
+                        })
+                        .collect::<Vec<_>>();
+                    format.push('=');
+                    format.push_str(&specifiers.join(","));
+                }
                 Ok(self.add_node(
                     Type::Token,
                     NodePayload::Trace {

--- a/xlsynth-pir/tests/ir_random.rs
+++ b/xlsynth-pir/tests/ir_random.rs
@@ -1293,7 +1293,7 @@ fn probabilistic_event_generation_emits_tokens_effects_and_valid_xls_ir() {
     let mut live = HashSet::new();
     let mut saw_token_param = false;
     let mut saw_token_literal = false;
-    let mut saw_trace_dynamic_operand = false;
+    let mut saw_trace_operand_counts = BTreeSet::new();
 
     for sample in 0..750 {
         let generated =
@@ -1312,9 +1312,17 @@ fn probabilistic_event_generation_emits_tokens_effects_and_valid_xls_ir() {
                 NodePayload::Trace {
                     format, operands, ..
                 } => {
-                    saw_trace_dynamic_operand |= format == "random_trace={}"
-                        && operands.len() == 1
-                        && generated.function.get_node(operands[0]).ty != Type::Token;
+                    let expected_format = match operands.len() {
+                        0 => "random_trace".to_string(),
+                        count => format!("random_trace={}", vec!["{}"; count].join(",")),
+                    };
+                    assert_eq!(format, &expected_format);
+                    assert!(
+                        operands
+                            .iter()
+                            .all(|operand| generated.function.get_node(*operand).ty != Type::Token)
+                    );
+                    saw_trace_operand_counts.insert(operands.len());
                 }
                 _ => {}
             }
@@ -1343,7 +1351,7 @@ fn probabilistic_event_generation_emits_tokens_effects_and_valid_xls_ir() {
     }
     assert!(saw_token_param);
     assert!(saw_token_literal);
-    assert!(saw_trace_dynamic_operand);
+    assert_eq!(saw_trace_operand_counts, BTreeSet::from([0, 1, 2, 3]));
 }
 
 #[test]

--- a/xlsynth-pir/tests/ir_random.rs
+++ b/xlsynth-pir/tests/ir_random.rs
@@ -1294,6 +1294,11 @@ fn probabilistic_event_generation_emits_tokens_effects_and_valid_xls_ir() {
     let mut saw_token_param = false;
     let mut saw_token_literal = false;
     let mut saw_trace_operand_counts = BTreeSet::new();
+    let mut saw_trace_format_specifiers = BTreeSet::new();
+    let mut saw_trace_escaped_open_brace = false;
+    let trace_format_specifiers = [
+        "{}", "{:u}", "{:d}", "{:x}", "{:0x}", "{:#x}", "{:b}", "{:0b}", "{:#b}",
+    ];
 
     for sample in 0..750 {
         let generated =
@@ -1312,17 +1317,19 @@ fn probabilistic_event_generation_emits_tokens_effects_and_valid_xls_ir() {
                 NodePayload::Trace {
                     format, operands, ..
                 } => {
-                    let expected_format = match operands.len() {
-                        0 => "random_trace".to_string(),
-                        count => format!("random_trace={}", vec!["{}"; count].join(",")),
-                    };
-                    assert_eq!(format, &expected_format);
+                    assert!(format.starts_with("random_trace"));
                     assert!(
                         operands
                             .iter()
                             .all(|operand| generated.function.get_node(*operand).ty != Type::Token)
                     );
                     saw_trace_operand_counts.insert(operands.len());
+                    saw_trace_escaped_open_brace |= format.contains("{{");
+                    for specifier in trace_format_specifiers {
+                        if format.contains(specifier) {
+                            saw_trace_format_specifiers.insert(specifier);
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -1352,6 +1359,11 @@ fn probabilistic_event_generation_emits_tokens_effects_and_valid_xls_ir() {
     assert!(saw_token_param);
     assert!(saw_token_literal);
     assert_eq!(saw_trace_operand_counts, BTreeSet::from([0, 1, 2, 3]));
+    assert_eq!(
+        saw_trace_format_specifiers,
+        BTreeSet::from(trace_format_specifiers)
+    );
+    assert!(saw_trace_escaped_open_brace);
 }
 
 #[test]


### PR DESCRIPTION
This requires adding a small runtime library (as a crate).