### PR TITLE
Use bitwuzla universally now unless --solver specifies otherwise.

### DIFF
--- a/scripts/run_all_fuzz_tests.py
+++ b/scripts/run_all_fuzz_tests.py
@@ -43,7 +43,7 @@ def find_fuzz_dirs(repo_root: Path) -> list[Path]:
         if not child.is_dir():
             continue
         fuzz_dir = child / "fuzz"
-        if fuzz_dir.exists():
+        if (fuzz_dir / "Cargo.toml").is_file():
             fuzz_dirs.append(fuzz_dir)
     return fuzz_dirs
 

--- a/xlsynth-autocov/README.md
+++ b/xlsynth-autocov/README.md
@@ -28,7 +28,7 @@ cargo run -p xlsynth-autocov --bin relevant -- \
   --node-text-id 123
 ```
 
-By default it uses `--solver auto`. You can also select a solver explicitly:
+By default it uses `--solver bitwuzla`. You can also select a solver explicitly:
 
 ```bash
 cargo run -p xlsynth-autocov --bin relevant -- \

--- a/xlsynth-autocov/src/bin/relevant.rs
+++ b/xlsynth-autocov/src/bin/relevant.rs
@@ -10,9 +10,6 @@ use xlsynth_prover::prover::SolverChoice;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 enum SolverArg {
-    /// Let the library select an appropriate prover based on available
-    /// features.
-    Auto,
     /// Use the external XLS tool-chain binaries (configured via tool_path or
     /// environment).
     Toolchain,
@@ -22,7 +19,6 @@ enum SolverArg {
     BitwuzlaBinary,
     #[cfg(feature = "has-easy-smt")]
     BoolectorBinary,
-    #[cfg(feature = "has-bitwuzla")]
     Bitwuzla,
     #[cfg(feature = "has-boolector")]
     Boolector,
@@ -30,7 +26,6 @@ enum SolverArg {
 
 fn solver_choice_from_arg(arg: SolverArg) -> SolverChoice {
     match arg {
-        SolverArg::Auto => SolverChoice::Auto,
         SolverArg::Toolchain => SolverChoice::Toolchain,
         #[cfg(feature = "has-easy-smt")]
         SolverArg::Z3Binary => SolverChoice::Z3Binary,
@@ -38,7 +33,6 @@ fn solver_choice_from_arg(arg: SolverArg) -> SolverChoice {
         SolverArg::BitwuzlaBinary => SolverChoice::BitwuzlaBinary,
         #[cfg(feature = "has-easy-smt")]
         SolverArg::BoolectorBinary => SolverChoice::BoolectorBinary,
-        #[cfg(feature = "has-bitwuzla")]
         SolverArg::Bitwuzla => SolverChoice::Bitwuzla,
         #[cfg(feature = "has-boolector")]
         SolverArg::Boolector => SolverChoice::Boolector,
@@ -65,9 +59,9 @@ struct Args {
 
     /// Solver selection for equivalence checking.
     ///
-    /// Values match `xlsynth-prover`'s `SolverChoice` strings (e.g. `auto`,
-    /// `toolchain`, `bitwuzla` when enabled).
-    #[arg(long, value_enum, default_value_t = SolverArg::Auto)]
+    /// Values match `xlsynth-prover`'s `SolverChoice` strings (e.g.
+    /// `bitwuzla`, `toolchain`).
+    #[arg(long, value_enum, default_value_t = SolverArg::Bitwuzla)]
     solver: SolverArg,
 
     /// Optional toolchain path (used only with `--solver toolchain`).

--- a/xlsynth-driver/README.md
+++ b/xlsynth-driver/README.md
@@ -30,7 +30,7 @@ Proves two IR functions to be equivalent or provides a counterexample to their e
 Key flags:
 
 - `--top <NAME>` or per-side `--lhs_ir_top <NAME>` / `--rhs_ir_top <NAME>` to select entry points.
-- `--solver <auto|toolchain|bitwuzla|boolector|z3-binary|bitwuzla-binary|boolector-binary>`
+- `--solver <bitwuzla|toolchain|boolector|z3-binary|bitwuzla-binary|boolector-binary>`
 - `--flatten_aggregates=<BOOL>`
 - `--drop_params <CSV>`
 - `--parallelism-strategy <single-threaded|output-bits|input-bit-split>`
@@ -46,7 +46,7 @@ Proves two IR blocks to be equivalent by selecting block members from package-fo
 Key flags:
 
 - `--lhs_top <NAME>` / `--rhs_top <NAME>` or shared `--top <NAME>` to select block entry points (by block name in each package). If omitted, the package `top` block is used when present; otherwise the first block member is selected.
-- `--solver <auto|toolchain|bitwuzla|boolector|z3-binary|bitwuzla-binary|boolector-binary>`
+- `--solver <bitwuzla|toolchain|boolector|z3-binary|bitwuzla-binary|boolector-binary>`
 - `--flatten_aggregates=<BOOL>`
 - `--drop_params <CSV>`
 - `--parallelism-strategy <single-threaded|output-bits|input-bit-split>`
@@ -1645,6 +1645,7 @@ Notes:
 
 - Structural hashing ignores position metadata, assertion/trace strings, and parameter text ids (params are keyed by ordinal position in the signature). It includes node kinds, types, selected attributes (e.g., widths), and child structure.
 - Opcode summaries group discrepancies by operator per depth to make eyeballing easier; detailed signatures include operand/attribute types for precise diagnosis.
+- `--solver <bitwuzla|toolchain|boolector|z3-binary|bitwuzla-binary|boolector-binary>` selects the backend used for the emitted equivalence checks. The default is `bitwuzla`.
 
 ### `ir-localized-eco`
 
@@ -1659,6 +1660,7 @@ Computes a localized ECO diff (old → new) between two IR functions and emits a
   - `--sanity-samples <N>` – if > 0, run N randomized interpreter samples (in addition to all-zeros and all-ones) to sanity-check that patched(old) ≡ new.
   - `--sanity-seed <SEED>` – seed for randomized interpreter samples.
   - `--compute-text-diff=<BOOL>` – compute IR/RTL text diffs (expensive). Defaults to `false`.
+  - `--solver <bitwuzla|toolchain|boolector|z3-binary|bitwuzla-binary|boolector-binary>` – backend for the final equivalence proof. Defaults to `bitwuzla`.
 
 Example:
 
@@ -1998,8 +2000,8 @@ running the same prover-backed flow as `ir-equiv`.
 
 - Positional arguments: `<lhs_g8r_file> <rhs_g8r_file>`
 - Solver selection:
-  - `--solver auto|z3-binary|bitwuzla-binary|boolector-binary|bitwuzla|boolector|toolchain`
-  - Default: `auto`
+  - `--solver bitwuzla|z3-binary|bitwuzla-binary|boolector-binary|boolector|toolchain`
+  - Default: `bitwuzla`
 - Optional JSON output:
   - `--output_json <path>` writes the structured result to a file
 
@@ -2019,7 +2021,7 @@ function-equivalence command.
   - `--top <NAME>` selects the entry function in `<rhs_ir_file>`.
   - The GateFn side uses the GateFn's own name as its lifted IR top.
 - Proving flags (same shape as `ir-equiv`):
-  - `--solver <auto|toolchain|bitwuzla|boolector|z3-binary|bitwuzla-binary|boolector-binary>`
+  - `--solver <bitwuzla|toolchain|boolector|z3-binary|bitwuzla-binary|boolector-binary>`
   - `--flatten_aggregates=<BOOL>`
   - `--drop_params <CSV>`
   - `--parallelism-strategy <single-threaded|output-bits|input-bit-split>`
@@ -2048,8 +2050,8 @@ same prover-backed flow as `ir-equiv`.
 
 - Positional arguments: `<lhs_aig_file> <rhs_aig_file>`
 - Solver selection:
-  - `--solver auto|z3-binary|bitwuzla-binary|boolector-binary|bitwuzla|boolector|toolchain`
-  - Default: `auto`
+  - `--solver bitwuzla|z3-binary|bitwuzla-binary|boolector-binary|boolector|toolchain`
+  - Default: `bitwuzla`
 - Optional JSON output:
   - `--output_json <path>` writes the structured result to a file
 
@@ -2085,7 +2087,7 @@ lifting the AIGER into IR and then running the same IR equivalence flow as
   for the canonical flattening rule.
 - No AIGER-side regrouping is inferred from symbol names or suffixes.
 - Proving flags (same shape as `ir-equiv`):
-  - `--solver <auto|toolchain|bitwuzla|boolector|z3-binary|bitwuzla-binary|boolector-binary>`
+  - `--solver <bitwuzla|toolchain|boolector|z3-binary|bitwuzla-binary|boolector-binary>`
   - `--flatten_aggregates=<BOOL>`
   - `--drop_params <CSV>`
   - `--parallelism-strategy <single-threaded|output-bits|input-bit-split>`
@@ -2135,7 +2137,7 @@ Checks two DSLX functions for functional equivalence. By default it converts bot
 - Entry-point selection: either `--dslx_top <NAME>` or both `--lhs_dslx_top <NAME>` and `--rhs_dslx_top <NAME>`.
 - Search paths: `--dslx_path <P1;P2;...>` and `--dslx_stdlib_path <PATH>`.
 - Behavior flags:
-  - `--solver <auto|toolchain|bitwuzla|boolector|z3-binary|bitwuzla-binary|boolector-binary>`
+  - `--solver <bitwuzla|toolchain|boolector|z3-binary|bitwuzla-binary|boolector-binary>`
   - `--flatten_aggregates=<BOOL>`
   - `--drop_params <CSV>`
   - `--parallelism-strategy <single-threaded|output-bits|input-bit-split>`
@@ -2369,7 +2371,7 @@ xlsynth-driver dslx-fn-prove-assertions \
 ```
 
 - Inputs: `--dslx_input_file <FILE>` and `--dslx_top <FUNC>` select the DSLX module and entry point.
-- Backend: `--solver <...>` selects the SMT backend. `auto` chooses only supported in-process SMT backends and errors when none are available. `toolchain` mode is not currently supported for this command because the flow proves an IR-level wrapper with fixed implicit activation.
+- Backend: `--solver <...>` selects the SMT backend. The default is `bitwuzla`, which requires an in-process Bitwuzla build feature. `toolchain` mode is not currently supported for this command because the flow proves an IR-level wrapper with fixed implicit activation.
 - Assertion filter: `--assert-label-filter <REGEX>` includes only assertions whose label matches the regex.
 - Enum inputs: `--assume-enum-in-bound <BOOL>` defaults to `true`, constraining enum-typed top parameters to declared enum members instead of all lowered bit patterns.
 - UF mapping: repeat `--uf <func_name:uf_name>` to treat helper functions as uninterpreted. Assertions inside UF-mapped functions are ignored during proving.
@@ -2409,7 +2411,7 @@ Proves that DSLX `#[quickcheck]` functions always return true.
 - Inputs: `--dslx_input_file <FILE>` plus optional DSLX search paths.
 - Scripts: `--tactic_json <PATH>` (`--tactic_jsonl <PATH>` for JSONL) switches to the tactic/script-driven workflow so you can edit QuickCheck obligations before solving.
 - Filters: `--test_filter <REGEX>` restricts which quickcheck functions are proved.
-- Backend: `--solver <...>` selects the solver/toolchain (`auto` defers to the library's feature-based default).
+- Backend: `--solver <...>` selects the solver/toolchain. The default is `bitwuzla`.
 - Semantics: `--assertion-semantics <ignore|never|assume>` (defaults to `never`; external toolchain supports only `never`).
 - Assertion filter: `--assert-label-filter <REGEX>` – include only assertions whose label matches this regex (use `|` to combine multiple labels).
 - UF mapping: `--uf <func_name:uf_name>` may be specified multiple times to treat functions as uninterpreted.
@@ -2632,7 +2634,7 @@ Schema details
   - Optional:
     - `dslx_path`: array of paths (joined with `;`)
     - `dslx_stdlib_path`: path
-    - `solver`: same values as above, except `toolchain` is rejected by this command. `auto` requires an available in-process SMT backend for this task.
+    - `solver`: same values as above, except `toolchain` is rejected by this command. The default `bitwuzla` backend requires an in-process Bitwuzla build feature.
     - `assert_label_filter`: string (regex)
     - `assume_enum_in_bound`: bool
     - `uf`: array of strings, each "`<func_name>:<uf_name>`". Functions sharing the same `uf_name` are assumed equivalent; assertions inside them are ignored.

--- a/xlsynth-driver/src/dslx_fn_prove_assertions.rs
+++ b/xlsynth-driver/src/dslx_fn_prove_assertions.rs
@@ -139,7 +139,7 @@ pub fn handle_dslx_fn_prove_assertions(
     let solver = matches
         .get_one::<String>("solver")
         .map(|s| s.parse().unwrap())
-        .unwrap_or(SolverChoice::Auto);
+        .unwrap_or(SolverChoice::Bitwuzla);
     if solver == SolverChoice::Toolchain {
         report_cli_error_and_exit(
             "Solver 'toolchain' is not supported for this command",

--- a/xlsynth-driver/src/ir_localized_eco.rs
+++ b/xlsynth-driver/src/ir_localized_eco.rs
@@ -18,6 +18,7 @@ use xlsynth_pir::ir_parser::{self, emit_fn_as_block};
 use xlsynth_pir::random_inputs::{
     generate_biased_arguments_with_rng, generate_pattern_arguments, BitValuePattern,
 };
+use xlsynth_prover::prover::SolverChoice;
 
 #[derive(serde::Serialize)]
 struct AddedOpsSummaryItem {
@@ -39,6 +40,15 @@ pub fn handle_ir_localized_eco(matches: &ArgMatches, config: &Option<ToolchainCo
     let new_path = std::path::Path::new(matches.get_one::<String>("new_ir_file").unwrap());
     let old_ir_top = matches.get_one::<String>("old_ir_top");
     let new_ir_top = matches.get_one::<String>("new_ir_top");
+    let solver: SolverChoice = matches
+        .get_one::<String>("solver")
+        .unwrap()
+        .parse()
+        .unwrap();
+    let tool_path = config
+        .as_ref()
+        .and_then(|c| c.tool_path.as_deref())
+        .map(Path::new);
 
     // Read inputs to detect whether they are package IR or standalone block IR.
     let old_text = match std::fs::read_to_string(old_path) {
@@ -121,6 +131,8 @@ pub fn handle_ir_localized_eco(matches: &ArgMatches, config: &Option<ToolchainCo
             old_ports,
             new_block_fn,
             new_ports,
+            solver,
+            tool_path,
         );
     }
 
@@ -305,64 +317,49 @@ pub fn handle_ir_localized_eco(matches: &ArgMatches, config: &Option<ToolchainCo
             }
         }
     }
-    // Optional: Prove old vs new equivalence using toolchain if available.
-    // Determine tool_path: prefer --toolchain config; otherwise use XLSYNTH_TOOLS
-    // env var if set.
-    let mut tool_path_opt: Option<String> = config.as_ref().and_then(|c| c.tool_path.clone());
-    if tool_path_opt.is_none() {
-        if let Ok(env_tools) = std::env::var("XLSYNTH_TOOLS") {
-            if !env_tools.trim().is_empty() {
-                tool_path_opt = Some(env_tools);
-            }
-        }
-    }
+    // Prove: patched_old.ir ≡ new.ir using the selected solver.
+    let patched_ir_text = std::fs::read_to_string(&patched_ir_path).unwrap();
+    let new_ir_text = std::fs::read_to_string(new_path).unwrap();
+    // Use the new function's name as the top on both sides (patched equals new
+    // package text).
+    let lhs_top = Some(new_fn.name.as_str());
+    let rhs_top = Some(new_fn.name.as_str());
+    println!(
+        "  Starting equivalence proof using solver '{}': patched='{}' top='{}' vs new='{}' top='{}'",
+        solver,
+        patched_ir_path.display(),
+        lhs_top.unwrap_or(""),
+        new_path.display(),
+        rhs_top.unwrap_or("")
+    );
+    let request = IrEquivRequest::new(
+        IrModule::new(&patched_ir_text)
+            .with_path(Some(patched_ir_path.as_path()))
+            .with_top(lhs_top),
+        IrModule::new(&new_ir_text)
+            .with_path(Some(new_path))
+            .with_top(rhs_top),
+    )
+    .with_solver(Some(solver))
+    .with_tool_path(tool_path);
 
-    if let Some(tool_path) = tool_path_opt.as_deref() {
-        // Prove: patched_old.ir ≡ new.ir
-        let patched_ir_text = std::fs::read_to_string(&patched_ir_path).unwrap();
-        let new_ir_text = std::fs::read_to_string(new_path).unwrap();
-        // Use the new function's name as the top on both sides (patched equals new
-        // package text).
-        let lhs_top = Some(new_fn.name.as_str());
-        let rhs_top = Some(new_fn.name.as_str());
-        println!(
-            "  Starting equivalence proof using toolchain at {}: patched='{}' top='{}' vs new='{}' top='{}'",
-            tool_path,
-            patched_ir_path.display(),
-            lhs_top.unwrap_or(""),
-            new_path.display(),
-            rhs_top.unwrap_or("")
-        );
-        let request = IrEquivRequest::new(
-            IrModule::new(&patched_ir_text)
-                .with_path(Some(patched_ir_path.as_path()))
-                .with_top(lhs_top),
-            IrModule::new(&new_ir_text)
-                .with_path(Some(new_path))
-                .with_top(rhs_top),
-        )
-        .with_tool_path(Some(Path::new(tool_path)));
-
-        let outcome = dispatch_ir_equiv(&request, "ir-localized-eco");
-        let dur = std::time::Duration::from_micros(outcome.time_micros as u64);
-        if outcome.success {
-            println!("  Equivalence: proved (patched(old) ≡ new) in {:?}", dur);
-        } else {
-            println!("  Equivalence: FAILED (patched(old) vs new) in {:?}", dur);
-            if let Some(err) = outcome.error_str.as_ref() {
-                println!("    error: {}", err);
-                // Attempt to replay the counterexample via interpreter.
-                if let Some(input_idx) = err.find("input:") {
-                    let arg_text = err[input_idx + "input:".len()..].trim();
-                    match try_interpret_cex(&new_ir_text, new_fn, &patched_ir_path, arg_text) {
-                        Ok(()) => {}
-                        Err(e) => println!("    interpreter replay: skipped ({})", e),
-                    }
+    let outcome = dispatch_ir_equiv(&request, "ir-localized-eco");
+    let dur = std::time::Duration::from_micros(outcome.time_micros as u64);
+    if outcome.success {
+        println!("  Equivalence: proved (patched(old) ≡ new) in {:?}", dur);
+    } else {
+        println!("  Equivalence: FAILED (patched(old) vs new) in {:?}", dur);
+        if let Some(err) = outcome.error_str.as_ref() {
+            println!("    error: {}", err);
+            // Attempt to replay the counterexample via interpreter.
+            if let Some(input_idx) = err.find("input:") {
+                let arg_text = err[input_idx + "input:".len()..].trim();
+                match try_interpret_cex(&new_ir_text, new_fn, &patched_ir_path, arg_text) {
+                    Ok(()) => {}
+                    Err(e) => println!("    interpreter replay: skipped ({})", e),
                 }
             }
         }
-    } else {
-        println!("  Equivalence: skipped (no --toolchain config and no XLSYNTH_TOOLS env var)");
     }
 }
 
@@ -446,6 +443,8 @@ fn handle_ir_localized_eco_blocks_in_packages(
     old_ports: &BlockMetadata,
     new_fn: &ir_mod::Fn,
     new_ports: &BlockMetadata,
+    solver: SolverChoice,
+    tool_path: Option<&Path>,
 ) {
     // Summaries (rebase-based): will compute added_count after building applied.
     let added_ops: Vec<AddedOpsSummaryItem> = Vec::new();
@@ -535,21 +534,15 @@ fn handle_ir_localized_eco_blocks_in_packages(
     println!("  Done.");
 
     // Attempt equivalence by wrapping the functions into minimal packages and
-    // invoking the external checker, if tools are configured.
-    match std::env::var("XLSYNTH_TOOLS") {
-        Ok(p) if !p.trim().is_empty() => {
-            let lhs_pkg = format!("package lhs\n\ntop {}", applied.to_string());
-            let rhs_pkg = format!("package rhs\n\ntop {}", new_fn.to_string());
-            let top_name = Some(new_fn.name.as_str());
-            match check_equivalence::check_equivalence_with_top(&lhs_pkg, &rhs_pkg, top_name, false)
-            {
-                Ok(()) => println!("  Equivalence: proved (patched(old) ≡ new)"),
-                Err(e) => println!("  Equivalence: FAILED: {}", e),
-            }
-        }
-        _ => {
-            println!("  Equivalence: skipped (no XLSYNTH_TOOLS env var)");
-        }
+    // using the selected solver.
+    let lhs_pkg = format!("package lhs\n\ntop {}", applied.to_string());
+    let rhs_pkg = format!("package rhs\n\ntop {}", new_fn.to_string());
+    let top_name = Some(new_fn.name.as_str());
+    match check_equivalence::check_equivalence_with_top_and_solver(
+        &lhs_pkg, &rhs_pkg, top_name, solver, tool_path,
+    ) {
+        Ok(()) => println!("  Equivalence: proved (patched(old) ≡ new)"),
+        Err(e) => println!("  Equivalence: FAILED: {}", e),
     }
 }
 

--- a/xlsynth-driver/src/ir_structural_similarity.rs
+++ b/xlsynth-driver/src/ir_structural_similarity.rs
@@ -16,7 +16,9 @@ use xlsynth_pir::{
 use crate::toolchain_config::ToolchainConfig;
 use comfy_table::presets::ASCII_MARKDOWN;
 use comfy_table::{ContentArrangement, Table};
+use std::path::Path;
 use xlsynth_g8r::check_equivalence;
+use xlsynth_prover::prover::SolverChoice;
 
 fn find_node_signature_by_textual_id(f: &ir::Fn, text: &str) -> Option<String> {
     for (i, _n) in f.nodes.iter().enumerate() {
@@ -69,25 +71,42 @@ fn ir_fn_to_table(f: &ir::Fn, diff_region: &std::collections::HashSet<ir::NodeRe
     table.to_string()
 }
 
-fn print_equiv_result(label: &str, lhs_pkg_text: &str, rhs_pkg_text: &str, top_name: &str) {
-    match check_equivalence::check_equivalence_with_top(
+fn print_equiv_result(
+    label: &str,
+    lhs_pkg_text: &str,
+    rhs_pkg_text: &str,
+    top_name: &str,
+    solver: SolverChoice,
+    tool_path: Option<&Path>,
+) {
+    match check_equivalence::check_equivalence_with_top_and_solver(
         lhs_pkg_text,
         rhs_pkg_text,
         Some(top_name),
-        false,
+        solver,
+        tool_path,
     ) {
         Ok(()) => println!("  Equiv ({}): OK", label),
         Err(e) => println!("  Equiv ({}): FAILED: {}", label, e),
     }
 }
 
-pub fn handle_ir_structural_similarity(matches: &ArgMatches, _config: &Option<ToolchainConfig>) {
+pub fn handle_ir_structural_similarity(matches: &ArgMatches, config: &Option<ToolchainConfig>) {
     let lhs = matches.get_one::<String>("lhs_ir_file").unwrap();
     let lhs_path = std::path::Path::new(lhs);
     let rhs = matches.get_one::<String>("rhs_ir_file").unwrap();
     let rhs_path = std::path::Path::new(rhs);
     let lhs_ir_top = matches.get_one::<String>("lhs_ir_top");
     let rhs_ir_top = matches.get_one::<String>("rhs_ir_top");
+    let solver: SolverChoice = matches
+        .get_one::<String>("solver")
+        .unwrap()
+        .parse()
+        .unwrap();
+    let tool_path = config
+        .as_ref()
+        .and_then(|c| c.tool_path.as_deref())
+        .map(Path::new);
 
     // Prepare output directory: user-provided or a kept temp directory.
     let out_dir = if let Some(dir_str) = matches.get_one::<String>("output_dir") {
@@ -421,6 +440,8 @@ pub fn handle_ir_structural_similarity(matches: &ArgMatches, _config: &Option<To
                 &lhs_diff_pkg,
                 &lhs_orig_text,
                 lhs_outline.outer.name.as_str(),
+                solver,
+                tool_path,
             );
         }
         Err(e) => println!("  Equiv (lhs_diff ≡ lhs_orig): skipped (read error: {})", e),
@@ -439,6 +460,8 @@ pub fn handle_ir_structural_similarity(matches: &ArgMatches, _config: &Option<To
                 &rhs_diff_pkg,
                 &rhs_orig_text,
                 lhs_outline.outer.name.as_str(),
+                solver,
+                tool_path,
             );
         }
         Err(e) => println!("  Equiv (rhs_diff ≡ rhs_orig): skipped (read error: {})", e),

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -143,6 +143,28 @@ use xlsynth_prover::prover::types::QuickCheckAssertionSemantics;
 static DEFAULT_ADDER_MAPPING: Lazy<String> =
     Lazy::new(|| xlsynth_g8r::ir2gate_utils::AdderMapping::default().to_string());
 
+/// Builds the shared solver-selection argument used by formal subcommands.
+fn solver_arg(help: &'static str) -> Arg {
+    Arg::new("solver")
+        .long("solver")
+        .value_name("SOLVER")
+        .help(help)
+        .value_parser([
+            #[cfg(feature = "has-easy-smt")]
+            "z3-binary",
+            #[cfg(feature = "has-easy-smt")]
+            "bitwuzla-binary",
+            #[cfg(feature = "has-easy-smt")]
+            "boolector-binary",
+            "bitwuzla",
+            #[cfg(feature = "has-boolector")]
+            "boolector",
+            "toolchain",
+        ])
+        .default_value("bitwuzla")
+        .action(ArgAction::Set)
+}
+
 #[derive(Deserialize)]
 struct XlsynthToolchain {
     toolchain: ToolchainConfig,
@@ -720,26 +742,7 @@ fn main() {
             clap::Command::new("dslx-fn-prove-assertions")
                 .about("Prove that assertions reachable from a DSLX function cannot fail")
                 .add_dslx_input_args(true)
-                .arg(
-                    clap::Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Select solver backend")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(clap::ArgAction::Set),
-                )
+                .arg(solver_arg("Select solver backend"))
                 .arg(
                     clap::Arg::new("assert_label_filter")
                         .long("assert-label-filter")
@@ -1127,26 +1130,9 @@ fn main() {
                         .long("rhs_ir_top")
                         .help("The top-level entry point for the right-hand side IR"),
                 )
-                .arg(
-                    Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Use the specified solver for equivalence checking (requires --features=with-easy-smt)")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(ArgAction::Set),
-                )
+                .arg(solver_arg(
+                    "Use the specified solver for equivalence checking",
+                ))
                 .add_bool_arg(
                     "flatten_aggregates",
                     "Flatten tuple and array types to bits for equivalence checking",
@@ -1228,26 +1214,9 @@ fn main() {
                         .long("top")
                         .help("Top-level block name for both IRs"),
                 )
-                .arg(
-                    Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Use the specified solver for equivalence checking (requires --features=with-easy-smt)")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(ArgAction::Set),
-                )
+                .arg(solver_arg(
+                    "Use the specified solver for equivalence checking",
+                ))
                 .add_bool_arg(
                     "flatten_aggregates",
                     "Flatten tuple and array types to bits for equivalence checking",
@@ -1519,26 +1488,9 @@ fn main() {
                         .value_name("DIR")
                         .help("Directory to write outputs (original IR copies). If omitted, a temp directory is created and printed."),
                 )
-                .arg(
-                    Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Use the specified solver for equivalence checking")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(ArgAction::Set),
-                )
+                .arg(solver_arg(
+                    "Use the specified solver for equivalence checking",
+                ))
                 .add_bool_arg(
                     "show_discrepancies",
                     "Show per-depth discrepancy signatures in verbose form",
@@ -1581,26 +1533,9 @@ fn main() {
                         .value_name("DIR")
                         .help("Directory to write outputs (JSON, patched .ir). If omitted, a temp directory is created and printed."),
                 )
-                .arg(
-                    Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Use the specified solver for equivalence checking")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(ArgAction::Set),
-                )
+                .arg(solver_arg(
+                    "Use the specified solver for equivalence checking",
+                ))
                 .arg(
                     Arg::new("compute_text_diff")
                         .long("compute-text-diff")
@@ -2422,26 +2357,9 @@ fn main() {
                         .required(true)
                         .index(2),
                 )
-                .arg(
-                    Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Use the specified solver for equivalence checking")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(ArgAction::Set),
-                )
+                .arg(solver_arg(
+                    "Use the specified solver for equivalence checking",
+                ))
                 .arg(
                     clap::Arg::new("output_json")
                         .long("output_json")
@@ -2466,26 +2384,9 @@ fn main() {
                         .index(2),
                 )
                 .add_ir_top_arg(false)
-                .arg(
-                    Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Use the specified solver for equivalence checking")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(ArgAction::Set),
-                )
+                .arg(solver_arg(
+                    "Use the specified solver for equivalence checking",
+                ))
                 .add_bool_arg(
                     "flatten_aggregates",
                     "Flatten tuple and array types to bits for equivalence checking",
@@ -2612,26 +2513,9 @@ fn main() {
                         .required(true)
                         .index(2),
                 )
-                .arg(
-                    Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Use the specified solver for equivalence checking")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(ArgAction::Set),
-                )
+                .arg(solver_arg(
+                    "Use the specified solver for equivalence checking",
+                ))
                 .arg(
                     clap::Arg::new("output_json")
                         .long("output_json")
@@ -2663,26 +2547,9 @@ interpreted before lift. See docs/bit_blasted_output_ordering.md, section
                         .index(2),
                 )
                 .add_ir_top_arg(false)
-                .arg(
-                    Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Use the specified solver for equivalence checking (requires --features=with-easy-smt)")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(ArgAction::Set),
-                )
+                .arg(solver_arg(
+                    "Use the specified solver for equivalence checking",
+                ))
                 .add_bool_arg(
                     "flatten_aggregates",
                     "Flatten tuple and array types to bits for equivalence checking",
@@ -3297,26 +3164,7 @@ interpreted before lift. See docs/bit_blasted_output_ordering.md, section
                         .value_name("FILTER")
                         .help("Regular expression; prove only quickcheck functions whose name fully matches the pattern"),
                 )
-                .arg(
-                    clap::Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Select solver backend")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(clap::ArgAction::Set),
-                )
+                .arg(solver_arg("Select solver backend"))
                 .arg(
                     clap::Arg::new("assertion_semantics")
                         .long("assertion-semantics")
@@ -3360,26 +3208,7 @@ interpreted before lift. See docs/bit_blasted_output_ordering.md, section
                         .required(true)
                         .action(clap::ArgAction::Append),
                 )
-                .arg(
-                    clap::Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Select solver backend")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(clap::ArgAction::Set),
-                )
+                .arg(solver_arg("Select solver backend"))
                 .arg(
                     clap::Arg::new("output_json")
                         .long("output_json")
@@ -3478,28 +3307,9 @@ interpreted before lift. See docs/bit_blasted_output_ordering.md, section
                     "type_inference_v2",
                     "Enable the experimental type-inference v2 algorithm (external toolchain only)",
                 )
-                .arg(
-                    clap::Arg::new("solver")
-                        .long("solver")
-                        .value_name("SOLVER")
-                        .help("Use the specified solver for equivalence checking")
-                        .value_parser([
-                            #[cfg(feature = "has-easy-smt")]
-                            "z3-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "bitwuzla-binary",
-                            #[cfg(feature = "has-easy-smt")]
-                            "boolector-binary",
-                            "bitwuzla",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector",
-                            #[cfg(feature = "has-boolector")]
-                            "boolector-legacy",
-                            "toolchain",
-                        ])
-                        .default_value("bitwuzla")
-                        .action(clap::ArgAction::Set),
-                )
+                .arg(solver_arg(
+                    "Use the specified solver for equivalence checking",
+                ))
                 .add_bool_arg(
                     "flatten_aggregates",
                     "Flatten tuple and array types to bits for equivalence checking",

--- a/xlsynth-driver/src/main.rs
+++ b/xlsynth-driver/src/main.rs
@@ -726,20 +726,18 @@ fn main() {
                         .value_name("SOLVER")
                         .help("Select solver backend")
                         .value_parser([
-                            "auto",
                             #[cfg(feature = "has-easy-smt")]
                             "z3-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "bitwuzla-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "boolector-binary",
-                            #[cfg(feature = "has-bitwuzla")]
                             "bitwuzla",
                             #[cfg(feature = "has-boolector")]
                             "boolector",
                             "toolchain",
                         ])
-                        .default_value("auto")
+                        .default_value("bitwuzla")
                         .action(clap::ArgAction::Set),
                 )
                 .arg(
@@ -1135,20 +1133,18 @@ fn main() {
                         .value_name("SOLVER")
                         .help("Use the specified solver for equivalence checking (requires --features=with-easy-smt)")
                         .value_parser([
-                            "auto",
                             #[cfg(feature = "has-easy-smt")]
                             "z3-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "bitwuzla-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "boolector-binary",
-                            #[cfg(feature = "has-bitwuzla")]
                             "bitwuzla",
                             #[cfg(feature = "has-boolector")]
                             "boolector",
                             "toolchain",
                         ])
-                        .default_value("auto")
+                        .default_value("bitwuzla")
                         .action(ArgAction::Set),
                 )
                 .add_bool_arg(
@@ -1238,20 +1234,18 @@ fn main() {
                         .value_name("SOLVER")
                         .help("Use the specified solver for equivalence checking (requires --features=with-easy-smt)")
                         .value_parser([
-                            "auto",
                             #[cfg(feature = "has-easy-smt")]
                             "z3-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "bitwuzla-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "boolector-binary",
-                            #[cfg(feature = "has-bitwuzla")]
                             "bitwuzla",
                             #[cfg(feature = "has-boolector")]
                             "boolector",
                             "toolchain",
                         ])
-                        .default_value("auto")
+                        .default_value("bitwuzla")
                         .action(ArgAction::Set),
                 )
                 .add_bool_arg(
@@ -1525,6 +1519,26 @@ fn main() {
                         .value_name("DIR")
                         .help("Directory to write outputs (original IR copies). If omitted, a temp directory is created and printed."),
                 )
+                .arg(
+                    Arg::new("solver")
+                        .long("solver")
+                        .value_name("SOLVER")
+                        .help("Use the specified solver for equivalence checking")
+                        .value_parser([
+                            #[cfg(feature = "has-easy-smt")]
+                            "z3-binary",
+                            #[cfg(feature = "has-easy-smt")]
+                            "bitwuzla-binary",
+                            #[cfg(feature = "has-easy-smt")]
+                            "boolector-binary",
+                            "bitwuzla",
+                            #[cfg(feature = "has-boolector")]
+                            "boolector",
+                            "toolchain",
+                        ])
+                        .default_value("bitwuzla")
+                        .action(ArgAction::Set),
+                )
                 .add_bool_arg(
                     "show_discrepancies",
                     "Show per-depth discrepancy signatures in verbose form",
@@ -1566,6 +1580,26 @@ fn main() {
                         .long("output_dir")
                         .value_name("DIR")
                         .help("Directory to write outputs (JSON, patched .ir). If omitted, a temp directory is created and printed."),
+                )
+                .arg(
+                    Arg::new("solver")
+                        .long("solver")
+                        .value_name("SOLVER")
+                        .help("Use the specified solver for equivalence checking")
+                        .value_parser([
+                            #[cfg(feature = "has-easy-smt")]
+                            "z3-binary",
+                            #[cfg(feature = "has-easy-smt")]
+                            "bitwuzla-binary",
+                            #[cfg(feature = "has-boolector")]
+                            "boolector-binary",
+                            "bitwuzla",
+                            #[cfg(feature = "has-boolector")]
+                            "boolector",
+                            "toolchain",
+                        ])
+                        .default_value("bitwuzla")
+                        .action(ArgAction::Set),
                 )
                 .arg(
                     Arg::new("compute_text_diff")
@@ -2394,20 +2428,18 @@ fn main() {
                         .value_name("SOLVER")
                         .help("Use the specified solver for equivalence checking")
                         .value_parser([
-                            "auto",
                             #[cfg(feature = "has-easy-smt")]
                             "z3-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "bitwuzla-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "boolector-binary",
-                            #[cfg(feature = "has-bitwuzla")]
                             "bitwuzla",
                             #[cfg(feature = "has-boolector")]
                             "boolector",
                             "toolchain",
                         ])
-                        .default_value("auto")
+                        .default_value("bitwuzla")
                         .action(ArgAction::Set),
                 )
                 .arg(
@@ -2440,20 +2472,18 @@ fn main() {
                         .value_name("SOLVER")
                         .help("Use the specified solver for equivalence checking")
                         .value_parser([
-                            "auto",
                             #[cfg(feature = "has-easy-smt")]
                             "z3-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "bitwuzla-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "boolector-binary",
-                            #[cfg(feature = "has-bitwuzla")]
                             "bitwuzla",
                             #[cfg(feature = "has-boolector")]
                             "boolector",
                             "toolchain",
                         ])
-                        .default_value("auto")
+                        .default_value("bitwuzla")
                         .action(ArgAction::Set),
                 )
                 .add_bool_arg(
@@ -2588,20 +2618,18 @@ fn main() {
                         .value_name("SOLVER")
                         .help("Use the specified solver for equivalence checking")
                         .value_parser([
-                            "auto",
                             #[cfg(feature = "has-easy-smt")]
                             "z3-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "bitwuzla-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "boolector-binary",
-                            #[cfg(feature = "has-bitwuzla")]
                             "bitwuzla",
                             #[cfg(feature = "has-boolector")]
                             "boolector",
                             "toolchain",
                         ])
-                        .default_value("auto")
+                        .default_value("bitwuzla")
                         .action(ArgAction::Set),
                 )
                 .arg(
@@ -2641,20 +2669,18 @@ interpreted before lift. See docs/bit_blasted_output_ordering.md, section
                         .value_name("SOLVER")
                         .help("Use the specified solver for equivalence checking (requires --features=with-easy-smt)")
                         .value_parser([
-                            "auto",
                             #[cfg(feature = "has-easy-smt")]
                             "z3-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "bitwuzla-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "boolector-binary",
-                            #[cfg(feature = "has-bitwuzla")]
                             "bitwuzla",
                             #[cfg(feature = "has-boolector")]
                             "boolector",
                             "toolchain",
                         ])
-                        .default_value("auto")
+                        .default_value("bitwuzla")
                         .action(ArgAction::Set),
                 )
                 .add_bool_arg(
@@ -3277,20 +3303,18 @@ interpreted before lift. See docs/bit_blasted_output_ordering.md, section
                         .value_name("SOLVER")
                         .help("Select solver backend")
                         .value_parser([
-                            "auto",
                             #[cfg(feature = "has-easy-smt")]
                             "z3-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "bitwuzla-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "boolector-binary",
-                            #[cfg(feature = "has-bitwuzla")]
                             "bitwuzla",
                             #[cfg(feature = "has-boolector")]
                             "boolector",
                             "toolchain",
                         ])
-                        .default_value("auto")
+                        .default_value("bitwuzla")
                         .action(clap::ArgAction::Set),
                 )
                 .arg(
@@ -3342,20 +3366,18 @@ interpreted before lift. See docs/bit_blasted_output_ordering.md, section
                         .value_name("SOLVER")
                         .help("Select solver backend")
                         .value_parser([
-                            "auto",
                             #[cfg(feature = "has-easy-smt")]
                             "z3-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "bitwuzla-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "boolector-binary",
-                            #[cfg(feature = "has-bitwuzla")]
                             "bitwuzla",
                             #[cfg(feature = "has-boolector")]
                             "boolector",
                             "toolchain",
                         ])
-                        .default_value("auto")
+                        .default_value("bitwuzla")
                         .action(clap::ArgAction::Set),
                 )
                 .arg(
@@ -3462,14 +3484,12 @@ interpreted before lift. See docs/bit_blasted_output_ordering.md, section
                         .value_name("SOLVER")
                         .help("Use the specified solver for equivalence checking")
                         .value_parser([
-                            "auto",
                             #[cfg(feature = "has-easy-smt")]
                             "z3-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "bitwuzla-binary",
                             #[cfg(feature = "has-easy-smt")]
                             "boolector-binary",
-                            #[cfg(feature = "has-bitwuzla")]
                             "bitwuzla",
                             #[cfg(feature = "has-boolector")]
                             "boolector",
@@ -3477,7 +3497,7 @@ interpreted before lift. See docs/bit_blasted_output_ordering.md, section
                             "boolector-legacy",
                             "toolchain",
                         ])
-                        .default_value("auto")
+                        .default_value("bitwuzla")
                         .action(clap::ArgAction::Set),
                 )
                 .add_bool_arg(

--- a/xlsynth-driver/src/prove_enum_in_bound.rs
+++ b/xlsynth-driver/src/prove_enum_in_bound.rs
@@ -107,7 +107,7 @@ pub fn handle_prove_enum_in_bound(matches: &clap::ArgMatches, config: &Option<To
     let solver_choice = matches
         .get_one::<String>("solver")
         .map(|s| s.parse().unwrap())
-        .unwrap_or(SolverChoice::Auto);
+        .unwrap_or(SolverChoice::Bitwuzla);
 
     if let SolverChoice::Toolchain = solver_choice {
         report_cli_error_and_exit(

--- a/xlsynth-driver/src/prove_quickcheck.rs
+++ b/xlsynth-driver/src/prove_quickcheck.rs
@@ -231,7 +231,7 @@ pub fn handle_prove_quickcheck(matches: &clap::ArgMatches, config: &Option<Toolc
             .collect()
     }
 
-    let solver_choice = solver_choice_opt.unwrap_or(SolverChoice::Auto);
+    let solver_choice = solver_choice_opt.unwrap_or(SolverChoice::Bitwuzla);
     let tool_path = config.as_ref().and_then(|c| c.tool_path.as_deref());
     let prover = xlsynth_prover::prover::prover_for_choice(
         solver_choice,

--- a/xlsynth-driver/src/prover_config.rs
+++ b/xlsynth-driver/src/prover_config.rs
@@ -667,7 +667,7 @@ mod tests {
             dslx_top: "main".into(),
             dslx_path: Some(vec!["a".into(), "b".into()]),
             dslx_stdlib_path: Some("stdlib".into()),
-            solver: Some(SolverChoice::Auto),
+            solver: Some(SolverChoice::Bitwuzla),
             assert_label_filter: Some("red|blue".into()),
             assume_enum_in_bound: Some(false),
             uf: Some(vec!["helper:F".into()]),
@@ -686,7 +686,7 @@ mod tests {
                 "--dslx_stdlib_path",
                 "stdlib",
                 "--solver",
-                "auto",
+                "bitwuzla",
                 "--assert-label-filter",
                 "red|blue",
                 "--assume-enum-in-bound",
@@ -748,7 +748,7 @@ mod tests {
             "kind": "dslx-fn-prove-assertions",
             "dslx_input_file": "assertions.x",
             "dslx_top": "main",
-            "solver": "auto"
+            "solver": "bitwuzla"
           }
         ]"#;
         let tasks: Vec<ProverTask> = serde_json::from_str(json).unwrap();

--- a/xlsynth-g8r/Cargo.toml
+++ b/xlsynth-g8r/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 xlsynth = { path = "../xlsynth", version = "0.53.0" }
 xlsynth-pir = { path = "../xlsynth-pir", version = "0.53.0" }
+xlsynth-prover = { path = "../xlsynth-prover", version = "0.53.0" }
 xlsynth-mcmc = { path = "../xlsynth-mcmc", version = "0.53.0" }
 env_logger = "0.11"
 log = "0.4"
@@ -67,6 +68,9 @@ prost-build = "0.12"
 
 [features]
 default = []
+has-bitwuzla = ["xlsynth-prover/has-bitwuzla"]
+with-bitwuzla-system = ["xlsynth-prover/with-bitwuzla-system", "has-bitwuzla"]
+with-bitwuzla-built = ["xlsynth-prover/with-bitwuzla-built", "has-bitwuzla"]
 with-z3-system = ["dep:z3"]
 with-z3-built = ["dep:z3", "z3/static-link-z3"]
 

--- a/xlsynth-g8r/benches/mcmc_benchmark.rs
+++ b/xlsynth-g8r/benches/mcmc_benchmark.rs
@@ -118,6 +118,7 @@ fn benchmark_mcmc_iteration(c: &mut Criterion) {
                     initial_temp,
                     objective,
                     false,
+                    false,
                     &simd_inputs,
                     &baseline_outputs,
                 )

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_gate_transform_equiv.rs
@@ -31,7 +31,7 @@ fuzz_target!(|graph: FuzzGraph| {
     {
         return;
     }
-    if let Err(e) = check_equivalence::prove_same_gate_fn_via_ir(&g, &new_g) {
+    if let Err(e) = check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&g, &new_g) {
         panic!("Transform {} broke equivalence: {}", t.display_name(), e);
     }
 });

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_opt_equiv.rs
@@ -128,8 +128,11 @@ fuzz_target!(|data: &[u8]| {
 
     // Check equivalence using the external tool first, specifying the top function
     let opt_ir = optimized_pkg.to_string();
-    let ext_equiv =
-        check_equivalence::check_equivalence_with_top(&orig_ir, &opt_ir, Some(top_fn_name), false);
+    let ext_equiv = check_equivalence::check_equivalence_with_top_via_toolchain(
+        &orig_ir,
+        &opt_ir,
+        Some(top_fn_name),
+    );
     #[cfg(feature = "has-bitwuzla")]
     {
         let bitwuzla_result = prove_ir_fn_equiv::<Bitwuzla>(

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_rebase_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_ir_rebase_equiv.rs
@@ -6,10 +6,9 @@ use libfuzzer_sys::fuzz_target;
 use xlsynth_g8r_fuzz::generate_upstream_formal_random_pir_pair;
 use xlsynth_pir::ir;
 use xlsynth_pir::ir_verify::verify_function_in_package;
-use xlsynth_pir::prove_equiv_via_toolchain::{
-    prove_ir_fn_equiv_via_toolchain, ToolchainEquivResult,
-};
 use xlsynth_pir::simple_rebase::rebase_onto;
+use xlsynth_prover::prover::types::EquivResult;
+use xlsynth_prover::prover::{SolverChoice, prover_for_choice};
 
 fn max_text_id(f: &ir::Fn) -> usize {
     f.nodes.iter().map(|n| n.text_id).max().unwrap_or(0)
@@ -52,14 +51,13 @@ fuzz_target!(|data: &[u8]| {
         panic!("rebased IR failed verification: {}", e);
     }
 
-    match prove_ir_fn_equiv_via_toolchain(&desired, &rebased) {
-        ToolchainEquivResult::Proved => {}
+    match prover_for_choice(SolverChoice::Toolchain, None).prove_ir_fn_equiv(&desired, &rebased) {
+        EquivResult::Proved => {}
         other => {
-            // Treat tool infra failure as non-sample failure; but equivalence disproved
-            // must panic.
+            // Early-return rationale: tool interruption or infrastructure failure
+            // is not a property of this sample; an equivalence disproof must panic.
             match other {
-                ToolchainEquivResult::Error(_) => return,
-                // No other variant currently, but keep match exhaustive for clarity.
+                EquivResult::Inconclusive(_) | EquivResult::Error(_) => return,
                 _ => panic!("rebase_onto failed equivalence: {:?}", other),
             }
         }

--- a/xlsynth-g8r/src/aig/bulk_replace.rs
+++ b/xlsynth-g8r/src/aig/bulk_replace.rs
@@ -450,7 +450,7 @@ mod tests {
 
         log::info!("Replaced function:\n{}", replaced_fn.to_string());
 
-        check_equivalence::prove_same_gate_fn_via_ir(original_fn, &replaced_fn)
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(original_fn, &replaced_fn)
             .expect("original and replaced functions should be equivalent");
 
         let stats: SummaryStats = get_summary_stats(&replaced_fn);
@@ -505,9 +505,10 @@ mod tests {
             replaced_fn.to_string()
         );
 
-        check_equivalence::prove_same_gate_fn_via_ir(original_fn, &replaced_fn).expect(
-            "original and replaced functions should be equivalent after multiple substitutions",
-        );
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(original_fn, &replaced_fn)
+            .expect(
+                "original and replaced functions should be equivalent after multiple substitutions",
+            );
 
         let stats: SummaryStats = get_summary_stats(&replaced_fn);
         let original_stats: SummaryStats = get_summary_stats(original_fn);
@@ -540,7 +541,7 @@ mod tests {
             replaced_fn.to_string()
         );
 
-        check_equivalence::prove_same_gate_fn_via_ir(original_fn, &replaced_fn)
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(original_fn, &replaced_fn)
             .expect("Replacing AND(true, true) with true should preserve equivalence");
 
         assert_eq!(replaced_fn.outputs.len(), 1);

--- a/xlsynth-g8r/src/aig/fraig.rs
+++ b/xlsynth-g8r/src/aig/fraig.rs
@@ -403,7 +403,7 @@ mod tests {
         );
 
         // Outputs should be equivalent
-        check_equivalence::prove_same_gate_fn_via_ir(&test_graph.g, &optimized_fn)
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&test_graph.g, &optimized_fn)
             .expect("fraig optimization should preserve equivalence");
     }
 
@@ -433,7 +433,7 @@ mod tests {
                 .expect("fraig_optimize should not panic on dead redundant nodes");
 
         // The optimized function must remain equivalent to the original.
-        crate::check_equivalence::prove_same_gate_fn_via_ir(&gate_fn, &optimized_fn)
+        crate::check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_fn, &optimized_fn)
             .expect("optimized function should be equivalent to original");
 
         // Ensure the optimized function still respects basic invariants.

--- a/xlsynth-g8r/src/aig_serdes/load_aiger.rs
+++ b/xlsynth-g8r/src/aig_serdes/load_aiger.rs
@@ -338,7 +338,7 @@ mod tests {
             let loaded = load_aiger(&aiger, GateBuilderOptions::no_opt()).unwrap();
             let schema = GateFnInterfaceSchema::from_pir_fn(&sample.g8r_fn).unwrap();
             let repacked = repack_gate_fn_interface_with_schema(loaded.gate_fn, &schema).unwrap();
-            check_equivalence::validate_same_fn(&sample.g8r_fn, &repacked)
+            check_equivalence::validate_same_fn_via_toolchain(&sample.g8r_fn, &repacked)
                 .unwrap_or_else(|e| panic!("AIGER roundtrip failed for {}: {}", case.name, e));
         }
     }

--- a/xlsynth-g8r/src/aig_serdes/load_aiger_binary.rs
+++ b/xlsynth-g8r/src/aig_serdes/load_aiger_binary.rs
@@ -288,9 +288,10 @@ mod tests {
             let loaded = load_aiger_binary(&aiger, GateBuilderOptions::no_opt()).unwrap();
             let schema = GateFnInterfaceSchema::from_pir_fn(&sample.g8r_fn).unwrap();
             let repacked = repack_gate_fn_interface_with_schema(loaded.gate_fn, &schema).unwrap();
-            check_equivalence::validate_same_fn(&sample.g8r_fn, &repacked).unwrap_or_else(|e| {
-                panic!("binary AIGER roundtrip failed for {}: {}", case.name, e)
-            });
+            check_equivalence::validate_same_fn_via_toolchain(&sample.g8r_fn, &repacked)
+                .unwrap_or_else(|e| {
+                    panic!("binary AIGER roundtrip failed for {}: {}", case.name, e)
+                });
         }
     }
 

--- a/xlsynth-g8r/src/bin/g8r-equivalent.rs
+++ b/xlsynth-g8r/src/bin/g8r-equivalent.rs
@@ -60,13 +60,14 @@ fn main() {
     println!("SAT/Z3 oracle: {}", sat_equiv);
 
     // Checker 2: IR-based equivalence.
-    let ir_equiv = match xlsynth_g8r::check_equivalence::prove_same_gate_fn_via_ir(&lhs, &rhs) {
-        Ok(_) => true,
-        Err(e) => {
-            eprintln!("IR equivalence checker error: {}", e);
-            false
-        }
-    };
+    let ir_equiv =
+        match xlsynth_g8r::check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&lhs, &rhs) {
+            Ok(_) => true,
+            Err(e) => {
+                eprintln!("IR equivalence checker error: {}", e);
+                false
+            }
+        };
     println!("IR checker: {}", ir_equiv);
 
     // Checker 3: Varisat-based SAT prover (structural)

--- a/xlsynth-g8r/src/bin/g8r-equivalent.rs
+++ b/xlsynth-g8r/src/bin/g8r-equivalent.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Compare two `.g8r` GateFn descriptions for equivalence using all available
-//! equivalence checkers (SAT/Z3 oracle + IR-based checker).
+//! equivalence checkers (CaDiCaL, Varisat, and an XLS IR-based checker).
 //!
 //! Exit status:
 //!   0 – all checkers agree the GateFns are equivalent
@@ -49,15 +49,15 @@ fn main() {
         }
     };
 
-    // Checker 1: SAT/Z3 oracle (fast path)
+    // Checker 1: CaDiCaL gate-level oracle (fast path)
     let sat_equiv = match oracle_equiv_sat(&lhs, &rhs) {
         Ok(equiv) => equiv,
         Err(e) => {
-            eprintln!("SAT/Z3 oracle error: {}", e);
+            eprintln!("CaDiCaL oracle error: {}", e);
             exit(2);
         }
     };
-    println!("SAT/Z3 oracle: {}", sat_equiv);
+    println!("CaDiCaL oracle: {}", sat_equiv);
 
     // Checker 2: IR-based equivalence.
     let ir_equiv =
@@ -72,9 +72,9 @@ fn main() {
 
     // Checker 3: Varisat-based SAT prover (structural)
     let varisat_equiv = {
-        let mut ctx = prove_gate_fn_equiv_sat::Ctx::new();
+        let mut ctx = prove_gate_fn_equiv_sat::VarisatCtx::new();
         matches!(
-            prove_gate_fn_equiv_sat::prove_gate_fn_equiv(&lhs, &rhs, &mut ctx),
+            prove_gate_fn_equiv_sat::prove_gate_fn_equiv_varisat(&lhs, &rhs, &mut ctx),
             EquivResult::Proved
         )
     };

--- a/xlsynth-g8r/src/bin/mcmc-driver.rs
+++ b/xlsynth-g8r/src/bin/mcmc-driver.rs
@@ -102,6 +102,10 @@ struct CliArgs {
     #[clap(long)]
     paranoid: bool,
 
+    /// Also cross-check native formal results with the XLS IR checker binary.
+    #[clap(long)]
+    xls_cross_check: bool,
+
     /// Iterations between checkpoints written to disk (0 to disable).
     #[clap(long, value_parser, default_value_t = 5000)]
     checkpoint_iters: u64,
@@ -150,6 +154,7 @@ fn run_chain_segment(
         cfg.metric,
         periodic_dump_dir,
         cfg.paranoid,
+        cfg.xls_cross_check,
         0,
         progress_interval,
         Some(best),

--- a/xlsynth-g8r/src/check_equivalence.rs
+++ b/xlsynth-g8r/src/check_equivalence.rs
@@ -1,74 +1,70 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Instant;
+use std::path::Path;
 
 use crate::{aig::GateFn, aig_serdes::gate2ir};
 use xlsynth_pir::ir;
+use xlsynth_prover::prover::types::EquivResult;
+use xlsynth_prover::prover::{SolverChoice, prover_for_choice};
 
 pub fn check_equivalence(orig_package: &str, gate_package: &str) -> Result<(), String> {
-    check_equivalence_with_top(orig_package, gate_package, None, false)
+    check_equivalence_with_top_and_solver(
+        orig_package,
+        gate_package,
+        None,
+        SolverChoice::Bitwuzla,
+        None,
+    )
 }
 
-pub fn check_equivalence_with_top(
+/// Checks package equivalence using an explicitly selected solver backend.
+pub fn check_equivalence_with_top_and_solver(
     orig_package: &str,
     gate_package: &str,
     top_fn_name: Option<&str>,
-    keep_temp_dir: bool,
+    solver: SolverChoice,
+    tool_path: Option<&Path>,
 ) -> Result<(), String> {
-    let tempdir = tempfile::tempdir().unwrap();
-    let dirpath = if keep_temp_dir {
-        tempdir.keep()
-    } else {
-        tempdir.path().to_path_buf()
-    };
-    let orig_path = dirpath.join("orig.ir");
-    let gate_path = dirpath.join("gate.ir");
-    std::fs::write(orig_path.clone(), orig_package).unwrap();
-    std::fs::write(gate_path.clone(), gate_package).unwrap();
-    let tools_dir_str =
-        std::env::var("XLSYNTH_TOOLS").expect("XLSYNTH_TOOLS env var should be set");
-    let tools_dirpath = std::path::PathBuf::from(tools_dir_str);
-    assert!(
-        tools_dirpath.exists(),
-        "XLSYNTH_TOOLS environment variable does not exist"
-    );
-    let check_ir_equivalence_main_path = tools_dirpath.join("check_ir_equivalence_main");
-    assert!(
-        check_ir_equivalence_main_path.exists(),
-        "check_ir_equivalence_main not found in XLSYNTH_TOOLS"
-    );
+    let prover = prover_for_choice(solver, tool_path);
+    match prover.prove_ir_pkg_text_equiv(orig_package, gate_package, top_fn_name) {
+        EquivResult::Proved => Ok(()),
+        EquivResult::Inconclusive(msg) => Err(format!("inconclusive: {msg}")),
+        EquivResult::Disproved {
+            lhs_inputs,
+            rhs_inputs,
+            lhs_output,
+            rhs_output,
+        } => Err(format!(
+            "not equivalent: lhs_inputs={lhs_inputs:?} rhs_inputs={rhs_inputs:?} \
+             lhs_output={lhs_output:?} rhs_output={rhs_output:?}"
+        )),
+        EquivResult::ToolchainDisproved(msg) | EquivResult::Error(msg) => Err(msg),
+    }
+}
 
-    let mut command = std::process::Command::new(check_ir_equivalence_main_path);
-    // Optional: a flag like "--alsologtostderr" is useful while debugging to mirror
-    // logs to stderr, but not required for functionality.
-    command.arg(orig_path.to_str().unwrap());
-    command.arg(gate_path.to_str().unwrap());
-    if let Some(top) = top_fn_name {
-        command.arg("--top");
-        command.arg(top);
-    }
-    log::info!("check_equivalence_with_top; running command: {:?}", command);
-    let start = Instant::now();
-    let output = command.output().unwrap();
-    let elapsed = start.elapsed();
-    if !output.status.success() {
-        let stderr_str = String::from_utf8_lossy(&output.stderr);
-        let stdout_str = String::from_utf8_lossy(&output.stdout);
-        let err_kind = if stderr_str.contains("DEADLINE_EXCEEDED")
-            || stderr_str.contains("SIGINT")
-            || stderr_str.contains("interrupted")
-        {
-            "TimedOutOrInterrupted"
-        } else {
-            "SolverFailed"
-        };
-        return Err(format!(
-            "{}: check_ir_equivalence_main failed with retcode {}\nstdout: {:?}\nstderr: {:?}",
-            err_kind, output.status, stdout_str, stderr_str
-        ));
-    }
-    log::info!("check_equivalence_with_top; successful in {:?}", elapsed);
-    Ok(())
+/// Checks package equivalence with the explicitly selected XLS toolchain
+/// oracle.
+pub fn check_equivalence_with_top_via_toolchain(
+    orig_package: &str,
+    gate_package: &str,
+    top_fn_name: Option<&str>,
+) -> Result<(), String> {
+    check_equivalence_with_top_and_solver(
+        orig_package,
+        gate_package,
+        top_fn_name,
+        SolverChoice::Toolchain,
+        None,
+    )
+}
+
+/// Checks package equivalence with the explicitly selected XLS toolchain
+/// oracle.
+pub fn check_equivalence_via_toolchain(
+    orig_package: &str,
+    gate_package: &str,
+) -> Result<(), String> {
+    check_equivalence_with_top_via_toolchain(orig_package, gate_package, None)
 }
 
 fn get_fn_signature(f: &ir::Fn) -> String {
@@ -107,6 +103,16 @@ pub fn validate_same_signature(orig_fn: &ir::Fn, gate_fn: &GateFn) -> Result<(),
 /// conversion from "gate IR" to "XLS IR" to use the original function's
 /// signature so we can check XLS IR equivalence directly.
 pub fn validate_same_fn(orig_fn: &ir::Fn, gate_fn: &GateFn) -> Result<(), String> {
+    validate_same_fn_with_solver(orig_fn, gate_fn, SolverChoice::Bitwuzla, None)
+}
+
+/// Checks a PIR function and a GateFn using an explicitly selected solver.
+pub fn validate_same_fn_with_solver(
+    orig_fn: &ir::Fn,
+    gate_fn: &GateFn,
+    solver: SolverChoice,
+    tool_path: Option<&Path>,
+) -> Result<(), String> {
     let orig_ir_fn_text: String = orig_fn.to_string();
     let xlsynth_package_ir: String =
         gate2ir::gate_fn_to_xlsynth_ir(gate_fn, "gate", &orig_fn.get_type())
@@ -114,8 +120,18 @@ pub fn validate_same_fn(orig_fn: &ir::Fn, gate_fn: &GateFn) -> Result<(), String
             .to_string();
     log::info!("xlsynth_package_ir:\n{}", xlsynth_package_ir);
     let orig_ir_pkg_text: String = format!("package orig\n\ntop {}", orig_ir_fn_text);
-    let result = check_equivalence(&orig_ir_pkg_text, &xlsynth_package_ir);
-    result
+    check_equivalence_with_top_and_solver(
+        &orig_ir_pkg_text,
+        &xlsynth_package_ir,
+        None,
+        solver,
+        tool_path,
+    )
+}
+
+/// Checks a PIR function and GateFn with the explicitly selected XLS oracle.
+pub fn validate_same_fn_via_toolchain(orig_fn: &ir::Fn, gate_fn: &GateFn) -> Result<(), String> {
+    validate_same_fn_with_solver(orig_fn, gate_fn, SolverChoice::Toolchain, None)
 }
 
 /// Structured result for IR-level equivalence checking.
@@ -138,72 +154,29 @@ impl IrCheckResult {
     }
 }
 
-/// Run the external `check_ir_equivalence_main` tool and get a structured
-/// result. This is similar to the logic inside `check_equivalence_with_top`
-/// but returns an `IrCheckResult` instead of `Result<(), String>`.
-fn run_external_ir_tool(orig_pkg: &str, gate_pkg: &str) -> IrCheckResult {
-    let tempdir = tempfile::tempdir().unwrap();
-    let dirpath = tempdir.path();
-    let orig_path = dirpath.join("orig.ir");
-    let gate_path = dirpath.join("gate.ir");
-    if std::fs::write(&orig_path, orig_pkg).is_err() {
-        return IrCheckResult::OtherProcessError("failed to write orig temp file".to_string());
-    }
-    if std::fs::write(&gate_path, gate_pkg).is_err() {
-        return IrCheckResult::OtherProcessError("failed to write gate temp file".to_string());
-    }
-
-    let tools_dir = match std::env::var("XLSYNTH_TOOLS") {
-        Ok(p) => std::path::PathBuf::from(p),
-        Err(_) => {
-            return IrCheckResult::OtherProcessError("XLSYNTH_TOOLS env var not set".to_string());
+fn map_equiv_result(result: EquivResult) -> IrCheckResult {
+    match result {
+        EquivResult::Proved => IrCheckResult::Equivalent,
+        EquivResult::Inconclusive(_) => IrCheckResult::TimedOutOrInterrupted,
+        EquivResult::Disproved { .. } | EquivResult::ToolchainDisproved(_) => {
+            IrCheckResult::NotEquivalent
         }
-    };
-    let exe = tools_dir.join("check_ir_equivalence_main");
-    if !exe.exists() {
-        return IrCheckResult::OtherProcessError(format!(
-            "check_ir_equivalence_main not found in {}",
-            tools_dir.display()
-        ));
+        EquivResult::Error(msg) => IrCheckResult::OtherProcessError(msg),
     }
-
-    let output = std::process::Command::new(exe)
-        // Optional debug flag can mirror logs to stderr; not required for functionality.
-        .arg(orig_path)
-        .arg(gate_path)
-        .output();
-
-    let output = match output {
-        Ok(o) => o,
-        Err(e) => return IrCheckResult::OtherProcessError(format!("failed to spawn process: {e}")),
-    };
-
-    if output.status.success() {
-        return IrCheckResult::Equivalent;
-    }
-
-    let stderr_str = String::from_utf8_lossy(&output.stderr).to_string();
-
-    if stderr_str.contains("DEADLINE_EXCEEDED")
-        || stderr_str.contains("SIGINT")
-        || stderr_str.contains("interrupted")
-    {
-        return IrCheckResult::TimedOutOrInterrupted;
-    }
-
-    // Heuristic: if the tool reports a counterexample it usually exits 1 and prints
-    // something like "NOT EQUIVALENT" or "counterexample".
-    if stderr_str.to_lowercase().contains("not equivalent")
-        || stderr_str.to_lowercase().contains("counterexample")
-    {
-        return IrCheckResult::NotEquivalent;
-    }
-
-    IrCheckResult::OtherProcessError(format!("retcode {} stderr: {}", output.status, stderr_str))
 }
 
 /// Structured variant of `prove_same_gate_fn_via_ir`.
 pub fn prove_same_gate_fn_via_ir_status(lhs: &GateFn, rhs: &GateFn) -> IrCheckResult {
+    prove_same_gate_fn_via_ir_status_with_solver(lhs, rhs, SolverChoice::Bitwuzla, None)
+}
+
+/// Checks two GateFns using an explicitly selected IR solver backend.
+pub fn prove_same_gate_fn_via_ir_status_with_solver(
+    lhs: &GateFn,
+    rhs: &GateFn,
+    solver: SolverChoice,
+    tool_path: Option<&Path>,
+) -> IrCheckResult {
     let lhs_type = lhs.get_flat_type();
     let rhs_type = rhs.get_flat_type();
     if lhs_type != rhs_type {
@@ -212,13 +185,29 @@ pub fn prove_same_gate_fn_via_ir_status(lhs: &GateFn, rhs: &GateFn) -> IrCheckRe
     let lhs_ir: xlsynth::IrPackage = gate2ir::gate_fn_to_xlsynth_ir(lhs, "lhs", &lhs_type).unwrap();
     let rhs_ir: xlsynth::IrPackage = gate2ir::gate_fn_to_xlsynth_ir(rhs, "rhs", &rhs_type).unwrap();
 
-    run_external_ir_tool(&lhs_ir.to_string(), &rhs_ir.to_string())
+    let prover = prover_for_choice(solver, tool_path);
+    map_equiv_result(prover.prove_ir_pkg_text_equiv(&lhs_ir.to_string(), &rhs_ir.to_string(), None))
+}
+
+/// Checks two GateFns with the explicitly selected XLS toolchain oracle.
+pub fn prove_same_gate_fn_via_ir_status_via_toolchain(lhs: &GateFn, rhs: &GateFn) -> IrCheckResult {
+    prove_same_gate_fn_via_ir_status_with_solver(lhs, rhs, SolverChoice::Toolchain, None)
 }
 
 /// Backwards-compatibility wrapper that preserves the original
 /// Result<(),String> behaviour used elsewhere in the codebase.
 pub fn prove_same_gate_fn_via_ir(lhs: &GateFn, rhs: &GateFn) -> Result<(), String> {
     match prove_same_gate_fn_via_ir_status(lhs, rhs) {
+        IrCheckResult::Equivalent => Ok(()),
+        IrCheckResult::NotEquivalent => Err("not equivalent".to_string()),
+        IrCheckResult::TimedOutOrInterrupted => Err("TimedOutOrInterrupted".to_string()),
+        IrCheckResult::OtherProcessError(msg) => Err(msg),
+    }
+}
+
+/// Checks two GateFns with the explicitly selected XLS toolchain oracle.
+pub fn prove_same_gate_fn_via_ir_via_toolchain(lhs: &GateFn, rhs: &GateFn) -> Result<(), String> {
+    match prove_same_gate_fn_via_ir_status_via_toolchain(lhs, rhs) {
         IrCheckResult::Equivalent => Ok(()),
         IrCheckResult::NotEquivalent => Err("not equivalent".to_string()),
         IrCheckResult::TimedOutOrInterrupted => Err("TimedOutOrInterrupted".to_string()),

--- a/xlsynth-g8r/src/gate_builder.rs
+++ b/xlsynth-g8r/src/gate_builder.rs
@@ -1176,7 +1176,7 @@ mod tests {
             builder.add_output("o".to_string(), AigBitVector::from_bit(result_linear));
             builder.build()
         };
-        check_equivalence::prove_same_gate_fn_via_ir(&gate_fn_tree, &gate_fn_linear)
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_fn_tree, &gate_fn_linear)
             .expect("tree and linear reduce should be equivalent");
     }
 

--- a/xlsynth-g8r/src/gate_fn_equiv_report.rs
+++ b/xlsynth-g8r/src/gate_fn_equiv_report.rs
@@ -40,14 +40,15 @@ pub fn prove_gate_fn_equiv_report(lhs: &GateFn, rhs: &GateFn) -> EquivReport {
         results.insert("z3".to_string(), res);
     }
 
-    let ir_checker = match check_equivalence::prove_same_gate_fn_via_ir_status(lhs, rhs) {
-        IrCheckResult::Equivalent => EngineResult::Equiv,
-        IrCheckResult::NotEquivalent => EngineResult::NotEquiv(None),
-        IrCheckResult::TimedOutOrInterrupted => {
-            EngineResult::NotEquiv(Some("TimedOutOrInterrupted".to_string()))
-        }
-        IrCheckResult::OtherProcessError(msg) => EngineResult::NotEquiv(Some(msg)),
-    };
+    let ir_checker =
+        match check_equivalence::prove_same_gate_fn_via_ir_status_via_toolchain(lhs, rhs) {
+            IrCheckResult::Equivalent => EngineResult::Equiv,
+            IrCheckResult::NotEquivalent => EngineResult::NotEquiv(None),
+            IrCheckResult::TimedOutOrInterrupted => {
+                EngineResult::NotEquiv(Some("TimedOutOrInterrupted".to_string()))
+            }
+            IrCheckResult::OtherProcessError(msg) => EngineResult::NotEquiv(Some(msg)),
+        };
     results.insert("ir".to_string(), ir_checker);
 
     let varisat = {

--- a/xlsynth-g8r/src/gate_fn_equiv_report.rs
+++ b/xlsynth-g8r/src/gate_fn_equiv_report.rs
@@ -13,6 +13,8 @@ use std::collections::BTreeMap;
 pub enum EngineResult {
     Equiv,
     NotEquiv(Option<String>),
+    TimedOutOrInterrupted,
+    Error(String),
 }
 
 impl EngineResult {
@@ -44,16 +46,25 @@ pub fn prove_gate_fn_equiv_report(lhs: &GateFn, rhs: &GateFn) -> EquivReport {
         match check_equivalence::prove_same_gate_fn_via_ir_status_via_toolchain(lhs, rhs) {
             IrCheckResult::Equivalent => EngineResult::Equiv,
             IrCheckResult::NotEquivalent => EngineResult::NotEquiv(None),
-            IrCheckResult::TimedOutOrInterrupted => {
-                EngineResult::NotEquiv(Some("TimedOutOrInterrupted".to_string()))
-            }
-            IrCheckResult::OtherProcessError(msg) => EngineResult::NotEquiv(Some(msg)),
+            IrCheckResult::TimedOutOrInterrupted => EngineResult::TimedOutOrInterrupted,
+            IrCheckResult::OtherProcessError(msg) => EngineResult::Error(msg),
         };
     results.insert("ir".to_string(), ir_checker);
 
+    let cadical = match prove_gate_fn_equiv_sat::prove_gate_fn_equiv_with_backend(
+        lhs,
+        rhs,
+        prove_gate_fn_equiv_sat::GateFormalBackend::Cadical,
+    ) {
+        Ok(EquivResult::Proved) => EngineResult::Equiv,
+        Ok(EquivResult::Disproved(cex)) => EngineResult::NotEquiv(Some(format!("{:?}", cex))),
+        Err(e) => EngineResult::Error(e.to_string()),
+    };
+    results.insert("cadical".to_string(), cadical);
+
     let varisat = {
-        let mut ctx = prove_gate_fn_equiv_sat::Ctx::new();
-        match prove_gate_fn_equiv_sat::prove_gate_fn_equiv(lhs, rhs, &mut ctx) {
+        let mut ctx = prove_gate_fn_equiv_sat::VarisatCtx::new();
+        match prove_gate_fn_equiv_sat::prove_gate_fn_equiv_varisat(lhs, rhs, &mut ctx) {
             EquivResult::Proved => EngineResult::Equiv,
             EquivResult::Disproved(cex) => EngineResult::NotEquiv(Some(format!("{:?}", cex))),
         }

--- a/xlsynth-g8r/src/gatify/ir2gate.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate.rs
@@ -15,6 +15,7 @@ use xlsynth_pir::ir::{self, ParamId, StartAndLimit};
 use xlsynth_pir::ir_range_info::IrRangeInfo;
 use xlsynth_pir::ir_utils;
 use xlsynth_pir::ir_verify;
+use xlsynth_prover::prover::SolverChoice;
 
 use crate::ir2gate_utils::{
     AdderMapping, Direction, array_add_with_carry_out, gatify_add_brent_kung,
@@ -2670,6 +2671,10 @@ fn gatify_decode(
 
     // For every possible output value...
     for i in 0..output_bit_count {
+        if input_count < usize::BITS as usize && i >= (1usize << input_count) {
+            outputs.push(gb.get_false());
+            continue;
+        }
         let mut terms = Vec::with_capacity(input_count);
         // For each bit in the input, choose whether to use the bit directly or its
         // inversion.
@@ -4126,6 +4131,7 @@ pub struct GatifyOptions {
     pub fold: bool,
     pub hash: bool,
     pub check_equivalence: bool,
+    pub equivalence_solver: SolverChoice,
     pub adder_mapping: crate::ir2gate_utils::AdderMapping,
     pub mul_adder_mapping: Option<crate::ir2gate_utils::AdderMapping>,
     pub range_info: Option<Arc<IrRangeInfo>>,
@@ -4146,6 +4152,7 @@ impl GatifyOptions {
             fold: true,
             hash: true,
             check_equivalence: false,
+            equivalence_solver: SolverChoice::Bitwuzla,
             adder_mapping: crate::ir2gate_utils::AdderMapping::default(),
             mul_adder_mapping: None,
             range_info: None,
@@ -4166,6 +4173,7 @@ impl GatifyOptions {
             fold: true,
             hash: true,
             check_equivalence: false,
+            equivalence_solver: SolverChoice::Bitwuzla,
             adder_mapping: crate::ir2gate_utils::AdderMapping::default(),
             mul_adder_mapping: None,
             range_info: None,
@@ -4253,7 +4261,12 @@ fn gatify_lower_prepared_fn(
 
     if options.check_equivalence {
         log::info!("checking equivalence of IR function and gate function...");
-        check_equivalence::validate_same_fn(equiv_fn, &gate_fn)?;
+        check_equivalence::validate_same_fn_with_solver(
+            equiv_fn,
+            &gate_fn,
+            options.equivalence_solver,
+            None,
+        )?;
     }
     Ok(GatifyOutput {
         gate_fn,
@@ -5186,8 +5199,11 @@ fn f(x: bits[2] id=1, selector: bits[2] id=2) -> bits[2] {
     ) {
         let reference_gate_fn = build_cmp_gate_fn_for_qor_test(width, binop, reference_lowering);
         let comparison_gate_fn = build_cmp_gate_fn_for_qor_test(width, binop, comparison_lowering);
-        check_equivalence::prove_same_gate_fn_via_ir(&reference_gate_fn, &comparison_gate_fn)
-            .expect("comparison lowerings should be equivalent");
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(
+            &reference_gate_fn,
+            &comparison_gate_fn,
+        )
+        .expect("comparison lowerings should be equivalent");
     }
 
     fn gather_cmp_qor_rows() -> Vec<CmpRecursiveBitTreeQorRow> {
@@ -6380,6 +6396,48 @@ top fn f(start: bits[4], a: bits[8], b: bits[8]) -> bits[8][1] {
         gatify(&ir_fn, GatifyOptions::all_opts_disabled())
             .unwrap()
             .gate_fn
+    }
+
+    #[test]
+    fn test_decode_narrow_selector_marks_unrepresentable_outputs_false() {
+        let mut gb = GateBuilder::new("decode_narrow".to_string(), GateBuilderOptions::no_opt());
+        let input = gb.add_input("input".to_string(), 1);
+        let decoded = super::gatify_decode(&mut gb, 4, &input);
+
+        assert_eq!(decoded.get_bit_count(), 4);
+        assert!(gb.is_known_false(*decoded.get_lsb(2)));
+        assert!(gb.is_known_false(*decoded.get_lsb(3)));
+    }
+
+    #[test]
+    fn test_array_index_narrow_selector_does_not_alias_unrepresentable_cases() {
+        let gate_fn = gatify_ir_text(
+            r#"package sample
+
+top fn f(a: bits[5][4] id=1, index: bits[1] id=2) -> bits[5] {
+  ret selected: bits[5] = array_index(a, indices=[index], id=3)
+}
+"#,
+        );
+        let array_ty = ir::Type::new_array(ir::Type::Bits(5), 4);
+        let array_value = IrValue::make_array(&[
+            IrValue::make_ubits(5, 0).unwrap(),
+            IrValue::make_ubits(5, 30).unwrap(),
+            IrValue::make_ubits(5, 0).unwrap(),
+            IrValue::make_ubits(5, 31).unwrap(),
+        ])
+        .unwrap();
+        let got = gate_sim::eval(
+            &gate_fn,
+            &[
+                ir_value_to_gate_bits(&array_value, &array_ty),
+                IrBits::make_ubits(1, 1).unwrap(),
+            ],
+            gate_sim::Collect::None,
+        )
+        .outputs[0]
+            .clone();
+        assert_eq!(got, IrBits::make_ubits(5, 30).unwrap());
     }
 
     fn gatify_ir_text_with_gate_opt_in(ir_text: &str) -> Result<GateFn, String> {

--- a/xlsynth-g8r/src/ir2gate_utils.rs
+++ b/xlsynth-g8r/src/ir2gate_utils.rs
@@ -1210,7 +1210,7 @@ mod tests {
     fn test_gatify_add_carry_select(bits: usize, carry_select_partitions: &[usize]) {
         let ripple = make_ripple_carry(bits);
         let carry = make_carry_select(bits, carry_select_partitions);
-        check_equivalence::prove_same_gate_fn_via_ir(&ripple, &carry)
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&ripple, &carry)
             .expect("carry select and ripple carry should be equivalent");
     }
 
@@ -1219,10 +1219,12 @@ mod tests {
         for bits in 1..=16 {
             let ripple = make_ripple_carry(bits);
             let ks = make_kogge_stone(bits);
-            check_equivalence::prove_same_gate_fn_via_ir(&ripple, &ks).expect(&format!(
-                "kogge stone and ripple carry should be equivalent for {} bits",
-                bits
-            ));
+            check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&ripple, &ks).expect(
+                &format!(
+                    "kogge stone and ripple carry should be equivalent for {} bits",
+                    bits
+                ),
+            );
         }
     }
 
@@ -1231,10 +1233,12 @@ mod tests {
         for bits in 1..=16 {
             let ripple = make_ripple_carry(bits);
             let bk = make_brent_kung(bits);
-            check_equivalence::prove_same_gate_fn_via_ir(&ripple, &bk).expect(&format!(
-                "brent kung and ripple carry should be equivalent for {} bits",
-                bits
-            ));
+            check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&ripple, &bk).expect(
+                &format!(
+                    "brent kung and ripple carry should be equivalent for {} bits",
+                    bits
+                ),
+            );
         }
     }
 
@@ -1267,7 +1271,7 @@ mod tests {
             builder.add_output("results".to_string(), result.into());
             builder.build()
         };
-        check_equivalence::prove_same_gate_fn_via_ir(&via_adder, &via_bit_tests)
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&via_adder, &via_bit_tests)
             .expect("ule via adder and ule via bit tests should be equivalent");
     }
 }

--- a/xlsynth-g8r/src/ir2gates.rs
+++ b/xlsynth-g8r/src/ir2gates.rs
@@ -7,11 +7,13 @@ use xlsynth_pir::desugar_extensions;
 use xlsynth_pir::ir;
 use xlsynth_pir::ir_parser;
 use xlsynth_pir::ir_range_info::IrRangeInfo;
+use xlsynth_prover::prover::SolverChoice;
 
 pub struct Ir2GatesOptions {
     pub fold: bool,
     pub hash: bool,
     pub check_equivalence: bool,
+    pub equivalence_solver: SolverChoice,
     pub enable_rewrite_carry_out: bool,
     pub enable_rewrite_prio_encode: bool,
     pub enable_rewrite_nary_add: bool,
@@ -31,6 +33,7 @@ impl Ir2GatesOptions {
             fold: true,
             hash: true,
             check_equivalence: false,
+            equivalence_solver: SolverChoice::Bitwuzla,
             enable_rewrite_carry_out: prep_defaults.enable_rewrite_carry_out,
             enable_rewrite_prio_encode: prep_defaults.enable_rewrite_prio_encode,
             enable_rewrite_nary_add: prep_defaults.enable_rewrite_nary_add,
@@ -50,6 +53,7 @@ impl Ir2GatesOptions {
             fold: true,
             hash: true,
             check_equivalence: false,
+            equivalence_solver: SolverChoice::Bitwuzla,
             enable_rewrite_carry_out: prep_defaults.enable_rewrite_carry_out,
             enable_rewrite_prio_encode: prep_defaults.enable_rewrite_prio_encode,
             enable_rewrite_nary_add: prep_defaults.enable_rewrite_nary_add,
@@ -182,6 +186,7 @@ pub fn ir2gates_from_ir_text(
             fold: options.fold,
             hash: options.hash,
             check_equivalence: options.check_equivalence,
+            equivalence_solver: options.equivalence_solver,
             adder_mapping: options.adder_mapping,
             mul_adder_mapping: options.mul_adder_mapping,
             range_info: Some(range_info.clone()),

--- a/xlsynth-g8r/src/ir_aig_sharing.rs
+++ b/xlsynth-g8r/src/ir_aig_sharing.rs
@@ -340,9 +340,30 @@ pub fn confirm_or_deny_candidate_equivalence(
     gate_fn: &GateFn,
     candidate: &IrAigEquivalenceCandidate,
 ) -> Result<bool, String> {
+    confirm_or_deny_candidate_equivalence_with_backend(
+        pir_fn,
+        gate_fn,
+        candidate,
+        GateFormalBackend::default(),
+    )
+}
+
+/// Confirms or denies one candidate using the selected gate-formal backend.
+pub fn confirm_or_deny_candidate_equivalence_with_backend(
+    pir_fn: &ir::Fn,
+    gate_fn: &GateFn,
+    candidate: &IrAigEquivalenceCandidate,
+    backend: GateFormalBackend,
+) -> Result<bool, String> {
     let opts = GatifyOptions::all_opts_disabled();
-    let proofs =
-        prove_equivalence_candidates_varisat(pir_fn, gate_fn, &[candidate.clone()], &opts)?;
+    let proofs = prove_equivalence_candidates_with_backend_streaming(
+        pir_fn,
+        gate_fn,
+        &[candidate.clone()],
+        &opts,
+        backend,
+        |_proof| {},
+    )?;
     match &proofs[0].result {
         CandidateProofResult::Proved => Ok(true),
         CandidateProofResult::Disproved { .. } => Ok(false),

--- a/xlsynth-g8r/src/main.rs
+++ b/xlsynth-g8r/src/main.rs
@@ -14,6 +14,7 @@ use xlsynth_g8r::process_ir_path::{
 };
 use xlsynth_g8r::prove_gate_fn_equiv_common::GateFormalBackend;
 use xlsynth_g8r::result_proto;
+use xlsynth_prover::prover::SolverChoice;
 
 /// Simple program to parse an XLS IR file and emit a Verilog netlist.
 #[derive(Parser, Debug)]
@@ -56,6 +57,10 @@ struct Args {
     #[arg(long, default_value_t = true)]
     #[arg(action = clap::ArgAction::Set)]
     check_equivalence: bool,
+
+    /// Solver backend used for optional IR equivalence checking.
+    #[arg(long, default_value = "bitwuzla")]
+    solver: String,
 
     /// Whether to opt into lowering XLS gate ops.
     #[arg(long = "unsafe-gatify-gate-operation", default_value_t = false)]
@@ -113,10 +118,12 @@ fn main() {
         .expect("validated by clap value_parser");
     let cut_db_rewrite_mode =
         CutDbRewriteMode::parse(&args.cut_db_rewrite_mode).expect("validated by clap value_parser");
+    let equivalence_solver: SolverChoice = args.solver.parse().expect("invalid --solver value");
     let cut_db = Some(xlsynth_g8r::cut_db::loader::CutDb::load_default());
 
     let options = Options {
         check_equivalence: args.check_equivalence,
+        equivalence_solver,
         fold: args.fold,
         hash: args.hash,
         enable_rewrite_carry_out: false,

--- a/xlsynth-g8r/src/mcmc_logic.rs
+++ b/xlsynth-g8r/src/mcmc_logic.rs
@@ -24,6 +24,9 @@ use crate::aig::gate::GateFn;
 use crate::aig::{dce, get_summary_stats};
 use crate::aig_serdes::g8r::{emit_g8r, encode_g8r_binary, load_gate_fn_from_path};
 use crate::aig_sim::gate_simd::{self, Vec256};
+use crate::check_equivalence::{
+    IrCheckResult, prove_same_gate_fn_via_ir_status, prove_same_gate_fn_via_ir_status_via_toolchain,
+};
 use crate::gatify::ir2gate::{self, GatifyOptions};
 use crate::prove_gate_fn_equiv_common::{EquivResult, GateFormalBackend};
 use crate::prove_gate_fn_equiv_sat::{ValidationError, prove_gate_fn_equiv_with_backend};
@@ -124,6 +127,7 @@ pub fn mcmc_iteration(
     temp: f64,
     objective: Objective,
     paranoid: bool,
+    xls_cross_check: bool,
     simd_inputs: &[Vec256],
     baseline_outputs: &Vec<Vec256>,
 ) -> std::result::Result<McmcIterationOutput, ValidationError> {
@@ -218,17 +222,43 @@ pub fn mcmc_iteration(
                     context.gate_formal_backend,
                 )?;
                 if paranoid {
-                    let external_res =
-                        crate::check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(
+                    let native_ir_status =
+                        prove_same_gate_fn_via_ir_status(&current_gfn, &candidate_gfn);
+                    let native_ir_res = match native_ir_status {
+                        IrCheckResult::Equivalent => true,
+                        IrCheckResult::NotEquivalent => false,
+                        other => {
+                            return Err(ValidationError::IrEquivalenceError(format!(
+                                "native IR equivalence checker failed: {other:?}"
+                            )));
+                        }
+                    };
+                    if sat_res != native_ir_res {
+                        panic!(
+                            "[mcmc] ERROR: gate-level SAT oracle and native IR Bitwuzla checker DISAGREE in mcmc_iteration: gate-level SAT oracle: {}, native IR Bitwuzla: {}",
+                            sat_res, native_ir_res
+                        );
+                    }
+                    if xls_cross_check {
+                        let xls_ir_status = prove_same_gate_fn_via_ir_status_via_toolchain(
                             &current_gfn,
                             &candidate_gfn,
-                        )
-                        .is_ok();
-                    if sat_res != external_res {
-                        panic!(
-                            "[mcmc] ERROR: SAT oracle and external check_equivalence_with_top DISAGREE in mcmc_iteration: SAT oracle: {}, external: {}",
-                            sat_res, external_res
                         );
+                        let xls_ir_res = match xls_ir_status {
+                            IrCheckResult::Equivalent => true,
+                            IrCheckResult::NotEquivalent => false,
+                            other => {
+                                return Err(ValidationError::IrEquivalenceError(format!(
+                                    "XLS IR equivalence checker failed: {other:?}"
+                                )));
+                            }
+                        };
+                        if sat_res != xls_ir_res {
+                            panic!(
+                                "[mcmc] ERROR: gate-level SAT oracle and XLS IR checker DISAGREE in mcmc_iteration: gate-level SAT oracle: {}, XLS IR: {}",
+                                sat_res, xls_ir_res
+                            );
+                        }
                     }
                 }
                 sat_res
@@ -315,6 +345,7 @@ pub fn mcmc(
     objective: Objective,
     periodic_dump_dir: Option<PathBuf>,
     paranoid: bool,
+    xls_cross_check: bool,
     checkpoint_interval: u64,
     progress_interval: u64,
     shared_best: Option<Arc<Best>>,
@@ -489,6 +520,7 @@ pub fn mcmc(
             current_temp,
             objective,
             paranoid,
+            xls_cross_check,
             &simd_inputs,
             &baseline_outputs,
         )?;
@@ -657,6 +689,7 @@ pub fn mcmc(
                         global_iter,
                         "Iter checkpoint",
                         gate_formal_backend,
+                        xls_cross_check,
                     )?;
                 }
             }
@@ -680,6 +713,7 @@ pub fn mcmc(
             options.start_iteration + iterations_count,
             "Final checkpoint",
             gate_formal_backend,
+            xls_cross_check,
         )?;
         if progress_interval > 0 {
             let elapsed_secs = start_time.elapsed().as_secs_f64();
@@ -835,15 +869,30 @@ fn write_checkpoint(
     iter: u64,
     context: &str,
     gate_formal_backend: GateFormalBackend,
+    xls_cross_check: bool,
 ) -> Result<()> {
     // Cross-check equivalence
     let equiv_ok_sat = oracle_equiv_sat_with_backend(original_gfn, best_gfn, gate_formal_backend)?;
-    use crate::check_equivalence::{IrCheckResult, prove_same_gate_fn_via_ir_status_via_toolchain};
 
-    let ir_status = prove_same_gate_fn_via_ir_status_via_toolchain(original_gfn, best_gfn);
-    let equiv_ok_external = matches!(ir_status, IrCheckResult::Equivalent);
+    let native_ir_status = prove_same_gate_fn_via_ir_status(original_gfn, best_gfn);
+    let equiv_ok_native_ir = matches!(native_ir_status, IrCheckResult::Equivalent);
+    let xls_ir_status = if xls_cross_check {
+        Some(prove_same_gate_fn_via_ir_status_via_toolchain(
+            original_gfn,
+            best_gfn,
+        ))
+    } else {
+        None
+    };
+    let xls_ir_disagrees = match xls_ir_status.as_ref() {
+        Some(IrCheckResult::Equivalent) => !equiv_ok_sat,
+        Some(IrCheckResult::NotEquivalent) => equiv_ok_sat,
+        Some(IrCheckResult::TimedOutOrInterrupted | IrCheckResult::OtherProcessError(_)) | None => {
+            false
+        }
+    };
 
-    if equiv_ok_sat != equiv_ok_external || !equiv_ok_sat {
+    if equiv_ok_sat != equiv_ok_native_ir || xls_ir_disagrees || !equiv_ok_sat {
         // Ensure we persist the disagreeing pair for offline triage.
         if let Some(parent_dir) = g8r_path.parent() {
             let dump_dir = parent_dir.join("equiv_failures");
@@ -874,27 +923,38 @@ fn write_checkpoint(
         }
 
         return Err(anyhow::anyhow!(
-            "[mcmc] ERROR: Equivalence disagreement at iter {} (sat:{}, external:{})",
+            "[mcmc] ERROR: Equivalence disagreement at iter {} (gate SAT:{}, native IR Bitwuzla:{}, XLS IR:{:?})",
             iter,
             equiv_ok_sat,
-            equiv_ok_external
+            equiv_ok_native_ir,
+            xls_ir_status
         ));
     }
-    match ir_status {
+    match native_ir_status {
         IrCheckResult::Equivalent => {}
-        IrCheckResult::TimedOutOrInterrupted => {
+        other => {
+            return Err(anyhow::anyhow!(
+                "[mcmc] ERROR: Native IR Bitwuzla equivalence checker failed at iter {}: {:?}",
+                iter,
+                other
+            ));
+        }
+    }
+    match xls_ir_status {
+        Some(IrCheckResult::Equivalent) | None => {}
+        Some(IrCheckResult::TimedOutOrInterrupted) => {
             eprintln!(
-                "[mcmc] Warning: External IR equivalence check timed out or was interrupted (iteration {}). Proceeding with SAT oracle result only.",
+                "[mcmc] Warning: XLS IR equivalence check timed out or was interrupted (iteration {}). Proceeding with native proof results only.",
                 iter
             );
         }
-        IrCheckResult::OtherProcessError(ref msg) => {
+        Some(IrCheckResult::OtherProcessError(ref msg)) => {
             eprintln!(
-                "[mcmc] Warning: External IR equivalence checker failed at iter {}: {}",
+                "[mcmc] Warning: XLS IR equivalence checker failed at iter {}: {}",
                 iter, msg
             );
         }
-        IrCheckResult::NotEquivalent => {}
+        Some(IrCheckResult::NotEquivalent) => {}
     }
     let best_design = SequentialGateFn::from_gate_fn(best_gfn.clone());
     if let Err(e) = std::fs::write(g8r_path, emit_g8r(&best_design)) {

--- a/xlsynth-g8r/src/mcmc_logic.rs
+++ b/xlsynth-g8r/src/mcmc_logic.rs
@@ -218,11 +218,12 @@ pub fn mcmc_iteration(
                     context.gate_formal_backend,
                 )?;
                 if paranoid {
-                    let external_res = crate::check_equivalence::prove_same_gate_fn_via_ir(
-                        &current_gfn,
-                        &candidate_gfn,
-                    )
-                    .is_ok();
+                    let external_res =
+                        crate::check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(
+                            &current_gfn,
+                            &candidate_gfn,
+                        )
+                        .is_ok();
                     if sat_res != external_res {
                         panic!(
                             "[mcmc] ERROR: SAT oracle and external check_equivalence_with_top DISAGREE in mcmc_iteration: SAT oracle: {}, external: {}",
@@ -837,9 +838,9 @@ fn write_checkpoint(
 ) -> Result<()> {
     // Cross-check equivalence
     let equiv_ok_sat = oracle_equiv_sat_with_backend(original_gfn, best_gfn, gate_formal_backend)?;
-    use crate::check_equivalence::{IrCheckResult, prove_same_gate_fn_via_ir_status};
+    use crate::check_equivalence::{IrCheckResult, prove_same_gate_fn_via_ir_status_via_toolchain};
 
-    let ir_status = prove_same_gate_fn_via_ir_status(original_gfn, best_gfn);
+    let ir_status = prove_same_gate_fn_via_ir_status_via_toolchain(original_gfn, best_gfn);
     let equiv_ok_external = matches!(ir_status, IrCheckResult::Equivalent);
 
     if equiv_ok_sat != equiv_ok_external || !equiv_ok_sat {

--- a/xlsynth-g8r/src/process_ir_path.rs
+++ b/xlsynth-g8r/src/process_ir_path.rs
@@ -33,6 +33,7 @@ use crate::use_count::get_id_to_use_count;
 use xlsynth_pir::ir;
 use xlsynth_pir::ir_range_info::IrRangeInfo;
 use xlsynth_pir::ir_utils;
+use xlsynth_prover::prover::SolverChoice;
 
 pub const DEFAULT_MAX_FRAIG_SIM_SAMPLES: usize = 8 * 1024;
 
@@ -142,6 +143,7 @@ impl Into<crate::result_proto::Ir2GatesSummaryStats> for Ir2GatesSummaryStats {
 
 pub struct Options {
     pub check_equivalence: bool,
+    pub equivalence_solver: SolverChoice,
     pub fold: bool,
     pub hash: bool,
     pub enable_rewrite_carry_out: bool,
@@ -279,6 +281,7 @@ impl CanonicalG8rOptions {
     ) -> Options {
         Options {
             check_equivalence: false,
+            equivalence_solver: SolverChoice::Bitwuzla,
             fold: self.fold,
             hash: self.hash,
             enable_rewrite_carry_out: self.enable_rewrite_carry_out,
@@ -333,6 +336,7 @@ impl From<&Options> for ir2gates::Ir2GatesOptions {
             fold: options.fold,
             hash: options.hash,
             check_equivalence: false, // check is done below if requested
+            equivalence_solver: options.equivalence_solver,
             enable_rewrite_carry_out: options.enable_rewrite_carry_out,
             enable_rewrite_prio_encode: options.enable_rewrite_prio_encode,
             enable_rewrite_nary_add: options.enable_rewrite_nary_add,
@@ -353,6 +357,7 @@ impl From<&CanonicalG8rOptions> for ir2gates::Ir2GatesOptions {
             fold: options.fold,
             hash: options.hash,
             check_equivalence: false,
+            equivalence_solver: SolverChoice::Bitwuzla,
             enable_rewrite_carry_out: options.enable_rewrite_carry_out,
             enable_rewrite_prio_encode: options.enable_rewrite_prio_encode,
             enable_rewrite_nary_add: options.enable_rewrite_nary_add,
@@ -720,7 +725,12 @@ pub fn process_ir_text_with_gatefn(
     if options.check_equivalence {
         println!("== Checking equivalence...");
         let start = std::time::Instant::now();
-        let eq = check_equivalence::validate_same_fn(&ir_top, &gate_fn);
+        let eq = check_equivalence::validate_same_fn_with_solver(
+            &ir_top,
+            &gate_fn,
+            options.equivalence_solver,
+            None,
+        );
         let duration = start.elapsed();
         println!("Equivalence check took {:?}.", duration);
         println!("Equivalence: {:?}", eq);

--- a/xlsynth-g8r/src/prove_gate_fn_equiv_sat.rs
+++ b/xlsynth-g8r/src/prove_gate_fn_equiv_sat.rs
@@ -24,11 +24,11 @@ use varisat::ExtendFormula;
 use xlsynth::IrBits;
 
 /// Context holding a SAT solver so clause memory can be reused across calls.
-pub struct Ctx<'a> {
+pub struct VarisatCtx<'a> {
     pub(crate) solver: varisat::Solver<'a>,
 }
 
-impl<'a> Ctx<'a> {
+impl<'a> VarisatCtx<'a> {
     pub fn new() -> Self {
         Self {
             solver: varisat::Solver::new(),
@@ -649,7 +649,11 @@ pub fn prove_gate_fn_equiv_with_backend_and_options(
 }
 
 /// Checks equivalence of two gate functions using a Varisat context.
-pub fn prove_gate_fn_equiv<'a>(a: &GateFn, b: &GateFn, ctx: &mut Ctx<'a>) -> EquivResult {
+pub fn prove_gate_fn_equiv_varisat<'a>(
+    a: &GateFn,
+    b: &GateFn,
+    ctx: &mut VarisatCtx<'a>,
+) -> EquivResult {
     prove_gate_fn_equiv_with_solver(a, b, &mut ctx.solver).expect("solver error")
 }
 

--- a/xlsynth-g8r/tests/array_index_lowering_equiv_test.rs
+++ b/xlsynth-g8r/tests/array_index_lowering_equiv_test.rs
@@ -3,7 +3,7 @@
 use xlsynth_g8r::check_equivalence;
 use xlsynth_g8r::gatify::ir2gate::{ArrayIndexLoweringStrategy, GatifyOptions, gatify};
 use xlsynth_g8r::ir2gate_utils::AdderMapping;
-use xlsynth_g8r::prove_gate_fn_equiv_sat::{Ctx, EquivResult, prove_gate_fn_equiv};
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{EquivResult, VarisatCtx, prove_gate_fn_equiv_varisat};
 use xlsynth_pir::ir_parser;
 
 fn build_direct_array_index_ir_text(
@@ -72,9 +72,9 @@ fn assert_strategies_are_equivalent(
 ) {
     let lhs_gate = gatify_ir_text_with_strategy(ir_text, lhs);
     let rhs_gate = gatify_ir_text_with_strategy(ir_text, rhs);
-    let mut ctx = Ctx::new();
+    let mut ctx = VarisatCtx::new();
     assert_eq!(
-        prove_gate_fn_equiv(&lhs_gate, &rhs_gate, &mut ctx),
+        prove_gate_fn_equiv_varisat(&lhs_gate, &rhs_gate, &mut ctx),
         EquivResult::Proved,
         "lowerings should be equivalent for IR:\n{}",
         ir_text

--- a/xlsynth-g8r/tests/array_index_lowering_equiv_test.rs
+++ b/xlsynth-g8r/tests/array_index_lowering_equiv_test.rs
@@ -61,7 +61,7 @@ fn assert_strategy_matches_ir(ir_text: &str, strategy: ArrayIndexLoweringStrateg
     let ir_package = parser.parse_and_validate_package().expect("parse package");
     let ir_fn = ir_package.get_top_fn().expect("top fn");
     let gate_fn = gatify_ir_text_with_strategy(ir_text, strategy);
-    check_equivalence::validate_same_fn(&ir_fn, &gate_fn)
+    check_equivalence::validate_same_fn_via_toolchain(&ir_fn, &gate_fn)
         .expect("strategy should preserve IR semantics");
 }
 

--- a/xlsynth-g8r/tests/aug_opt_affine_shift_amount_equiv.rs
+++ b/xlsynth-g8r/tests/aug_opt_affine_shift_amount_equiv.rs
@@ -94,7 +94,7 @@ fn gatify_without_prep(pir_fn: &ir::Fn) -> GateFn {
 fn assert_ir_fns_equivalent(orig_fn: &ir::Fn, prepared_fn: &ir::Fn, label: &str) {
     let orig_pkg_text = format!("package orig\n\ntop {}", orig_fn);
     let prepared_pkg_text = format!("package prepared\n\ntop {}", prepared_fn);
-    check_equivalence::check_equivalence_via_toolchain(&orig_pkg_text, &prepared_pkg_text)
+    check_equivalence::check_equivalence(&orig_pkg_text, &prepared_pkg_text)
         .unwrap_or_else(|e| panic!("PIR equivalence failed for {label}: {e}"));
 }
 
@@ -301,9 +301,9 @@ fn assert_rewrites_and_proves(case: &AffineShiftCase, prove_gates: bool) {
     if prove_gates {
         let gate_old = gatify_without_prep(&pir_fn);
         let gate_new = gatify_without_prep(&prepared);
-        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_old, &gate_new)
+        check_equivalence::prove_same_gate_fn_via_ir(&gate_old, &gate_new)
             .unwrap_or_else(|e| panic!("gate equivalence failed for {label}: {e}"));
-        check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &gate_new)
+        check_equivalence::validate_same_fn(&pir_fn, &gate_new)
             .unwrap_or_else(|e| panic!("rewritten gate validation failed for {label}: {e}"));
     }
 }

--- a/xlsynth-g8r/tests/aug_opt_affine_shift_amount_equiv.rs
+++ b/xlsynth-g8r/tests/aug_opt_affine_shift_amount_equiv.rs
@@ -94,7 +94,7 @@ fn gatify_without_prep(pir_fn: &ir::Fn) -> GateFn {
 fn assert_ir_fns_equivalent(orig_fn: &ir::Fn, prepared_fn: &ir::Fn, label: &str) {
     let orig_pkg_text = format!("package orig\n\ntop {}", orig_fn);
     let prepared_pkg_text = format!("package prepared\n\ntop {}", prepared_fn);
-    check_equivalence::check_equivalence(&orig_pkg_text, &prepared_pkg_text)
+    check_equivalence::check_equivalence_via_toolchain(&orig_pkg_text, &prepared_pkg_text)
         .unwrap_or_else(|e| panic!("PIR equivalence failed for {label}: {e}"));
 }
 
@@ -301,9 +301,9 @@ fn assert_rewrites_and_proves(case: &AffineShiftCase, prove_gates: bool) {
     if prove_gates {
         let gate_old = gatify_without_prep(&pir_fn);
         let gate_new = gatify_without_prep(&prepared);
-        check_equivalence::prove_same_gate_fn_via_ir(&gate_old, &gate_new)
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_old, &gate_new)
             .unwrap_or_else(|e| panic!("gate equivalence failed for {label}: {e}"));
-        check_equivalence::validate_same_fn(&pir_fn, &gate_new)
+        check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &gate_new)
             .unwrap_or_else(|e| panic!("rewritten gate validation failed for {label}: {e}"));
     }
 }

--- a/xlsynth-g8r/tests/aug_opt_affine_shift_amount_qor.rs
+++ b/xlsynth-g8r/tests/aug_opt_affine_shift_amount_qor.rs
@@ -93,9 +93,12 @@ fn row_for_case(case: AffineShiftQorCase) -> AffineShiftQorRow {
 
     let gate_dynamic_shift = gatify_gate_fn(&pir_fn);
     let gate_affine_select = gatify_gate_fn(&prepared);
-    check_equivalence::prove_same_gate_fn_via_ir(&gate_dynamic_shift, &gate_affine_select)
-        .unwrap_or_else(|e| panic!("gate equivalence failed for {case:?}: {e}"));
-    check_equivalence::validate_same_fn(&pir_fn, &gate_affine_select)
+    check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(
+        &gate_dynamic_shift,
+        &gate_affine_select,
+    )
+    .unwrap_or_else(|e| panic!("gate equivalence failed for {case:?}: {e}"));
+    check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &gate_affine_select)
         .unwrap_or_else(|e| panic!("rewritten gate validation failed for {case:?}: {e}"));
 
     let dynamic_shift = get_aig_stats(&gate_dynamic_shift);

--- a/xlsynth-g8r/tests/aug_opt_selected_opposite_subtracts_qor.rs
+++ b/xlsynth-g8r/tests/aug_opt_selected_opposite_subtracts_qor.rs
@@ -4,9 +4,7 @@ use xlsynth_g8r::aig::get_summary_stats::get_aig_stats;
 use xlsynth_g8r::gatify::ir2gate::{GatifyOptions, gatify_prepared_fn};
 use xlsynth_g8r::ir2gate_utils::AdderMapping;
 use xlsynth_g8r::prove_gate_fn_equiv_common::EquivResult;
-use xlsynth_g8r::prove_gate_fn_equiv_sat::{
-    Ctx as VarisatCtx, prove_gate_fn_equiv as prove_gate_fn_equiv_sat,
-};
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{VarisatCtx, prove_gate_fn_equiv_varisat};
 use xlsynth_pir::aug_opt::{AugOptMode, AugOptOptions, run_aug_opt_over_ir_text_with_stats};
 use xlsynth_pir::ir;
 use xlsynth_pir::ir_parser;
@@ -93,7 +91,7 @@ fn assert_gate_equiv_via_sat(
     context: &str,
 ) {
     let mut ctx = VarisatCtx::new();
-    match prove_gate_fn_equiv_sat(lhs, rhs, &mut ctx) {
+    match prove_gate_fn_equiv_varisat(lhs, rhs, &mut ctx) {
         EquivResult::Proved => {}
         EquivResult::Disproved(cex) => {
             panic!("gate equivalence failed for {context}; counterexample inputs: {cex:?}");

--- a/xlsynth-g8r/tests/ext_carry_out_prep_for_gatify_equiv.rs
+++ b/xlsynth-g8r/tests/ext_carry_out_prep_for_gatify_equiv.rs
@@ -23,7 +23,7 @@ fn assert_ir_fns_equivalent(orig_fn: &ir::Fn, prepared_fn: &ir::Fn) {
     desugar_extensions_in_fn(&mut prepared_desugared).expect("desugar prepared PIR");
     let orig_pkg_text = format!("package orig\n\ntop {}", orig_desugared);
     let prepared_pkg_text = format!("package prepared\n\ntop {}", prepared_desugared);
-    check_equivalence::check_equivalence(&orig_pkg_text, &prepared_pkg_text)
+    check_equivalence::check_equivalence_via_toolchain(&orig_pkg_text, &prepared_pkg_text)
         .expect("prepared PIR should be equivalent to original PIR");
 }
 
@@ -108,7 +108,8 @@ top fn cone(x: bits[8] id=1, y: bits[8] id=2) -> bits[1] {
     .expect("gatify");
 
     // Double-check explicitly (gatify also checks when check_equivalence=true).
-    check_equivalence::validate_same_fn(&pir_fn, &gatify_output.gate_fn).expect("equiv");
+    check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &gatify_output.gate_fn)
+        .expect("equiv");
 }
 
 #[test]
@@ -153,7 +154,8 @@ fn carry_out_rewrite_sweep_up_to_4_bits_only_triggers_for_msb_slice() {
                 },
             )
             .expect("gatify");
-            check_equivalence::validate_same_fn(&pir_fn, &gatify_output.gate_fn).expect("equiv");
+            check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &gatify_output.gate_fn)
+                .expect("equiv");
         }
     }
 }
@@ -203,7 +205,8 @@ top fn cone(a: bits[9] id=1, b: bits[9] id=2) -> bits[1] {
     )
     .expect("gatify");
 
-    check_equivalence::validate_same_fn(&pir_fn, &gatify_output.gate_fn).expect("equiv");
+    check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &gatify_output.gate_fn)
+        .expect("equiv");
 }
 
 #[test]
@@ -254,5 +257,6 @@ top fn cone(p0: bits[9] id=1, p1: bits[9] id=2) -> bits[1] {
     )
     .expect("gatify");
 
-    check_equivalence::validate_same_fn(&pir_fn, &gatify_output.gate_fn).expect("equiv");
+    check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &gatify_output.gate_fn)
+        .expect("equiv");
 }

--- a/xlsynth-g8r/tests/ext_clz_ir2gates_equiv.rs
+++ b/xlsynth-g8r/tests/ext_clz_ir2gates_equiv.rs
@@ -94,7 +94,7 @@ fn direct_ext_clz_matches_desugared_semantics_width_sweep() {
                 continue;
             }
 
-            check_equivalence::prove_same_gate_fn_via_ir(&gate_ext, &gate_desugared).unwrap_or_else(
+            check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_ext, &gate_desugared).unwrap_or_else(
             |e| {
                 panic!(
                     "expected direct ext_clz lowering to match desugared semantics for bit_count={bit_count} offset={offset}: {e}"
@@ -178,7 +178,7 @@ fn gate_graph_equivalence_old_vs_clz_rewrite_width_sweep() {
         let gate_old = gatify_for_test(&pir_fn, /* enable_rewrite_prio_encode= */ false);
         let gate_new = gatify_for_test(&pir_fn, /* enable_rewrite_prio_encode= */ true);
 
-        check_equivalence::prove_same_gate_fn_via_ir(&gate_old, &gate_new).unwrap_or_else(|e| {
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_old, &gate_new).unwrap_or_else(|e| {
             panic!(
                 "expected old vs rewritten CLZ lowering to be equivalent for bit_count={bit_count}: {e}"
             )

--- a/xlsynth-g8r/tests/ext_mask_low_ir2gates_equiv.rs
+++ b/xlsynth-g8r/tests/ext_mask_low_ir2gates_equiv.rs
@@ -51,7 +51,7 @@ fn direct_ext_mask_low_matches_desugared_semantics_width_sweep() {
             continue;
         }
 
-        check_equivalence::prove_same_gate_fn_via_ir(&gate_ext, &gate_desugared).unwrap_or_else(
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_ext, &gate_desugared).unwrap_or_else(
             |e| {
                 panic!(
                     "expected direct ext_mask_low lowering to match desugared semantics for output_width={output_width} count_width={count_width}: {e}"
@@ -71,7 +71,7 @@ fn direct_ext_mask_low_matches_desugared_for_non_power_of_two_widths() {
 
         let gate_ext = gatify_for_test(&pir_fn);
         let gate_desugared = gatify_for_test(&desugared_fn);
-        check_equivalence::prove_same_gate_fn_via_ir(&gate_ext, &gate_desugared).unwrap_or_else(
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_ext, &gate_desugared).unwrap_or_else(
             |e| {
                 panic!(
                     "expected non-power-of-two ext_mask_low lowering to match desugared semantics for output_width={output_width}: {e}"

--- a/xlsynth-g8r/tests/ext_mask_low_prep_for_gatify_equiv.rs
+++ b/xlsynth-g8r/tests/ext_mask_low_prep_for_gatify_equiv.rs
@@ -23,7 +23,7 @@ fn assert_ir_fns_equivalent(orig_fn: &ir::Fn, prepared_fn: &ir::Fn) {
     desugar_extensions_in_fn(&mut prepared_desugared).expect("desugar prepared PIR");
     let orig_pkg_text = format!("package orig\n\ntop {}", orig_desugared);
     let prepared_pkg_text = format!("package prepared\n\ntop {}", prepared_desugared);
-    check_equivalence::check_equivalence(&orig_pkg_text, &prepared_pkg_text)
+    check_equivalence::check_equivalence_via_toolchain(&orig_pkg_text, &prepared_pkg_text)
         .expect("prepared PIR should be equivalent to original PIR");
 }
 
@@ -614,7 +614,7 @@ fn gate_graph_equivalence_old_vs_mask_low_rewrite() {
         let pir_fn = parse_top_fn(&ir_text);
         let gate_old = gatify_for_test(&pir_fn, /* enable_rewrite_mask_low= */ false);
         let gate_new = gatify_for_test(&pir_fn, /* enable_rewrite_mask_low= */ true);
-        check_equivalence::prove_same_gate_fn_via_ir(&gate_old, &gate_new)
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_old, &gate_new)
             .expect("expected old vs rewritten mask-low lowering to be equivalent");
     }
 }
@@ -644,7 +644,7 @@ fn gate_graph_equivalence_shifted_all_ones_rewrite_sweep() {
         let pir_fn = parse_top_fn(&ir_text);
         let gate_old = gatify_for_test(&pir_fn, /* enable_rewrite_mask_low= */ false);
         let gate_new = gatify_for_test(&pir_fn, /* enable_rewrite_mask_low= */ true);
-        check_equivalence::prove_same_gate_fn_via_ir(&gate_old, &gate_new).unwrap_or_else(|e| {
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_old, &gate_new).unwrap_or_else(|e| {
             panic!(
                 "expected shifted-all-ones rewrite to be equivalent for source_width={source_width} count_width={count_width} start={start} width={width}: {e}"
             )

--- a/xlsynth-g8r/tests/ext_nary_add_ir2gates_test.rs
+++ b/xlsynth-g8r/tests/ext_nary_add_ir2gates_test.rs
@@ -4,7 +4,7 @@ use xlsynth::{IrBits, IrValue};
 use xlsynth_g8r::aig::get_summary_stats::get_aig_stats;
 use xlsynth_g8r::ir2gate_utils::AdderMapping;
 use xlsynth_g8r::ir2gates;
-use xlsynth_g8r::prove_gate_fn_equiv_sat::{Ctx, EquivResult, prove_gate_fn_equiv};
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{EquivResult, VarisatCtx, prove_gate_fn_equiv_varisat};
 use xlsynth_pir::ir::{
     ExtNaryAddArchitecture, ExtNaryAddTerm, FileTable, MemberType, Node, NodePayload, Package,
     PackageMember, Param, ParamId, Type,
@@ -226,9 +226,9 @@ fn assert_lowered_ir_texts_are_equivalent(
 ) {
     let lhs = lower_ir_to_gates_output(lhs_ir_text, fold, hash);
     let rhs = lower_ir_to_gates_output(rhs_ir_text, fold, hash);
-    let mut ctx = Ctx::new();
+    let mut ctx = VarisatCtx::new();
     assert_eq!(
-        prove_gate_fn_equiv(
+        prove_gate_fn_equiv_varisat(
             &lhs.gatify_output.gate_fn,
             &rhs.gatify_output.gate_fn,
             &mut ctx

--- a/xlsynth-g8r/tests/ext_normalize_left_ir2gates_equiv.rs
+++ b/xlsynth-g8r/tests/ext_normalize_left_ir2gates_equiv.rs
@@ -34,7 +34,7 @@ top fn ext_normalize_left_4b(input: bits[4] id=1) -> (bits[8], bits[3]) {
 
     let gate_ext = gatify_for_test(&pir_fn);
     let gate_desugared = gatify_for_test(&desugared_fn);
-    check_equivalence::prove_same_gate_fn_via_ir(&gate_ext, &gate_desugared)
+    check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_ext, &gate_desugared)
         .expect("direct ext_normalize_left lowering should match desugared semantics");
 }
 
@@ -53,7 +53,7 @@ top fn ext_normalize_left_5b(input: bits[5] id=1) -> (bits[7], bits[4]) {
 
     let gate_ext = gatify_for_test(&pir_fn);
     let gate_desugared = gatify_for_test(&desugared_fn);
-    check_equivalence::prove_same_gate_fn_via_ir(&gate_ext, &gate_desugared)
+    check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_ext, &gate_desugared)
         .expect("direct ext_normalize_left lowering should match desugared semantics");
 }
 
@@ -72,7 +72,7 @@ top fn ext_normalize_left_zeroed(input: bits[4] id=1) -> bits[8] {
 
     let gate_ext = gatify_for_test(&pir_fn);
     let gate_desugared = gatify_for_test(&desugared_fn);
-    check_equivalence::prove_same_gate_fn_via_ir(&gate_ext, &gate_desugared)
+    check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_ext, &gate_desugared)
         .expect("large-offset ext_normalize_left lowering should match desugared semantics");
 }
 

--- a/xlsynth-g8r/tests/ext_prio_encode_prep_for_gatify_equiv.rs
+++ b/xlsynth-g8r/tests/ext_prio_encode_prep_for_gatify_equiv.rs
@@ -23,7 +23,7 @@ fn assert_ir_fns_equivalent(orig_fn: &ir::Fn, prepared_fn: &ir::Fn) {
     desugar_extensions_in_fn(&mut prepared_desugared).expect("desugar prepared PIR");
     let orig_pkg_text = format!("package orig\n\ntop {}", orig_desugared);
     let prepared_pkg_text = format!("package prepared\n\ntop {}", prepared_desugared);
-    check_equivalence::check_equivalence(&orig_pkg_text, &prepared_pkg_text)
+    check_equivalence::check_equivalence_via_toolchain(&orig_pkg_text, &prepared_pkg_text)
         .expect("prepared PIR should be equivalent to original PIR");
 }
 
@@ -152,7 +152,7 @@ fn gate_graph_equivalence_old_vs_rewrite_width_sweep() {
             let gate_old = gatify_for_test(&pir_fn, /* enable_rewrite_prio_encode= */ false);
             let gate_new = gatify_for_test(&pir_fn, /* enable_rewrite_prio_encode= */ true);
 
-            check_equivalence::prove_same_gate_fn_via_ir(&gate_old, &gate_new)
+            check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_old, &gate_new)
                 .expect("expected old vs rewritten prio-encode lowering to be equivalent");
         }
     }
@@ -183,7 +183,7 @@ fn direct_ext_prio_encode_matches_desugared_semantics_width_sweep() {
                 continue;
             }
 
-            check_equivalence::prove_same_gate_fn_via_ir(&gate_ext, &gate_desugared)
+            check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_ext, &gate_desugared)
                 .unwrap_or_else(|e| {
                     panic!(
                         "expected direct ext_prio_encode lowering to match desugared semantics for bit_count={bit_count} lsb_prio={lsb_prio}: {e}"

--- a/xlsynth-g8r/tests/gated_inc_dec_prep_for_gatify_equiv.rs
+++ b/xlsynth-g8r/tests/gated_inc_dec_prep_for_gatify_equiv.rs
@@ -119,9 +119,9 @@ fn assert_direct_and_helper_match(kind: GatedIncDecKind) {
         direct_stats, helper_stats,
         "expected direct and helper {kind:?} forms to have identical gate stats"
     );
-    check_equivalence::prove_same_gate_fn_via_ir(&direct_gate, &helper_gate)
+    check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&direct_gate, &helper_gate)
         .expect("direct and helper gates should be equivalent");
-    check_equivalence::validate_same_fn(&direct_fn, &helper_gate)
+    check_equivalence::validate_same_fn_via_toolchain(&direct_fn, &helper_gate)
         .expect("helper gate should match direct PIR");
 }
 

--- a/xlsynth-g8r/tests/gatify_tests.rs
+++ b/xlsynth-g8r/tests/gatify_tests.rs
@@ -44,7 +44,7 @@ fn do_test_ir_conversion_with_top(
     )
     .unwrap();
 
-    check_equivalence::validate_same_fn(&ir_fn, &gatify_output.gate_fn)
+    check_equivalence::validate_same_fn_via_toolchain(&ir_fn, &gatify_output.gate_fn)
         .expect("should validate IR to gate function equivalence");
 
     get_summary_stats(&gatify_output.gate_fn)

--- a/xlsynth-g8r/tests/ir_aig_sharing_candidates_test.rs
+++ b/xlsynth-g8r/tests/ir_aig_sharing_candidates_test.rs
@@ -4,8 +4,9 @@ use xlsynth_g8r::aig::gate::{AigBitVector, AigOperand};
 use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
 use xlsynth_g8r::gatify::ir2gate::GatifyOptions;
 use xlsynth_g8r::ir_aig_sharing::{
-    CandidateProofResult, IrAigCandidateRhs, IrAigSharingOptions, get_equivalences,
-    prove_equivalence_candidates_cadical, prove_equivalence_candidates_varisat,
+    CandidateProofResult, IrAigCandidateRhs, IrAigSharingOptions,
+    confirm_or_deny_candidate_equivalence, get_equivalences, prove_equivalence_candidates_cadical,
+    prove_equivalence_candidates_varisat,
 };
 use xlsynth_pir::ir_parser::Parser as PirParser;
 
@@ -47,10 +48,13 @@ top fn main(a: bits[1] id=1, b: bits[1] id=2) -> bits[1] {
         !hits.is_empty(),
         "expected at least one candidate for pir node id=3"
     );
+    let matching_candidate = hits
+        .iter()
+        .find(|c| c.rhs == IrAigCandidateRhs::AigOperand(AigOperand::from(and_ref)))
+        .expect("expected a candidate mapping to the AND node");
     assert!(
-        hits.iter()
-            .any(|c| c.rhs == IrAigCandidateRhs::AigOperand(AigOperand::from(and_ref))),
-        "expected a candidate mapping to the AND node"
+        confirm_or_deny_candidate_equivalence(pir_fn, &gate_fn, matching_candidate)
+            .expect("confirm candidate equivalence with default backend")
     );
 
     let gatify_opts = GatifyOptions::all_opts_disabled();

--- a/xlsynth-g8r/tests/mul_const_lowering_equiv_test.rs
+++ b/xlsynth-g8r/tests/mul_const_lowering_equiv_test.rs
@@ -135,12 +135,14 @@ fn prove_case(width: usize, case: &ConstantCase, literal_side: LiteralSide) {
             width, case.name, case.value, literal_side, e
         )
     });
-    check_equivalence::validate_same_fn(pir_fn, &output.gate_fn).unwrap_or_else(|e| {
-        panic!(
-            "equivalence proof failed for width={} case={} constant={} side={:?}: {}",
-            width, case.name, case.value, literal_side, e
-        )
-    });
+    check_equivalence::validate_same_fn_via_toolchain(pir_fn, &output.gate_fn).unwrap_or_else(
+        |e| {
+            panic!(
+                "equivalence proof failed for width={} case={} constant={} side={:?}: {}",
+                width, case.name, case.value, literal_side, e
+            )
+        },
+    );
 }
 
 #[test]

--- a/xlsynth-g8r/tests/prep_for_gatify_qor_equiv_test.rs
+++ b/xlsynth-g8r/tests/prep_for_gatify_qor_equiv_test.rs
@@ -17,7 +17,7 @@ fn parse_top_fn(ir_text: &str) -> ir::Fn {
 fn assert_ir_fns_equivalent(orig_fn: &ir::Fn, prepared_fn: &ir::Fn) {
     let orig_pkg_text = format!("package orig\n\ntop {}", orig_fn);
     let prepared_pkg_text = format!("package prepared\n\ntop {}", prepared_fn);
-    check_equivalence::check_equivalence(&orig_pkg_text, &prepared_pkg_text)
+    check_equivalence::check_equivalence_via_toolchain(&orig_pkg_text, &prepared_pkg_text)
         .expect("prepared PIR should be equivalent to original PIR");
 }
 
@@ -71,9 +71,9 @@ top fn shift_sel(data_hi: bits[9] id=1, data_lo: bits[3] id=2, pred: bits[1] id=
     let (gate_old, stats_old) = gatify_without_prep(&pir_fn);
     let (gate_new, stats_new) = gatify_without_prep(&prepared);
 
-    check_equivalence::prove_same_gate_fn_via_ir(&gate_old, &gate_new)
+    check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_old, &gate_new)
         .expect("old vs rewritten shift_sel lowerings should be equivalent");
-    check_equivalence::validate_same_fn(&pir_fn, &gate_new)
+    check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &gate_new)
         .expect("rewritten shift_sel lowering should match source PIR");
 
     assert_eq!(
@@ -121,9 +121,9 @@ top fn shift_priority(data_hi: bits[8] id=1, data_lo: bits[4] id=2, p0: bits[1] 
     let (gate_old, stats_old) = gatify_without_prep(&pir_fn);
     let (gate_new, stats_new) = gatify_without_prep(&prepared);
 
-    check_equivalence::prove_same_gate_fn_via_ir(&gate_old, &gate_new)
+    check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_old, &gate_new)
         .expect("old vs rewritten shift_priority lowerings should be equivalent");
-    check_equivalence::validate_same_fn(&pir_fn, &gate_new)
+    check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &gate_new)
         .expect("rewritten shift_priority lowering should match source PIR");
 
     assert_eq!(
@@ -172,9 +172,9 @@ top fn add_xor_and(a: bits[8] id=1, b: bits[8] id=2) -> bits[8] {
     let (gate_old, stats_old) = gatify_without_prep(&pir_fn);
     let (gate_new, stats_new) = gatify_without_prep(&prepared);
 
-    check_equivalence::prove_same_gate_fn_via_ir(&gate_old, &gate_new)
+    check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&gate_old, &gate_new)
         .expect("old vs rewritten add_xor_and lowerings should be equivalent");
-    check_equivalence::validate_same_fn(&pir_fn, &gate_new)
+    check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &gate_new)
         .expect("rewritten add_xor_and lowering should match source PIR");
 
     assert_eq!(

--- a/xlsynth-g8r/tests/range_specialization_tests.rs
+++ b/xlsynth-g8r/tests/range_specialization_tests.rs
@@ -57,7 +57,7 @@ top fn main(a0: bits[8] id=1, a1: bits[8] id=2, a2: bits[8] id=3, a3: bits[8] id
         },
     )
     .unwrap();
-    check_equivalence::validate_same_fn(&pir_fn, &spec.gate_fn).unwrap();
+    check_equivalence::validate_same_fn_via_toolchain(&pir_fn, &spec.gate_fn).unwrap();
     let spec_stats = get_summary_stats(&spec.gate_fn);
 
     assert_eq!(

--- a/xlsynth-g8r/tests/ripple_carry_qor_sweep_test.rs
+++ b/xlsynth-g8r/tests/ripple_carry_qor_sweep_test.rs
@@ -73,7 +73,7 @@ fn gather_ripple_carry_qor_rows() -> Vec<RippleCarryQorRow> {
     for bit_count in [1usize, 2, 3, 4, 5, 8, 16, 32, 64] {
         let old = make_ripple_carry_old(bit_count);
         let public = make_ripple_carry_public(bit_count);
-        check_equivalence::prove_same_gate_fn_via_ir(&old, &public)
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&old, &public)
             .expect("old and public ripple-carry lowerings should be equivalent");
         let old_stats = stats_for_gate_fn(&old);
         let public_stats = stats_for_gate_fn(&public);

--- a/xlsynth-g8r/tests/smul_gate_stats_sweep_test.rs
+++ b/xlsynth-g8r/tests/smul_gate_stats_sweep_test.rs
@@ -168,8 +168,11 @@ fn gather_smul_widening_rows() -> Vec<SmulWideningRow> {
 
         validate_smul_by_simulation(&native_signed, operand_width, output_width);
         if operand_width <= 3 {
-            check_equivalence::prove_same_gate_fn_via_ir(&sign_extend, &native_signed)
-                .expect("sign-extend and native signed multiply lowerings should be equivalent");
+            check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(
+                &sign_extend,
+                &native_signed,
+            )
+            .expect("sign-extend and native signed multiply lowerings should be equivalent");
         }
 
         let sign_extend_stats = stats_for_gate_fn(&sign_extend);

--- a/xlsynth-g8r/tests/test_adder_depths.rs
+++ b/xlsynth-g8r/tests/test_adder_depths.rs
@@ -101,9 +101,9 @@ fn adder_depths() {
         let bk = make_brent_kung(bits);
         let cs = make_carry_select(bits, &default_parts(bits));
 
-        check_equivalence::prove_same_gate_fn_via_ir(&ripple, &ks).unwrap();
-        check_equivalence::prove_same_gate_fn_via_ir(&ripple, &bk).unwrap();
-        check_equivalence::prove_same_gate_fn_via_ir(&ripple, &cs).unwrap();
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&ripple, &ks).unwrap();
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&ripple, &bk).unwrap();
+        check_equivalence::prove_same_gate_fn_via_ir_via_toolchain(&ripple, &cs).unwrap();
 
         let rd = depth(&ripple);
         let ksd = depth(&ks);

--- a/xlsynth-g8r/tests/test_adder_equivalence.rs
+++ b/xlsynth-g8r/tests/test_adder_equivalence.rs
@@ -37,6 +37,9 @@ top fn add_{n}_bits(a: bits[{n}] id=1, b: bits[{n}] id=2) -> bits[{n}] {{
             .unwrap();
     let gate_package_ir_text = gate_package.to_string();
 
-    let result = check_equivalence::check_equivalence(&orig_package_ir_text, &gate_package_ir_text);
+    let result = check_equivalence::check_equivalence_via_toolchain(
+        &orig_package_ir_text,
+        &gate_package_ir_text,
+    );
     assert!(result.is_ok(), "{}", result.unwrap_err());
 }

--- a/xlsynth-g8r/tests/test_gate_equiv_varisat.rs
+++ b/xlsynth-g8r/tests/test_gate_equiv_varisat.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use xlsynth_g8r::gate_builder::{GateBuilder, GateBuilderOptions};
-use xlsynth_g8r::prove_gate_fn_equiv_sat::{Ctx, EquivResult, prove_gate_fn_equiv};
+use xlsynth_g8r::prove_gate_fn_equiv_sat::{EquivResult, VarisatCtx, prove_gate_fn_equiv_varisat};
 
 #[test]
 fn test_simple_equivalence() {
@@ -12,8 +12,11 @@ fn test_simple_equivalence() {
     gb.add_output("out".to_string(), x.into());
     let g1 = gb.build();
 
-    let mut ctx = Ctx::new();
-    assert_eq!(prove_gate_fn_equiv(&g1, &g1, &mut ctx), EquivResult::Proved);
+    let mut ctx = VarisatCtx::new();
+    assert_eq!(
+        prove_gate_fn_equiv_varisat(&g1, &g1, &mut ctx),
+        EquivResult::Proved
+    );
 }
 
 #[test]
@@ -32,8 +35,8 @@ fn test_simple_inequivalence() {
     gb2.add_output("out".to_string(), y.into());
     let g2 = gb2.build();
 
-    let mut ctx = Ctx::new();
-    match prove_gate_fn_equiv(&g1, &g2, &mut ctx) {
+    let mut ctx = VarisatCtx::new();
+    match prove_gate_fn_equiv_varisat(&g1, &g2, &mut ctx) {
         EquivResult::Proved => panic!("Expected inequivalent"),
         EquivResult::Disproved(_) => (),
     }

--- a/xlsynth-mcmc-pir/fuzz/fuzz_targets/fuzz_pir_transform_arbitrary.rs
+++ b/xlsynth-mcmc-pir/fuzz/fuzz_targets/fuzz_pir_transform_arbitrary.rs
@@ -154,18 +154,14 @@ fn prove_candidate_equivalent(
 }
 
 fn make_in_process_prover() -> Box<dyn Prover> {
-    if cfg!(not(any(
-        feature = "has-bitwuzla",
-        feature = "has-boolector"
-    ))) {
+    if cfg!(not(feature = "has-bitwuzla")) {
         panic!(
-            "fuzz_pir_transform_arbitrary refuses SolverChoice::Auto when it \
-             would fall back to Toolchain; enable with-bitwuzla-system, \
-             with-bitwuzla-built, with-boolector-system, or with-boolector-built"
+            "fuzz_pir_transform_arbitrary requires in-process Bitwuzla; enable \
+             with-bitwuzla-system or with-bitwuzla-built"
         );
     }
     prover_for_choice_with_limits(
-        SolverChoice::Auto,
+        SolverChoice::Bitwuzla,
         None,
         SolverLimits::with_time_limit_per_ms(FUZZ_SOLVER_TIME_LIMIT_PER_MS),
     )

--- a/xlsynth-pir/fuzz/Cargo.toml
+++ b/xlsynth-pir/fuzz/Cargo.toml
@@ -20,6 +20,7 @@ pretty_assertions = "1.4.1"
 # Local crates
 xlsynth-pir = { path = ".." }
 xlsynth = { path = "../../xlsynth" }
+xlsynth-prover = { path = "../../xlsynth-prover" }
 tempfile = "3"
 
 # Fuzz targets

--- a/xlsynth-pir/fuzz/fuzz_targets/fuzz_ir_fn_to_dslx_roundtrip_equiv.rs
+++ b/xlsynth-pir/fuzz/fuzz_targets/fuzz_ir_fn_to_dslx_roundtrip_equiv.rs
@@ -7,10 +7,9 @@ use std::path::Path;
 use std::sync::Once;
 use xlsynth::DslxConvertOptions;
 use xlsynth_pir::ir_fn_to_dslx::IrFnToDslxError;
-use xlsynth_pir::prove_equiv_via_toolchain::{
-    prove_ir_pkg_equiv_with_tool_dir, ToolchainEquivResult,
-};
 use xlsynth_pir_fuzz::generate_standard_random_pir_package;
+use xlsynth_prover::prover::types::EquivResult;
+use xlsynth_prover::prover::{SolverChoice, prover_for_choice};
 
 static INIT_LOGGER: Once = Once::new();
 
@@ -68,13 +67,20 @@ fuzz_target!(|data: &[u8]| {
         .expect("set top on roundtrip rhs package");
     let rhs_ir_with_top = rhs_pkg_with_top.to_string();
 
-    let tools_dir = std::env::var("XLSYNTH_TOOLS").expect("XLSYNTH_TOOLS must be set");
-    match prove_ir_pkg_equiv_with_tool_dir(&lhs_ir_with_top, &rhs_ir_with_top, None, tools_dir) {
-        ToolchainEquivResult::Proved => {}
-        ToolchainEquivResult::Disproved(msg) => panic!(
+    match prover_for_choice(SolverChoice::Toolchain, None).prove_ir_pkg_text_equiv(
+        &lhs_ir_with_top,
+        &rhs_ir_with_top,
+        None,
+    ) {
+        EquivResult::Proved => {}
+        EquivResult::ToolchainDisproved(msg) => panic!(
             "IR equivalence disproved: {}\n=== INPUT_IR ===\n{}\n=== DSLX ===\n{}\n=== ROUNDTRIP_IR ===\n{}",
             msg, lhs_ir_with_top, translated.dslx_text, rhs_ir_with_top
         ),
-        ToolchainEquivResult::Error(msg) => panic!("IR equivalence tooling error: {}", msg),
+        // Early-return rationale: interruption or timeout of the external oracle
+        // is not a translation-soundness failure for this sample.
+        EquivResult::Inconclusive(_) => return,
+        EquivResult::Error(msg) => panic!("IR equivalence tooling error: {}", msg),
+        other => panic!("unexpected toolchain equivalence result: {other:?}"),
     }
 });

--- a/xlsynth-pir/src/prove_equiv_via_toolchain.rs
+++ b/xlsynth-pir/src/prove_equiv_via_toolchain.rs
@@ -7,7 +7,17 @@
 //! assumed that the $XLSYNTH_TOOLS are available for use in testing generally
 //! throughout the xlsynth-crate codebase.
 
+use std::io::{Read, Seek, SeekFrom};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
 use crate::ir::Fn;
+
+/// Environment variable overriding the XLS checker watchdog in milliseconds.
+pub const TOOLCHAIN_EQUIV_TIMEOUT_MS_ENV: &str = "XLSYNTH_TOOLCHAIN_EQUIV_TIMEOUT_MS";
+
+/// Default watchdog for explicit XLS checker invocations.
+pub const DEFAULT_TOOLCHAIN_EQUIV_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum ToolchainEquivResult {
@@ -27,6 +37,23 @@ pub fn prove_ir_pkg_equiv_with_tool_exe<P: AsRef<std::path::Path>>(
     rhs_pkg_text: &str,
     top: Option<&str>,
     tool_exe: P,
+) -> ToolchainEquivResult {
+    prove_ir_pkg_equiv_with_tool_exe_and_timeout(
+        lhs_pkg_text,
+        rhs_pkg_text,
+        top,
+        tool_exe,
+        configured_toolchain_equiv_timeout(),
+    )
+}
+
+/// Proves equivalence with an explicit watchdog timeout.
+pub fn prove_ir_pkg_equiv_with_tool_exe_and_timeout<P: AsRef<std::path::Path>>(
+    lhs_pkg_text: &str,
+    rhs_pkg_text: &str,
+    top: Option<&str>,
+    tool_exe: P,
+    timeout: Duration,
 ) -> ToolchainEquivResult {
     let exe = tool_exe.as_ref();
     if !exe.exists() {
@@ -48,34 +75,85 @@ pub fn prove_ir_pkg_equiv_with_tool_exe<P: AsRef<std::path::Path>>(
         cmd.arg("--top");
         cmd.arg(t);
     }
-    match cmd.output() {
-        Ok(output) if output.status.success() => ToolchainEquivResult::Proved,
-        Ok(output) => {
-            // Include stderr snippet to aid debugging, but do not print directly.
-            let mut msg = format!("tool exited with status {}", output.status);
-            if !output.stdout.is_empty() {
-                let stdout_str = String::from_utf8_lossy(&output.stdout);
-                msg.push_str(": ");
-                msg.push_str(&stdout_str);
+    let mut stdout_file = tempfile::tempfile().unwrap();
+    let mut stderr_file = tempfile::tempfile().unwrap();
+    cmd.stdout(Stdio::from(stdout_file.try_clone().unwrap()));
+    cmd.stderr(Stdio::from(stderr_file.try_clone().unwrap()));
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => return ToolchainEquivResult::Error(format!("spawn failed: {}", e)),
+    };
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let stdout = read_spooled_output(&mut stdout_file);
+                let stderr = read_spooled_output(&mut stderr_file);
+                return classify_tool_output(status, &stdout, &stderr);
             }
-            if !output.stderr.is_empty() {
-                let stderr_str = String::from_utf8_lossy(&output.stderr);
-                // Truncate to a reasonable length to avoid huge error strings.
-                let snippet: String = stderr_str.chars().take(512).collect();
-                msg.push_str(": ");
-                msg.push_str(&snippet);
+            Ok(None) if start.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return ToolchainEquivResult::TimedOutOrInterrupted(format!(
+                    "tool timed out after {} ms",
+                    timeout.as_millis()
+                ));
             }
-            let lowered = msg.to_ascii_lowercase();
-            if lowered.contains("deadline_exceeded")
-                || lowered.contains("sigint")
-                || lowered.contains("interrupted")
-            {
-                ToolchainEquivResult::TimedOutOrInterrupted(msg)
-            } else {
-                ToolchainEquivResult::Disproved(msg)
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return ToolchainEquivResult::Error(format!("wait failed: {}", e));
             }
         }
-        Err(e) => ToolchainEquivResult::Error(format!("spawn failed: {}", e)),
+    }
+}
+
+fn configured_toolchain_equiv_timeout() -> Duration {
+    std::env::var(TOOLCHAIN_EQUIV_TIMEOUT_MS_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_TOOLCHAIN_EQUIV_TIMEOUT)
+}
+
+fn read_spooled_output(file: &mut std::fs::File) -> Vec<u8> {
+    file.seek(SeekFrom::Start(0)).unwrap();
+    let mut output = Vec::new();
+    file.read_to_end(&mut output).unwrap();
+    output
+}
+
+fn classify_tool_output(
+    status: std::process::ExitStatus,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> ToolchainEquivResult {
+    if status.success() {
+        return ToolchainEquivResult::Proved;
+    }
+    // Include stderr snippet to aid debugging, but do not print directly.
+    let mut msg = format!("tool exited with status {}", status);
+    if !stdout.is_empty() {
+        let stdout_str = String::from_utf8_lossy(stdout);
+        msg.push_str(": ");
+        msg.push_str(&stdout_str);
+    }
+    if !stderr.is_empty() {
+        let stderr_str = String::from_utf8_lossy(stderr);
+        // Truncate to a reasonable length to avoid huge error strings.
+        let snippet: String = stderr_str.chars().take(512).collect();
+        msg.push_str(": ");
+        msg.push_str(&snippet);
+    }
+    let lowered = msg.to_ascii_lowercase();
+    if lowered.contains("deadline_exceeded")
+        || lowered.contains("sigint")
+        || lowered.contains("interrupted")
+    {
+        ToolchainEquivResult::TimedOutOrInterrupted(msg)
+    } else {
+        ToolchainEquivResult::Disproved(msg)
     }
 }
 
@@ -128,4 +206,34 @@ pub fn prove_ir_fn_strings_equiv_via_toolchain(lhs: &str, rhs: &str) -> Toolchai
 /// Convenience wrapper: reads `XLSYNTH_TOOLS` env var to locate the toolchain.
 pub fn prove_ir_fn_equiv_via_toolchain(lhs: &Fn, rhs: &Fn) -> ToolchainEquivResult {
     prove_ir_fn_strings_equiv_via_toolchain(&lhs.to_string(), &rhs.to_string())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    #[test]
+    fn toolchain_checker_watchdog_interrupts_slow_process() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("slow-checker");
+        std::fs::write(&exe, "#!/bin/sh\nexec sleep 10\n").unwrap();
+        let mut permissions = std::fs::metadata(&exe).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&exe, permissions).unwrap();
+
+        let result = prove_ir_pkg_equiv_with_tool_exe_and_timeout(
+            "package lhs\n",
+            "package rhs\n",
+            None,
+            exe,
+            Duration::from_millis(10),
+        );
+        assert!(matches!(
+            result,
+            ToolchainEquivResult::TimedOutOrInterrupted(msg)
+                if msg.contains("tool timed out after 10 ms")
+        ));
+    }
 }

--- a/xlsynth-pir/src/prove_equiv_via_toolchain.rs
+++ b/xlsynth-pir/src/prove_equiv_via_toolchain.rs
@@ -13,6 +13,7 @@ use crate::ir::Fn;
 pub enum ToolchainEquivResult {
     Proved,
     Disproved(String),
+    TimedOutOrInterrupted(String),
     Error(String),
 }
 
@@ -64,7 +65,15 @@ pub fn prove_ir_pkg_equiv_with_tool_exe<P: AsRef<std::path::Path>>(
                 msg.push_str(": ");
                 msg.push_str(&snippet);
             }
-            ToolchainEquivResult::Disproved(msg)
+            let lowered = msg.to_ascii_lowercase();
+            if lowered.contains("deadline_exceeded")
+                || lowered.contains("sigint")
+                || lowered.contains("interrupted")
+            {
+                ToolchainEquivResult::TimedOutOrInterrupted(msg)
+            } else {
+                ToolchainEquivResult::Disproved(msg)
+            }
         }
         Err(e) => ToolchainEquivResult::Error(format!("spawn failed: {}", e)),
     }

--- a/xlsynth-prover/src/dslx_assertions.rs
+++ b/xlsynth-prover/src/dslx_assertions.rs
@@ -12,11 +12,6 @@ use xlsynth_pir::ir::{self, Node, NodePayload, NodeRef, PackageMember, ParamId, 
 use xlsynth_pir::ir_parser::Parser;
 use xlsynth_pir::ir_utils::next_text_id;
 
-#[cfg(any(
-    feature = "has-bitwuzla",
-    feature = "has-boolector",
-    feature = "has-easy-smt"
-))]
 use crate::prover::prover_for_choice;
 use crate::prover::types::{
     BoolPropertyResult, ParamDomains, ProverFn, QuickCheckAssertionSemantics,
@@ -161,99 +156,11 @@ fn clone_param_with_new_id(param: &ir::Param, id: usize) -> ir::Param {
     }
 }
 
-#[cfg(feature = "has-bitwuzla")]
-fn auto_prover_for_assertions() -> Result<Box<dyn Prover>, String> {
-    use crate::solver::bitwuzla::BitwuzlaOptions;
-    Ok(Box::new(BitwuzlaOptions::new()))
-}
-
-#[cfg(all(feature = "has-boolector", not(feature = "has-bitwuzla")))]
-fn auto_prover_for_assertions() -> Result<Box<dyn Prover>, String> {
-    use crate::solver::boolector::BoolectorConfig;
-    Ok(Box::new(BoolectorConfig::new()))
-}
-
-#[cfg(all(
-    feature = "has-easy-smt",
-    not(feature = "has-bitwuzla"),
-    not(feature = "has-boolector")
-))]
-fn auto_prover_for_assertions() -> Result<Box<dyn Prover>, String> {
-    use crate::solver::{
-        Response, Solver,
-        easy_smt::{EasySmtConfig, EasySmtSolver},
-    };
-
-    fn is_usable(config: &EasySmtConfig) -> bool {
-        match EasySmtSolver::new(config) {
-            Ok(mut solver) => {
-                if solver.declare("probe_x", 1).is_err() {
-                    return false;
-                }
-                let one = solver.one(1);
-                let numerical_one = solver.numerical(1, 1);
-                let eq = solver.eq(&one, &numerical_one);
-                if solver.assert(&eq).is_err() {
-                    return false;
-                }
-                matches!(solver.check(), Ok(Response::Sat))
-            }
-            Err(_) => false,
-        }
-    }
-
-    for cfg in [
-        EasySmtConfig::z3(),
-        EasySmtConfig::boolector(),
-        EasySmtConfig::bitwuzla(),
-    ] {
-        if is_usable(&cfg) {
-            return Ok(Box::new(cfg));
-        }
-    }
-
-    missing_in_process_prover_error()
-}
-
-#[cfg(not(any(
-    feature = "has-bitwuzla",
-    feature = "has-boolector",
-    feature = "has-easy-smt"
-)))]
-fn auto_prover_for_assertions() -> Result<Box<dyn Prover>, String> {
-    missing_in_process_prover_error()
-}
-
-#[cfg(any(
-    all(
-        feature = "has-easy-smt",
-        not(feature = "has-bitwuzla"),
-        not(feature = "has-boolector")
-    ),
-    not(any(
-        feature = "has-bitwuzla",
-        feature = "has-boolector",
-        feature = "has-easy-smt"
-    ))
-))]
-fn missing_in_process_prover_error<T>() -> Result<T, String> {
-    Err(
-        "No supported in-process SMT backend is available for dslx-fn-prove-assertions; rebuild with an in-process solver feature or pass an explicit supported --solver"
-            .to_string(),
-    )
-}
-
 fn prover_for_assertions(choice: SolverChoice) -> Result<Box<dyn Prover>, String> {
     match choice {
-        SolverChoice::Auto => auto_prover_for_assertions(),
         SolverChoice::Toolchain => {
             Err("Solver 'toolchain' is not supported for dslx-fn-prove-assertions".to_string())
         }
-        #[cfg(any(
-            feature = "has-bitwuzla",
-            feature = "has-boolector",
-            feature = "has-easy-smt"
-        ))]
         other => Ok(prover_for_choice(other, None)),
     }
 }
@@ -409,7 +316,7 @@ pub fn run_dslx_assertions(
         .with_domains(top_domains)
         .with_uf_map(request.uf_map.clone());
 
-    let prover = prover_for_assertions(request.solver.unwrap_or(SolverChoice::Auto))?;
+    let prover = prover_for_assertions(request.solver.unwrap_or(SolverChoice::Bitwuzla))?;
     let start = Instant::now();
     let result = prover.prove_ir_quickcheck(
         &prover_fn,

--- a/xlsynth-prover/src/dslx_equiv.rs
+++ b/xlsynth-prover/src/dslx_equiv.rs
@@ -261,7 +261,7 @@ pub fn run_dslx_equiv(request: &DslxEquivRequest<'_>) -> Result<EquivReport, Str
     .map_err(|err| map_prepare_error(err, request.rhs.path))?;
 
     let prover = prover_for_choice(
-        request.solver.unwrap_or(SolverChoice::Auto),
+        request.solver.unwrap_or(SolverChoice::Bitwuzla),
         request.options.tool_path,
     );
     let assert_label_filter = request.assert_label_filter;
@@ -518,7 +518,7 @@ mod tests {
         let request = DslxEquivRequest::new(lhs_module, rhs_module)
             .with_drop_params(&drop_params)
             .with_parallelism(EquivParallelism::SingleThreaded)
-            .with_solver(Some(SolverChoice::Auto))
+            .with_solver(Some(SolverChoice::Bitwuzla))
             .with_assume_enum_in_bound(true)
             .with_optimize(true);
 

--- a/xlsynth-prover/src/ir_equiv.rs
+++ b/xlsynth-prover/src/ir_equiv.rs
@@ -149,7 +149,7 @@ impl<'a> IrEquivRequest<'a> {
 
 /// Dispatches an IR equivalence comparison using the requested solver.
 pub fn run_ir_equiv(request: &IrEquivRequest<'_>) -> Result<EquivReport, String> {
-    let choice = request.solver.unwrap_or(SolverChoice::Auto);
+    let choice = request.solver.unwrap_or(SolverChoice::Bitwuzla);
     let prover = prover_for_choice_with_limits(choice, request.tool_path, request.solver_limits);
     let (lhs_pkg, lhs_fn_dropped) = ir_utils::parse_package_and_drop_params(
         request.lhs.source,

--- a/xlsynth-prover/src/prover/external_prover.rs
+++ b/xlsynth-prover/src/prover/external_prover.rs
@@ -42,6 +42,23 @@ fn resolve_tool_path(prover: &ExternalProver, exe_name: &str) -> Result<PathBuf,
 }
 
 impl Prover for ExternalProver {
+    fn prove_ir_fn_equiv(
+        self: &Self,
+        lhs: &xlsynth_pir::ir::Fn,
+        rhs: &xlsynth_pir::ir::Fn,
+    ) -> EquivResult {
+        let lhs = ProverFn::new(lhs, None);
+        let rhs = ProverFn::new(rhs, None);
+        self.prove_ir_equiv(
+            &lhs,
+            &rhs,
+            EquivParallelism::SingleThreaded,
+            AssertionSemantics::Ignore,
+            None,
+            false,
+        )
+    }
+
     fn prove_ir_pkg_text_equiv(
         self: &Self,
         lhs_pkg_text: &str,
@@ -279,6 +296,7 @@ impl From<ToolchainEquivResult> for EquivResult {
         match result {
             ToolchainEquivResult::Proved => EquivResult::Proved,
             ToolchainEquivResult::Disproved(msg) => EquivResult::ToolchainDisproved(msg),
+            ToolchainEquivResult::TimedOutOrInterrupted(msg) => EquivResult::Inconclusive(msg),
             ToolchainEquivResult::Error(msg) => EquivResult::Error(msg),
         }
     }
@@ -300,4 +318,30 @@ fn unify_toolchain_tops<'a>(
     let unified = lhs_top.to_string();
     let rhs_rewritten = rhs_ir.replace(rhs_top, &unified);
     (Cow::Borrowed(lhs_ir), Cow::Owned(rhs_rewritten), unified)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xlsynth_pir::ir_parser::Parser;
+
+    #[test]
+    fn fn_equiv_convenience_uses_supported_assertion_semantics() {
+        let ir = r#"package test
+
+fn f(x: bits[1] id=1) -> bits[1] {
+  ret identity.2: bits[1] = identity(x, id=2)
+}
+"#;
+        let pkg = Parser::new(ir).parse_and_validate_package().unwrap();
+        let f = pkg.get_fn("f").unwrap();
+        let tool_dir = tempfile::tempdir().unwrap();
+        let prover = ExternalProver::ToolDir(tool_dir.path().to_path_buf());
+
+        let result = prover.prove_ir_fn_equiv(f, f);
+        assert!(matches!(
+            result,
+            EquivResult::Error(msg) if msg.contains("check_ir_equivalence_main not found")
+        ));
+    }
 }

--- a/xlsynth-prover/src/prover/mod.rs
+++ b/xlsynth-prover/src/prover/mod.rs
@@ -48,9 +48,6 @@ impl SolverLimits {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum SolverChoice {
-    /// Let the library select an appropriate prover based on available
-    /// features.
-    Auto,
     #[cfg(feature = "has-easy-smt")]
     Z3Binary,
     #[cfg(feature = "has-easy-smt")]
@@ -58,7 +55,9 @@ pub enum SolverChoice {
     #[cfg(feature = "has-easy-smt")]
     BoolectorBinary,
 
-    #[cfg(feature = "has-bitwuzla")]
+    /// Use the preferred in-process Bitwuzla backend.
+    ///
+    /// This intentionally does not fall back to slower solvers or XLS tools.
     Bitwuzla,
 
     #[cfg(feature = "has-boolector")]
@@ -72,14 +71,12 @@ pub enum SolverChoice {
 impl fmt::Display for SolverChoice {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
-            SolverChoice::Auto => "auto",
             #[cfg(feature = "has-easy-smt")]
             SolverChoice::Z3Binary => "z3-binary",
             #[cfg(feature = "has-easy-smt")]
             SolverChoice::BitwuzlaBinary => "bitwuzla-binary",
             #[cfg(feature = "has-easy-smt")]
             SolverChoice::BoolectorBinary => "boolector-binary",
-            #[cfg(feature = "has-bitwuzla")]
             SolverChoice::Bitwuzla => "bitwuzla",
             #[cfg(feature = "has-boolector")]
             SolverChoice::Boolector => "boolector",
@@ -93,7 +90,6 @@ impl FromStr for SolverChoice {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "auto" => Ok(Self::Auto),
             #[cfg(feature = "has-easy-smt")]
             "z3-binary" => Ok(Self::Z3Binary),
             #[cfg(feature = "has-easy-smt")]
@@ -101,7 +97,6 @@ impl FromStr for SolverChoice {
             #[cfg(feature = "has-easy-smt")]
             "boolector-binary" => Ok(Self::BoolectorBinary),
 
-            #[cfg(feature = "has-bitwuzla")]
             "bitwuzla" => Ok(Self::Bitwuzla),
 
             #[cfg(feature = "has-boolector")]
@@ -165,6 +160,73 @@ pub trait Prover {
         assert_label_filter: Option<&str>,
         uf_map: &HashMap<String, String>,
     ) -> Vec<QuickCheckRunResult>;
+}
+
+#[cfg(not(feature = "has-bitwuzla"))]
+struct UnavailableProver {
+    message: String,
+}
+
+#[cfg(not(feature = "has-bitwuzla"))]
+impl UnavailableProver {
+    fn for_bitwuzla_selection() -> Self {
+        Self {
+            message: "--solver=bitwuzla requires in-process Bitwuzla support; rebuild with \
+                      --features with-bitwuzla-system or --features with-bitwuzla-built, or select \
+                      an alternate solver explicitly"
+                .to_string(),
+        }
+    }
+}
+
+#[cfg(not(feature = "has-bitwuzla"))]
+impl Prover for UnavailableProver {
+    fn prove_ir_pkg_text_equiv(
+        self: &Self,
+        _lhs_pkg_text: &str,
+        _rhs_pkg_text: &str,
+        _top: Option<&str>,
+    ) -> EquivResult {
+        EquivResult::Error(self.message.clone())
+    }
+
+    fn prove_ir_equiv<'a>(
+        self: &Self,
+        _lhs: &ProverFn<'a>,
+        _rhs: &ProverFn<'a>,
+        _strategy: EquivParallelism,
+        _assertion_semantics: AssertionSemantics,
+        _assert_label_filter: Option<&str>,
+        _allow_flatten: bool,
+    ) -> EquivResult {
+        EquivResult::Error(self.message.clone())
+    }
+
+    fn prove_ir_quickcheck<'a>(
+        self: &Self,
+        _prover_fn: &ProverFn<'a>,
+        _assertion_semantics: QuickCheckAssertionSemantics,
+        _assert_label_filter: Option<&str>,
+    ) -> BoolPropertyResult {
+        BoolPropertyResult::Error(self.message.clone())
+    }
+
+    fn prove_dslx_quickcheck(
+        &self,
+        _entry_file: &std::path::Path,
+        _dslx_stdlib_path: Option<&std::path::Path>,
+        _additional_search_paths: &[&std::path::Path],
+        _test_filter: Option<&str>,
+        _assertion_semantics: QuickCheckAssertionSemantics,
+        _assert_label_filter: Option<&str>,
+        _uf_map: &HashMap<String, String>,
+    ) -> Vec<QuickCheckRunResult> {
+        vec![QuickCheckRunResult {
+            name: "solver-selection".to_string(),
+            duration: std::time::Duration::ZERO,
+            result: BoolPropertyResult::Error(self.message.clone()),
+        }]
+    }
 }
 
 impl<S: SolverConfig> Prover for S {
@@ -302,77 +364,17 @@ impl<S: SolverConfig> Prover for S {
     }
 }
 
-pub fn auto_selected_prover() -> Box<dyn Prover> {
-    auto_selected_prover_with_limits(SolverLimits::default())
+pub fn default_prover() -> Box<dyn Prover> {
+    default_prover_with_limits(SolverLimits::default())
 }
 
-/// Selects an appropriate prover and applies backend-supported resource limits.
-pub fn auto_selected_prover_with_limits(limits: SolverLimits) -> Box<dyn Prover> {
-    #[cfg(not(feature = "has-bitwuzla"))]
-    let _ = limits;
-    #[cfg(feature = "has-bitwuzla")]
-    {
-        use crate::solver::bitwuzla::BitwuzlaOptions;
-        let mut options = BitwuzlaOptions::new();
-        apply_bitwuzla_limits(&mut options, limits);
-        return Box::new(options);
-    }
-    #[cfg(all(feature = "has-boolector", not(feature = "has-bitwuzla")))]
-    {
-        use crate::solver::boolector::BoolectorConfig;
-        return Box::new(BoolectorConfig::new());
-    }
-    #[cfg(all(
-        feature = "has-easy-smt",
-        not(feature = "has-bitwuzla"),
-        not(feature = "has-boolector")
-    ))]
-    {
-        use crate::solver::{
-            Response, Solver,
-            easy_smt::{EasySmtConfig, EasySmtSolver},
-        };
-
-        fn is_usable(config: &EasySmtConfig) -> bool {
-            match EasySmtSolver::new(config) {
-                Ok(mut solver) => {
-                    // Minimal sanity: declare a symbol, assert a trivial constraint, check SAT.
-                    if solver.declare("probe_x", 1).is_err() {
-                        return false;
-                    }
-                    let one = solver.one(1);
-                    let a = solver.numerical(1, 1);
-                    let eq = solver.eq(&one, &a);
-                    if solver.assert(&eq).is_err() {
-                        return false;
-                    }
-                    match solver.check() {
-                        Ok(Response::Sat) => true,
-                        _ => false,
-                    }
-                }
-                Err(_) => false,
-            }
-        }
-
-        let candidates = [
-            EasySmtConfig::z3(),
-            EasySmtConfig::boolector(),
-            EasySmtConfig::bitwuzla(),
-        ];
-
-        for cfg in candidates.into_iter() {
-            if is_usable(&cfg) {
-                return Box::new(cfg);
-            }
-        }
-    }
-    #[cfg(all(not(feature = "has-bitwuzla"), not(feature = "has-boolector")))]
-    Box::new(ExternalProver::Toolchain)
+/// Creates the preferred Bitwuzla prover and applies supported resource limits.
+pub fn default_prover_with_limits(limits: SolverLimits) -> Box<dyn Prover> {
+    prover_for_choice_with_limits(SolverChoice::Bitwuzla, None, limits)
 }
 
 pub fn prove_ir_fn_equiv(lhs: &ir::Fn, rhs: &ir::Fn) -> EquivResult {
-    auto_selected_prover().prove_ir_fn_equiv(lhs, rhs)
+    default_prover().prove_ir_fn_equiv(lhs, rhs)
 }
 
 pub fn prove_ir_pkg_text_equiv(
@@ -380,7 +382,7 @@ pub fn prove_ir_pkg_text_equiv(
     rhs_pkg_text: &str,
     top: Option<&str>,
 ) -> EquivResult {
-    auto_selected_prover().prove_ir_pkg_text_equiv(lhs_pkg_text, rhs_pkg_text, top)
+    default_prover().prove_ir_pkg_text_equiv(lhs_pkg_text, rhs_pkg_text, top)
 }
 
 pub fn prove_ir_equiv<'a>(
@@ -391,7 +393,7 @@ pub fn prove_ir_equiv<'a>(
     assert_label_filter: Option<&str>,
     allow_flatten: bool,
 ) -> EquivResult {
-    auto_selected_prover().prove_ir_equiv(
+    default_prover().prove_ir_equiv(
         lhs,
         rhs,
         strategy,
@@ -402,7 +404,7 @@ pub fn prove_ir_equiv<'a>(
 }
 
 pub fn prove_ir_fn_quickcheck(ir_fn: &ProverFn<'_>) -> BoolPropertyResult {
-    auto_selected_prover().prove_ir_fn_quickcheck(ir_fn)
+    default_prover().prove_ir_fn_quickcheck(ir_fn)
 }
 
 pub fn prove_ir_quickcheck(
@@ -410,7 +412,7 @@ pub fn prove_ir_quickcheck(
     assertion_semantics: QuickCheckAssertionSemantics,
     assert_label_filter: Option<&str>,
 ) -> BoolPropertyResult {
-    auto_selected_prover().prove_ir_quickcheck(prover_fn, assertion_semantics, assert_label_filter)
+    default_prover().prove_ir_quickcheck(prover_fn, assertion_semantics, assert_label_filter)
 }
 
 pub fn prove_dslx_quickcheck(
@@ -422,7 +424,7 @@ pub fn prove_dslx_quickcheck(
     assert_label_filter: Option<&str>,
     uf_map: &HashMap<String, String>,
 ) -> Vec<QuickCheckRunResult> {
-    auto_selected_prover().prove_dslx_quickcheck(
+    default_prover().prove_dslx_quickcheck(
         entry_file,
         dslx_stdlib_path,
         additional_search_paths,
@@ -444,12 +446,18 @@ pub fn prover_for_choice_with_limits(
     limits: SolverLimits,
 ) -> Box<dyn Prover> {
     match choice {
-        SolverChoice::Auto => auto_selected_prover_with_limits(limits),
-        #[cfg(feature = "has-bitwuzla")]
         SolverChoice::Bitwuzla => {
-            let mut options = crate::solver::bitwuzla::BitwuzlaOptions::new();
-            apply_bitwuzla_limits(&mut options, limits);
-            Box::new(options)
+            #[cfg(feature = "has-bitwuzla")]
+            {
+                let mut options = crate::solver::bitwuzla::BitwuzlaOptions::new();
+                apply_bitwuzla_limits(&mut options, limits);
+                Box::new(options)
+            }
+            #[cfg(not(feature = "has-bitwuzla"))]
+            {
+                let _ = limits;
+                Box::new(UnavailableProver::for_bitwuzla_selection())
+            }
         }
         #[cfg(feature = "has-boolector")]
         SolverChoice::Boolector => Box::new(crate::solver::boolector::BoolectorConfig::new()),
@@ -487,5 +495,29 @@ fn apply_bitwuzla_limits(
     }
     if let Some(memory_limit_mb) = limits.memory_limit_mb {
         options.set_memory_limit(memory_limit_mb);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bitwuzla_choice_roundtrips_through_cli_spelling() {
+        assert_eq!(SolverChoice::Bitwuzla.to_string(), "bitwuzla");
+        assert_eq!(
+            "bitwuzla".parse::<SolverChoice>().unwrap(),
+            SolverChoice::Bitwuzla
+        );
+    }
+
+    #[cfg(not(feature = "has-bitwuzla"))]
+    #[test]
+    fn default_prover_reports_missing_bitwuzla_feature() {
+        let result = default_prover().prove_ir_pkg_text_equiv("", "", None);
+        assert!(matches!(
+            result,
+            EquivResult::Error(msg) if msg.contains("--solver=bitwuzla requires")
+        ));
     }
 }

--- a/xlsynth-prover/src/prover/mod.rs
+++ b/xlsynth-prover/src/prover/mod.rs
@@ -450,6 +450,7 @@ pub fn prover_for_choice_with_limits(
             #[cfg(feature = "has-bitwuzla")]
             {
                 let mut options = crate::solver::bitwuzla::BitwuzlaOptions::new();
+                options.set_sat_solver(crate::solver::bitwuzla::BitwuzlaSatSolver::CaDiCaL);
                 apply_bitwuzla_limits(&mut options, limits);
                 Box::new(options)
             }

--- a/xlsynth-prover/tests/ext_carry_out_desugar_equiv.rs
+++ b/xlsynth-prover/tests/ext_carry_out_desugar_equiv.rs
@@ -53,22 +53,6 @@ fn ext_carry_out_equivalent_to_desugared_export_form_and_exports_to_upstream() {
         );
         match res {
             EquivResult::Proved => {}
-            EquivResult::ToolchainDisproved(msg)
-                if msg.contains("Unknown operation")
-                    && msg.contains("ext_carry_out")
-                    && msg.contains("string-to-op conversion") =>
-            {
-                // Not a sample failure: when no SMT backend is enabled,
-                // `xlsynth-prover` falls back to the external XLS toolchain
-                // prover, and upstream XLS does not understand PIR extension ops
-                // like `ext_carry_out`.
-                //
-                // This test provides strong coverage when an SMT backend is
-                // available; in toolchain-only configurations we rely on
-                // `xlsynth-pir`'s interpreter/roundtrip tests for extension-op
-                // semantics.
-                return;
-            }
             _ => panic!("formal equivalence failed at w={}: {:?}", w, res),
         }
     }

--- a/xlsynth-prover/tests/ext_clz_desugar_equiv.rs
+++ b/xlsynth-prover/tests/ext_clz_desugar_equiv.rs
@@ -48,17 +48,6 @@ fn ext_clz_equivalent_to_desugared_export_form_and_exports_to_upstream() {
         );
         match res {
             EquivResult::Proved => {}
-            EquivResult::ToolchainDisproved(msg)
-                if msg.contains("Unknown operation")
-                    && msg.contains("ext_clz")
-                    && msg.contains("string-to-op conversion") =>
-            {
-                // Not a sample failure: when no SMT backend is enabled,
-                // `xlsynth-prover` falls back to the external XLS toolchain
-                // prover, and upstream XLS does not understand PIR extension ops
-                // like `ext_clz`.
-                return;
-            }
             _ => panic!("formal equivalence failed at w={}: {:?}", w, res),
         }
     }

--- a/xlsynth-prover/tests/ext_mask_low_desugar_equiv.rs
+++ b/xlsynth-prover/tests/ext_mask_low_desugar_equiv.rs
@@ -64,17 +64,6 @@ fn ext_mask_low_equivalent_to_desugared_export_form_and_exports_to_upstream() {
         );
         match res {
             EquivResult::Proved => {}
-            EquivResult::ToolchainDisproved(msg)
-                if msg.contains("Unknown operation")
-                    && msg.contains("ext_mask_low")
-                    && msg.contains("string-to-op conversion") =>
-            {
-                // Not a sample failure: when no SMT backend is enabled,
-                // `xlsynth-prover` falls back to the external XLS toolchain
-                // prover, and upstream XLS does not understand PIR extension ops
-                // like `ext_mask_low`.
-                return;
-            }
             _ => panic!(
                 "formal equivalence failed at output_width={} count_width={}: {:?}",
                 output_width, count_width, res

--- a/xlsynth-prover/tests/ext_nary_add_desugar_equiv.rs
+++ b/xlsynth-prover/tests/ext_nary_add_desugar_equiv.rs
@@ -49,13 +49,6 @@ fn f(a: bits[3] id=1, b: bits[5] id=2, c: bits[9] id=3) -> bits[6] {
     );
     match res {
         EquivResult::Proved => {}
-        EquivResult::ToolchainDisproved(msg)
-            if msg.contains("Unknown operation")
-                && msg.contains("ext_nary_add")
-                && msg.contains("string-to-op conversion") =>
-        {
-            return;
-        }
         _ => panic!("formal equivalence failed: {:?}", res),
     }
 }

--- a/xlsynth-prover/tests/ext_normalize_left_desugar_equiv.rs
+++ b/xlsynth-prover/tests/ext_normalize_left_desugar_equiv.rs
@@ -62,13 +62,6 @@ fn ext_normalize_left_equivalent_to_desugared_export_form_and_exports_to_upstrea
         );
         match res {
             EquivResult::Proved => {}
-            EquivResult::ToolchainDisproved(msg)
-                if msg.contains("Unknown operation")
-                    && msg.contains("ext_normalize_left")
-                    && msg.contains("string-to-op conversion") =>
-            {
-                return;
-            }
             _ => panic!(
                 "formal equivalence failed at input_width={} normalized_bit_count={} shift_offset={} clz_bit_count={:?}: {:?}",
                 input_width, normalized_bit_count, shift_offset, clz_bit_count, res

--- a/xlsynth-prover/tests/ext_prio_encode_desugar_equiv.rs
+++ b/xlsynth-prover/tests/ext_prio_encode_desugar_equiv.rs
@@ -49,13 +49,6 @@ fn ext_prio_encode_equivalent_to_desugared_export_form_and_exports_to_upstream()
             );
             match res {
                 EquivResult::Proved => {}
-                EquivResult::ToolchainDisproved(msg)
-                    if msg.contains("Unknown operation")
-                        && msg.contains("ext_prio_encode")
-                        && msg.contains("string-to-op conversion") =>
-                {
-                    return;
-                }
                 _ => panic!(
                     "formal equivalence failed at w={} lsb_prio={}: {:?}",
                     w, lsb_prio, res

--- a/xlsynth-sys/Cargo.toml
+++ b/xlsynth-sys/Cargo.toml
@@ -26,3 +26,4 @@ toml = "0.8"
 [dev-dependencies]
 syn = { version = "2", features = ["full"] }
 tempfile = "3.20"
+toml = "0.8"

--- a/xlsynth-sys/artifact_config.rs
+++ b/xlsynth-sys/artifact_config.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Resolved paths to the XLS artifacts supplied by the caller.
+pub struct ArtifactPaths {
+    pub dso_path: String,
+    pub dslx_stdlib_path: String,
+}
+
+/// Linker inputs derived from an explicit XLS DSO path.
+pub struct ExplicitDsoPath {
+    pub link_name: String,
+    pub path: PathBuf,
+    pub parent_dir: PathBuf,
+}
+
+/// Validates the optional `XLSYNTH_ARTIFACT_CONFIG` environment value.
+pub fn parse_artifact_config_env_path(
+    config_path: Option<OsString>,
+) -> Result<Option<PathBuf>, String> {
+    let Some(config_path) = config_path else {
+        return Ok(None);
+    };
+    let config_path = PathBuf::from(config_path);
+    if config_path.is_absolute() {
+        Ok(Some(config_path))
+    } else {
+        Err(format!(
+            concat!(
+                "XLSYNTH_ARTIFACT_CONFIG must be an absolute path; got relative path: {}.\n",
+                "The dso_path and dslx_stdlib_path values inside that TOML may still be relative ",
+                "to the TOML file's directory."
+            ),
+            config_path.display()
+        ))
+    }
+}
+
+/// Loads and resolves artifact paths relative to an artifact-config TOML file.
+pub fn load_artifact_paths_from_config_path(config_path: &Path) -> Result<ArtifactPaths, String> {
+    let config_contents = std::fs::read_to_string(config_path).map_err(|err| {
+        format!(
+            "Failed to read XLSYNTH_ARTIFACT_CONFIG {}: {}",
+            config_path.display(),
+            err
+        )
+    })?;
+    let config_value: toml::Value = toml::from_str(&config_contents).map_err(|err| {
+        format!(
+            "Failed to parse XLSYNTH_ARTIFACT_CONFIG {} as TOML: {}",
+            config_path.display(),
+            err
+        )
+    })?;
+    let config_table = config_value.as_table().ok_or_else(|| {
+        format!(
+            "XLSYNTH_ARTIFACT_CONFIG {} must contain a top-level TOML table",
+            config_path.display()
+        )
+    })?;
+
+    Ok(ArtifactPaths {
+        dso_path: parse_artifact_config_path(config_table, config_path, "dso_path")?,
+        dslx_stdlib_path: parse_artifact_config_path(
+            config_table,
+            config_path,
+            "dslx_stdlib_path",
+        )?,
+    })
+}
+
+/// Validates an explicit shared-library path and derives its linker inputs.
+pub fn validate_explicit_dso_path(dso_path: &Path) -> Result<ExplicitDsoPath, String> {
+    let dso_dir = dso_path.parent().ok_or_else(|| {
+        format!(
+            "Explicit XLS DSO path must have a parent directory: {}",
+            dso_path.display()
+        )
+    })?;
+    let dso_name = dso_path.file_name().ok_or_else(|| {
+        format!(
+            "Explicit XLS DSO path must name a shared library file: {}",
+            dso_path.display()
+        )
+    })?;
+    let dso_name = dso_name.to_str().ok_or_else(|| {
+        format!(
+            "Explicit XLS DSO path must be valid UTF-8: {}",
+            dso_path.display()
+        )
+    })?;
+    let (dso_name, ext) = dso_name.rsplit_once('.').ok_or_else(|| {
+        format!(
+            "Explicit XLS DSO path must end with a shared library extension: {}",
+            dso_path.display()
+        )
+    })?;
+    match ext {
+        "dylib" | "so" => {}
+        _ => return Err(format!("Expected shared library extension: {:?}", ext)),
+    }
+    if !dso_name.starts_with("lib") {
+        return Err(format!(
+            "DSO name should start with 'lib'; dso_name: {:?}",
+            dso_name
+        ));
+    }
+    Ok(ExplicitDsoPath {
+        link_name: dso_name[3..].to_string(),
+        path: dso_path.to_path_buf(),
+        parent_dir: dso_dir.to_path_buf(),
+    })
+}
+
+fn parse_artifact_config_path(
+    config_table: &toml::Table,
+    config_path: &Path,
+    key: &str,
+) -> Result<String, String> {
+    let raw_path = PathBuf::from(parse_artifact_config_string(
+        config_table,
+        config_path,
+        key,
+    )?);
+    let resolved_path = if raw_path.is_absolute() {
+        raw_path
+    } else {
+        resolve_artifact_config_dir(config_path)?.join(raw_path)
+    };
+    Ok(resolved_path.display().to_string())
+}
+
+fn parse_artifact_config_string(
+    config_table: &toml::Table,
+    config_path: &Path,
+    key: &str,
+) -> Result<String, String> {
+    config_table
+        .get(key)
+        .and_then(toml::Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            format!(
+                "XLSYNTH_ARTIFACT_CONFIG {} must define string key {:?}",
+                config_path.display(),
+                key
+            )
+        })
+}
+
+fn resolve_artifact_config_dir(config_path: &Path) -> Result<&Path, String> {
+    config_path.parent().ok_or_else(|| {
+        format!(
+            "XLSYNTH_ARTIFACT_CONFIG should have a parent directory: {}",
+            config_path.display()
+        )
+    })
+}

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
+mod artifact_config;
+
+use artifact_config::{ArtifactPaths, ExplicitDsoPath};
 use sha2::Digest;
 use std::io::BufRead;
 #[cfg(unix)]
@@ -10,17 +13,6 @@ use std::process::Command;
 
 const RELEASE_LIB_VERSION_TAG: &str = "v0.50.1";
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 6;
-
-struct ArtifactPaths {
-    dso_path: String,
-    dslx_stdlib_path: String,
-}
-
-struct ExplicitDsoPath {
-    link_name: String,
-    path: PathBuf,
-    parent_dir: PathBuf,
-}
 
 #[derive(Clone, Copy)]
 enum LinkDirectiveMode {
@@ -545,135 +537,17 @@ fn write_artifact_paths_rs(out_dir: &Path, artifact_paths: &ArtifactPaths) {
     });
 }
 
-fn parse_artifact_config_string(
-    config_table: &toml::Table,
-    config_path: &Path,
-    key: &str,
-) -> String {
-    config_table
-        .get(key)
-        .and_then(toml::Value::as_str)
-        .unwrap_or_else(|| {
-            panic!(
-                "XLSYNTH_ARTIFACT_CONFIG {} must define string key {:?}",
-                config_path.display(),
-                key
-            )
-        })
-        .to_string()
-}
-
-fn resolve_artifact_config_dir(config_path: &Path) -> &Path {
-    config_path.parent().unwrap_or_else(|| {
-        panic!(
-            "XLSYNTH_ARTIFACT_CONFIG should have a parent directory: {}",
-            config_path.display()
-        )
-    })
-}
-
-fn parse_artifact_config_env_path() -> Option<PathBuf> {
-    let config_path = PathBuf::from(std::env::var_os("XLSYNTH_ARTIFACT_CONFIG")?);
-    if config_path.is_absolute() {
-        Some(config_path)
-    } else {
-        panic!(
-            concat!(
-                "XLSYNTH_ARTIFACT_CONFIG must be an absolute path; got relative path: {}.\n",
-                "The dso_path and dslx_stdlib_path values inside that TOML may still be relative ",
-                "to the TOML file's directory."
-            ),
-            config_path.display()
-        );
-    }
-}
-
-fn parse_artifact_config_path(config_table: &toml::Table, config_path: &Path, key: &str) -> String {
-    let raw_path = PathBuf::from(parse_artifact_config_string(config_table, config_path, key));
-    let resolved_path = if raw_path.is_absolute() {
-        raw_path
-    } else {
-        resolve_artifact_config_dir(config_path).join(raw_path)
-    };
-    resolved_path.display().to_string()
-}
-
 fn load_artifact_paths_from_config() -> Option<ArtifactPaths> {
-    let config_path = parse_artifact_config_env_path()?;
+    let config_path = artifact_config::parse_artifact_config_env_path(std::env::var_os(
+        "XLSYNTH_ARTIFACT_CONFIG",
+    ))
+    .unwrap_or_else(|err| panic!("{}", err))?;
     println!("cargo:rerun-if-changed={}", config_path.display());
 
-    let config_contents = std::fs::read_to_string(&config_path).unwrap_or_else(|err| {
-        panic!(
-            "Failed to read XLSYNTH_ARTIFACT_CONFIG {}: {}",
-            config_path.display(),
-            err
-        )
-    });
-    let config_value: toml::Value = toml::from_str(&config_contents).unwrap_or_else(|err| {
-        panic!(
-            "Failed to parse XLSYNTH_ARTIFACT_CONFIG {} as TOML: {}",
-            config_path.display(),
-            err
-        )
-    });
-    let config_table = config_value.as_table().unwrap_or_else(|| {
-        panic!(
-            "XLSYNTH_ARTIFACT_CONFIG {} must contain a top-level TOML table",
-            config_path.display()
-        )
-    });
-
-    Some(ArtifactPaths {
-        dso_path: parse_artifact_config_path(config_table, &config_path, "dso_path"),
-        dslx_stdlib_path: parse_artifact_config_path(
-            config_table,
-            &config_path,
-            "dslx_stdlib_path",
-        ),
-    })
-}
-
-fn validate_explicit_dso_path(dso_path: &Path) -> ExplicitDsoPath {
-    let dso_dir = dso_path.parent().unwrap_or_else(|| {
-        panic!(
-            "Explicit XLS DSO path must have a parent directory: {}",
-            dso_path.display()
-        )
-    });
-    let dso_name = dso_path.file_name().unwrap_or_else(|| {
-        panic!(
-            "Explicit XLS DSO path must name a shared library file: {}",
-            dso_path.display()
-        )
-    });
-    let dso_name = dso_name.to_str().unwrap_or_else(|| {
-        panic!(
-            "Explicit XLS DSO path must be valid UTF-8: {}",
-            dso_path.display()
-        )
-    });
-    let (dso_name, ext) = dso_name.rsplit_once('.').unwrap_or_else(|| {
-        panic!(
-            "Explicit XLS DSO path must end with a shared library extension: {}",
-            dso_path.display()
-        )
-    });
-    match ext {
-        "dylib" | "so" => {}
-        _ => {
-            panic!("Expected shared library extension: {:?}", ext);
-        }
-    }
-    assert!(
-        dso_name.starts_with("lib"),
-        "DSO name should start with 'lib'; dso_name: {:?}",
-        dso_name
-    );
-    ExplicitDsoPath {
-        link_name: dso_name[3..].to_string(),
-        path: dso_path.to_path_buf(),
-        parent_dir: dso_dir.to_path_buf(),
-    }
+    Some(
+        artifact_config::load_artifact_paths_from_config_path(&config_path)
+            .unwrap_or_else(|err| panic!("{}", err)),
+    )
 }
 
 fn emit_link_directives_for_explicit_dso(dso_path: &ExplicitDsoPath) {
@@ -700,7 +574,8 @@ fn emit_explicit_artifact_override(
         source_name, artifact_paths.dso_path, artifact_paths.dslx_stdlib_path
     );
     write_artifact_paths_rs(out_dir, artifact_paths);
-    let dso_path = validate_explicit_dso_path(Path::new(&artifact_paths.dso_path));
+    let dso_path = artifact_config::validate_explicit_dso_path(Path::new(&artifact_paths.dso_path))
+        .unwrap_or_else(|err| panic!("{}", err));
     match link_directive_mode {
         LinkDirectiveMode::Native => emit_link_directives_for_explicit_dso(&dso_path),
         LinkDirectiveMode::Declared => {

--- a/xlsynth-sys/tests/artifact_config_test.rs
+++ b/xlsynth-sys/tests/artifact_config_test.rs
@@ -2,12 +2,15 @@
 //! Exercises `XLSYNTH_ARTIFACT_CONFIG` resolution and validation via nested
 //! Cargo smoke crates.
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+
+#[path = "../artifact_config.rs"]
+mod artifact_config;
 
 /// Resolves the configured XLS DSO to a concrete shared-library file for test
 /// fixtures.
@@ -309,67 +312,69 @@ fn artifact_config_resolves_relative_toml_paths_from_absolute_config_path() {
     );
 }
 
+/// Verifies relative TOML path resolution without invoking nested Cargo.
+#[test]
+fn artifact_config_resolver_resolves_relative_toml_paths() {
+    let temp_dir = make_temp_dir();
+    let config_root_dir = temp_dir.path().join("config-root");
+    let config_path = config_root_dir.join("artifact-config.toml");
+    write_artifact_config(&config_path, "artifacts/libxls-test.so", "artifacts/stdlib");
+
+    let artifact_paths = artifact_config::load_artifact_paths_from_config_path(&config_path)
+        .expect("artifact config should resolve");
+    assert_eq!(
+        artifact_paths.dso_path,
+        config_root_dir
+            .join("artifacts/libxls-test.so")
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        artifact_paths.dslx_stdlib_path,
+        config_root_dir
+            .join("artifacts/stdlib")
+            .display()
+            .to_string()
+    );
+}
+
 /// Verifies that `XLSYNTH_ARTIFACT_CONFIG` itself must be passed as an absolute
 /// path.
 #[test]
 fn artifact_config_requires_absolute_config_path() {
+    let err = artifact_config::parse_artifact_config_env_path(Some(OsString::from(
+        "config/artifact-config.toml",
+    )))
+    .err()
+    .expect("relative XLSYNTH_ARTIFACT_CONFIG should fail");
+    assert!(
+        err.contains("XLSYNTH_ARTIFACT_CONFIG must be an absolute path"),
+        "Error did not explain the absolute-path requirement:\n{}",
+        err
+    );
+    assert!(
+        err.contains("dso_path and dslx_stdlib_path values inside that TOML may still be relative"),
+        "Error did not preserve the relative-path guidance for TOML entries:\n{}",
+        err
+    );
+    assert!(
+        !err.contains("No such file or directory"),
+        "Resolver should reject relative XLSYNTH_ARTIFACT_CONFIG directly instead of failing with a file lookup error:\n{}",
+        err
+    );
+}
+
+/// Verifies that explicit DSO paths produce the expected linker inputs.
+#[test]
+fn explicit_dso_path_derives_link_inputs() {
     let temp_dir = make_temp_dir();
-    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let temp_crate_dir = temp_dir.path().join("artifact-config-relative-smoke");
-    let config_root_dir = temp_crate_dir.join("config");
-    let config_artifacts_dir = temp_crate_dir.join("artifacts");
-    let (expected_dso_path, _expected_stdlib_path) = copy_config_artifacts(&config_artifacts_dir);
-    let config_path = config_root_dir.join("artifact-config.toml");
-    write_artifact_config(
-        &config_path,
-        &format!(
-            "../artifacts/{}",
-            expected_dso_path
-                .file_name()
-                .unwrap_or_else(|| panic!(
-                    "Expected copied DSO path to have filename: {}",
-                    expected_dso_path.display()
-                ))
-                .to_string_lossy()
-        ),
-        "../artifacts/stdlib",
-    );
-    write_smoke_crate(&temp_crate_dir, &manifest_path);
+    let dso_path = temp_dir.path().join("libxls-test.so");
+    let explicit_dso_path = artifact_config::validate_explicit_dso_path(&dso_path)
+        .expect("shared-library DSO path should resolve");
 
-    let target_dir = temp_dir.path().join("relative-target");
-    let output = run_nested_cargo_with_artifact_config(
-        &temp_crate_dir,
-        &target_dir,
-        OsStr::new("config/artifact-config.toml"),
-        None,
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        !output.status.success(),
-        "Nested cargo run unexpectedly succeeded with relative XLSYNTH_ARTIFACT_CONFIG.\nstdout:\n{}\nstderr:\n{}",
-        stdout,
-        stderr
-    );
-    assert!(
-        stderr.contains("XLSYNTH_ARTIFACT_CONFIG must be an absolute path"),
-        "Nested cargo stderr did not explain the absolute-path requirement.\nstdout:\n{}\nstderr:\n{}",
-        stdout,
-        stderr
-    );
-    assert!(
-        stderr.contains("dso_path and dslx_stdlib_path values inside that TOML may still be relative"),
-        "Nested cargo stderr did not preserve the relative-path guidance for TOML entries.\nstdout:\n{}\nstderr:\n{}",
-        stdout,
-        stderr
-    );
-    assert!(
-        !stderr.contains("No such file or directory"),
-        "Nested cargo stderr should reject relative XLSYNTH_ARTIFACT_CONFIG directly instead of failing with a file lookup error.\nstdout:\n{}\nstderr:\n{}",
-        stdout,
-        stderr
-    );
+    assert_eq!(explicit_dso_path.link_name, "xls-test");
+    assert_eq!(explicit_dso_path.path, dso_path);
+    assert_eq!(explicit_dso_path.parent_dir, temp_dir.path());
 }
 
 /// Verifies that declared mode still rejects directory-valued explicit DSO
@@ -377,12 +382,7 @@ fn artifact_config_requires_absolute_config_path() {
 #[test]
 fn artifact_config_declared_mode_rejects_non_library_dso_paths() {
     let temp_dir = make_temp_dir();
-    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let temp_crate_dir = temp_dir.path().join("artifact-config-declared-invalid-dso");
-    let config_root_dir = temp_dir.path().join("config-root");
-    let config_artifacts_dir = config_root_dir.join("artifacts");
-    let (_expected_dso_path, expected_stdlib_path) = copy_config_artifacts(&config_artifacts_dir);
-    let invalid_dso_dir = config_artifacts_dir.join("not-a-lib-dir");
+    let invalid_dso_dir = temp_dir.path().join("not-a-lib-dir");
     fs::create_dir_all(&invalid_dso_dir).unwrap_or_else(|err| {
         panic!(
             "Failed to create invalid DSO directory {}: {}",
@@ -390,62 +390,12 @@ fn artifact_config_declared_mode_rejects_non_library_dso_paths() {
             err
         )
     });
-    let config_path = config_root_dir.join("artifact-config.toml");
-    write_artifact_config(
-        &config_path,
-        invalid_dso_dir
-            .strip_prefix(&config_root_dir)
-            .unwrap_or_else(|err| {
-                panic!(
-                    "Failed to relativize invalid DSO directory {} against {}: {}",
-                    invalid_dso_dir.display(),
-                    config_root_dir.display(),
-                    err
-                )
-            })
-            .to_string_lossy()
-            .as_ref(),
-        expected_stdlib_path
-            .strip_prefix(&config_root_dir)
-            .unwrap_or_else(|err| {
-                panic!(
-                    "Failed to relativize stdlib path {} against {}: {}",
-                    expected_stdlib_path.display(),
-                    config_root_dir.display(),
-                    err
-                )
-            })
-            .to_string_lossy()
-            .as_ref(),
-    );
-    write_smoke_crate(&temp_crate_dir, &manifest_path);
-
-    let target_dir = temp_dir.path().join("declared-invalid-dso-target");
-    let output = run_nested_cargo_with_artifact_config(
-        &temp_crate_dir,
-        &target_dir,
-        config_path.as_os_str(),
-        Some("declared"),
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let err = artifact_config::validate_explicit_dso_path(&invalid_dso_dir)
+        .err()
+        .expect("directory-valued explicit DSO path should fail");
     assert!(
-        !output.status.success(),
-        "Nested cargo run unexpectedly succeeded with a directory DSO path in declared mode.\nstdout:\n{}\nstderr:\n{}",
-        stdout,
-        stderr
-    );
-    assert!(
-        stderr.contains("Explicit XLS DSO path must end with a shared library extension"),
-        "Nested cargo stderr did not explain the invalid explicit DSO path.\nstdout:\n{}\nstderr:\n{}",
-        stdout,
-        stderr
-    );
-    assert!(
-        !stderr.contains("Skipping native link directives"),
-        "Declared-mode validation should fail before the build script reports skipped link directives.\nstdout:\n{}\nstderr:\n{}",
-        stdout,
-        stderr
+        err.contains("Explicit XLS DSO path must end with a shared library extension"),
+        "Error did not explain the invalid explicit DSO path:\n{}",
+        err
     );
 }

--- a/xlsynth-test-helpers/src/dslx_prover.rs
+++ b/xlsynth-test-helpers/src/dslx_prover.rs
@@ -25,7 +25,7 @@ pub fn default_xlsynth_tools_path() -> PathBuf {
 pub fn assert_dslx_quickchecks_prove(path: &Path, additional_search_paths: &[&Path]) {
     let tool_path = default_xlsynth_tools_path();
     let stdlib_path = tool_path.join("xls/dslx/stdlib");
-    let prover = prover_for_choice(SolverChoice::Auto, Some(&tool_path));
+    let prover = prover_for_choice(SolverChoice::Bitwuzla, Some(&tool_path));
     let results = prover.prove_dslx_quickcheck(
         path,
         Some(&stdlib_path),


### PR DESCRIPTION
Bitwuzla is almost always what we want. This change does require passing --features with-bitwuzla-system for all tests to pass, but this should avoid accidentally falling back on check_ir_eq_main ever.