### PR TITLE
Add a random block IR generator.

### DIFF
--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-from typing import Tuple
 import hashlib
+import os
 import shutil
+import subprocess
+import sys
 import tempfile
-import requests
 import time
 from optparse import OptionParser
+from typing import Tuple
+
+import requests
 
 GITHUB_API_URL = "https://api.github.com/repos/xlsynth/xlsynth/releases"
 # TODO(cdleary): add releases that cover the intersections of architecture and OS
@@ -252,6 +255,72 @@ def ensure_versioned_dso_alias(output_dir: str, version: str, platform: str) -> 
     )
 
 
+def ensure_macos_arm64_dso_alias(output_dir: str) -> None:
+    """Creates the conventional macOS libxls.dylib alias for arm64 downloads."""
+    unversioned_filename = "libxls-arm64.dylib"
+    conventional_filename = "libxls.dylib"
+    unversioned_path = os.path.join(output_dir, unversioned_filename)
+    conventional_path = os.path.join(output_dir, conventional_filename)
+
+    if not os.path.exists(unversioned_path):
+        raise FileNotFoundError(
+            f"Cannot create macOS DSO alias; missing downloaded DSO: {unversioned_path}"
+        )
+
+    if os.path.lexists(conventional_path):
+        try:
+            if os.path.samefile(conventional_path, unversioned_path):
+                print(
+                    "macOS DSO compatibility alias already exists: "
+                    f"{conventional_filename}"
+                )
+                return
+        except FileNotFoundError:
+            pass
+
+        if os.path.islink(conventional_path):
+            os.remove(conventional_path)
+        else:
+            raise FileExistsError(
+                "Cannot create macOS DSO alias; "
+                f"{conventional_path} already exists and does not point to "
+                f"{unversioned_path}"
+            )
+
+    os.symlink(unversioned_filename, conventional_path)
+    print(
+        "Created macOS DSO compatibility alias: "
+        f"{conventional_filename} -> {unversioned_filename}"
+    )
+
+
+def fix_macos_arm64_dso_install_name(output_dir: str) -> None:
+    """Rewrites the downloaded arm64 dylib id to its absolute local path."""
+    dso_path = os.path.join(output_dir, "libxls-arm64.dylib")
+    if not os.path.exists(dso_path):
+        raise FileNotFoundError(
+            f"Cannot fix macOS install-name; missing downloaded DSO: {dso_path}"
+        )
+
+    if sys.platform != "darwin":
+        print(
+            "Skipping macOS install-name fix for libxls-arm64.dylib because "
+            f"this host is {sys.platform}, not darwin"
+        )
+        return
+
+    install_name_tool = shutil.which("install_name_tool")
+    if install_name_tool is None:
+        raise RuntimeError(
+            "Cannot fix macOS install-name for libxls-arm64.dylib: "
+            "install_name_tool was not found on PATH"
+        )
+
+    install_name = os.path.realpath(dso_path)
+    print(f"Fixing macOS DSO install-name: {install_name}")
+    subprocess.check_call([install_name_tool, "-id", install_name, dso_path])
+
+
 def main():
     parser = OptionParser()
     parser.add_option(
@@ -355,6 +424,9 @@ def main():
 
     if options.dso:
         ensure_versioned_dso_alias(output_dir, version, options.platform)
+        if options.platform == "arm64":
+            ensure_macos_arm64_dso_alias(output_dir)
+            fix_macos_arm64_dso_install_name(output_dir)
 
     # Download and extract dslx_stdlib.tar.gz
     stdlib_filename = "dslx_stdlib.tar.gz"

--- a/xlsynth-g8r/fuzz/Cargo.toml
+++ b/xlsynth-g8r/fuzz/Cargo.toml
@@ -40,6 +40,12 @@ doc = false
 required-features = ["has-bitwuzla"]
 
 [[bin]]
+name = "fuzz_random_block_g8r_equiv"
+path = "fuzz_targets/fuzz_random_block_g8r_equiv.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "fuzz_g8r_formal"
 path = "fuzz_targets/fuzz_g8r_formal.rs"
 test = false

--- a/xlsynth-g8r/fuzz/FUZZ.md
+++ b/xlsynth-g8r/fuzz/FUZZ.md
@@ -1,5 +1,28 @@
 # xlsynth-g8r Fuzz Targets
 
+## `fuzz_random_block_g8r_equiv`
+
+Directly generates random block IR, lowers supported synchronous blocks to
+sequential G8R, and compares cycle-by-cycle external outputs and register state
+against an independent block-level reference evaluation. The stimulus sequence
+and initial values are produced by a deterministic RNG seeded from the
+generated IR, rather than from coverage-guided bytes. Registers without reset
+values receive random initial state; reset-bearing registers start from their
+declared reset value. A reset input is asserted with 50% probability on the
+first cycle and 10% probability on later cycles. The target requests
+synchronous-only reset generation and treats any asynchronous reset as a
+generator-contract failure.
+
+The essential property is that lowering a generated synchronous block to
+sequential G8R preserves each cycle's visible outputs and committed register
+state across random input sequences, including feedback, load-enables, mixed
+reset coverage, aggregate ports/registers, and zero-output blocks with state.
+Failures expose changed register feedback, load-enable, or reset semantics;
+disagreement while flattening aggregate block ports or register values;
+divergent visible outputs or committed register state on any simulated cycle;
+or generated block metadata that cannot be lowered by the supported
+synchronous block-to-G8R path.
+
 ## `fuzz_gatify`
 
 Generates bounded gatify-supported PIR directly with

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_random_block_g8r_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_random_block_g8r_equiv.rs
@@ -2,6 +2,8 @@
 
 #![no_main]
 
+//! Differentially checks generated block IR against sequential G8R lowering.
+
 use std::collections::BTreeMap;
 
 use libfuzzer_sys::fuzz_target;

--- a/xlsynth-g8r/src/block2sequential.rs
+++ b/xlsynth-g8r/src/block2sequential.rs
@@ -597,6 +597,9 @@ fn collect_block_outputs(
     block: &ir::Fn,
     metadata: &BlockMetadata,
 ) -> Result<Vec<TransitionEndpoint>, String> {
+    if metadata.output_names.is_empty() {
+        return Ok(Vec::new());
+    }
     let ret_ref = block
         .ret_node_ref
         .ok_or_else(|| "block2sequential: block has no return node".to_string())?;
@@ -705,16 +708,15 @@ fn set_transition_return(
     endpoints: &[TransitionEndpoint],
     max_text_id: &mut usize,
 ) {
-    assert!(
-        !endpoints.is_empty(),
-        "parsed blocks must have at least one output endpoint"
-    );
     if endpoints.len() == 1 {
         transition.ret_ty = endpoints[0].ty.clone();
         transition.ret_node_ref = Some(endpoints[0].node_ref);
         return;
     }
 
+    // Keep a real return node even for a stateless block with no outputs.
+    // Gatify represents the empty tuple as one zero-width packed output, which
+    // split_transition_outputs removes to recover an empty transition interface.
     *max_text_id += 1;
     let ret_ty = Type::Tuple(
         endpoints

--- a/xlsynth-g8r/tests/block2sequential_test.rs
+++ b/xlsynth-g8r/tests/block2sequential_test.rs
@@ -3,6 +3,7 @@
 use xlsynth::IrBits;
 use xlsynth_g8r::aig_serdes::sequential2ir::sequential_gate_fn_to_pir_block_package;
 use xlsynth_g8r::aig_sim::gate_sim::{self, Collect};
+use xlsynth_g8r::aig_sim::sequential::{self, SequentialState};
 use xlsynth_g8r::block2sequential::block_ir_to_sequential_gate_fn;
 use xlsynth_g8r::gatify::ir2gate::GatifyOptions;
 
@@ -57,6 +58,43 @@ top block top(a: bits[1], b: bits[1], y: bits[1], z: bits[1]) {
         result.outputs,
         vec![IrBits::bool(true), IrBits::bool(false)]
     );
+}
+
+#[test]
+fn lowers_block_without_outputs_or_registers() {
+    let block_ir = r#"package empty
+
+top block top(a: bits[1]) {
+  a: bits[1] = input_port(name=a, id=1)
+  not.2: bits[1] = not(a, id=2)
+}
+"#;
+
+    let sequential = lower(block_ir);
+
+    assert!(sequential.registers.is_empty());
+    assert!(sequential.outputs.is_empty());
+    assert!(sequential.clock.is_none());
+    assert_eq!(
+        sequential
+            .transition
+            .inputs
+            .iter()
+            .map(|input| input.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a"]
+    );
+    assert!(sequential.transition.outputs.is_empty());
+
+    let initial_state = SequentialState::from_register_values(&sequential, vec![]).unwrap();
+    let trace = sequential::simulate(
+        &sequential,
+        &[vec![IrBits::bool(false)], vec![IrBits::bool(true)]],
+        initial_state,
+    )
+    .unwrap();
+    assert_eq!(trace.external_outputs(), &[vec![], vec![]]);
+    assert!(trace.final_state().values().is_empty());
 }
 
 #[test]

--- a/xlsynth-pir/fuzz/Cargo.toml
+++ b/xlsynth-pir/fuzz/Cargo.toml
@@ -19,7 +19,6 @@ rand = "0.8"
 pretty_assertions = "1.4.1"
 # Local crates
 xlsynth-pir = { path = ".." }
-xlsynth-g8r = { path = "../../xlsynth-g8r" }
 xlsynth = { path = "../../xlsynth" }
 xlsynth-autocov = { path = "../../xlsynth-autocov" }
 xlsynth-prover = { path = "../../xlsynth-prover" }
@@ -53,12 +52,6 @@ doc = false
 [[bin]]
 name = "fuzz_random_block_roundtrip"
 path = "fuzz_targets/fuzz_random_block_roundtrip.rs"
-test = false
-doc = false
-
-[[bin]]
-name = "fuzz_random_block_g8r_equiv"
-path = "fuzz_targets/fuzz_random_block_g8r_equiv.rs"
 test = false
 doc = false
 

--- a/xlsynth-pir/fuzz/Cargo.toml
+++ b/xlsynth-pir/fuzz/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.8"
 pretty_assertions = "1.4.1"
 # Local crates
 xlsynth-pir = { path = ".." }
+xlsynth-g8r = { path = "../../xlsynth-g8r" }
 xlsynth = { path = "../../xlsynth" }
 xlsynth-autocov = { path = "../../xlsynth-autocov" }
 xlsynth-prover = { path = "../../xlsynth-prover" }
@@ -46,6 +47,18 @@ doc = false
 [[bin]]
 name = "fuzz_block_roundtrip"
 path = "fuzz_targets/fuzz_block_roundtrip.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_random_block_roundtrip"
+path = "fuzz_targets/fuzz_random_block_roundtrip.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_random_block_g8r_equiv"
+path = "fuzz_targets/fuzz_random_block_g8r_equiv.rs"
 test = false
 doc = false
 

--- a/xlsynth-pir/fuzz/FUZZ.md
+++ b/xlsynth-pir/fuzz/FUZZ.md
@@ -114,6 +114,64 @@ Main failure modes surfaced:
 
 ______________________________________________________________________
 
+# Direct Random Block Roundtrip Fuzz Target
+
+This target generates block IR directly with `xlsynth_pir::ir_random`,
+including input/output ports, upfront registers, optional load-enables, and a
+mix of reset and non-reset registers when reset is available. It validates the
+generated package, parses its printed text, and checks that printing is stable.
+
+Target name: `fuzz_random_block_roundtrip`
+
+Essential property under test:
+
+- Direct block generation should emit structurally valid PIR blocks whose
+  metadata, register reads/writes, output ports, and parser/printer roundtrip
+  remain consistent.
+
+Main failure modes surfaced:
+
+- Register metadata and `register_read` / `register_write` nodes disagree.
+- Register write argument, reset, or load-enable operands have invalid types.
+- Output port metadata drifts from the block return value shape.
+- PIR block parser/printer roundtrip changes generated structure or metadata.
+
+______________________________________________________________________
+
+# Random Block G8R Sequential Equivalence Fuzz Target
+
+This target directly generates random block IR, lowers supported synchronous
+blocks to sequential G8R, and compares cycle-by-cycle external outputs and
+register state against an independent block-level reference evaluation. The
+stimulus sequence and initial values are produced by a deterministic RNG seeded
+from the generated IR, rather than from coverage-guided bytes. Registers
+without reset values receive random initial state; reset-bearing registers
+start from their declared reset value. A reset input is asserted with 50%
+probability on the first cycle and 10% probability on later cycles. The target
+requests synchronous-only reset generation and treats any asynchronous reset as
+a generator-contract failure.
+
+Target name: `fuzz_random_block_g8r_equiv`
+
+Essential property under test:
+
+- Lowering a generated synchronous block to sequential G8R preserves each
+  cycle's visible outputs and committed register state across random input
+  sequences, including feedback, load-enables, mixed reset coverage, aggregate
+  ports/registers, and zero-output blocks with state.
+
+Main failure modes surfaced:
+
+- G8R lowering changes register feedback, load-enable, or reset semantics.
+- Flattening aggregate block ports or register values disagrees between PIR and
+  G8R.
+- Visible output values or committed register state diverge on any simulated
+  cycle.
+- Random generated block metadata cannot be lowered by the supported
+  synchronous block-to-G8R path.
+
+______________________________________________________________________
+
 # `ext_nary_add` Eval vs Desugared Eval Fuzz Target
 
 This fuzz target generates a single-function PIR package whose return value is

--- a/xlsynth-pir/fuzz/FUZZ.md
+++ b/xlsynth-pir/fuzz/FUZZ.md
@@ -138,40 +138,6 @@ Main failure modes surfaced:
 
 ______________________________________________________________________
 
-# Random Block G8R Sequential Equivalence Fuzz Target
-
-This target directly generates random block IR, lowers supported synchronous
-blocks to sequential G8R, and compares cycle-by-cycle external outputs and
-register state against an independent block-level reference evaluation. The
-stimulus sequence and initial values are produced by a deterministic RNG seeded
-from the generated IR, rather than from coverage-guided bytes. Registers
-without reset values receive random initial state; reset-bearing registers
-start from their declared reset value. A reset input is asserted with 50%
-probability on the first cycle and 10% probability on later cycles. The target
-requests synchronous-only reset generation and treats any asynchronous reset as
-a generator-contract failure.
-
-Target name: `fuzz_random_block_g8r_equiv`
-
-Essential property under test:
-
-- Lowering a generated synchronous block to sequential G8R preserves each
-  cycle's visible outputs and committed register state across random input
-  sequences, including feedback, load-enables, mixed reset coverage, aggregate
-  ports/registers, and zero-output blocks with state.
-
-Main failure modes surfaced:
-
-- G8R lowering changes register feedback, load-enable, or reset semantics.
-- Flattening aggregate block ports or register values disagrees between PIR and
-  G8R.
-- Visible output values or committed register state diverge on any simulated
-  cycle.
-- Random generated block metadata cannot be lowered by the supported
-  synchronous block-to-G8R path.
-
-______________________________________________________________________
-
 # `ext_nary_add` Eval vs Desugared Eval Fuzz Target
 
 This fuzz target generates a single-function PIR package whose return value is

--- a/xlsynth-pir/fuzz/fuzz_targets/fuzz_random_block_g8r_equiv.rs
+++ b/xlsynth-pir/fuzz/fuzz_targets/fuzz_random_block_g8r_equiv.rs
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+
+use std::collections::BTreeMap;
+
+use libfuzzer_sys::fuzz_target;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use xlsynth::{IrBits, IrValue};
+use xlsynth_g8r::aig_sim::sequential::{self, SequentialState};
+use xlsynth_g8r::block2sequential::block_package_to_sequential_gate_fn;
+use xlsynth_g8r::gatify::ir2gate::GatifyOptions;
+use xlsynth_pir::ir::{BlockMetadata, Fn, NodePayload, NodeRef, Type};
+use xlsynth_pir::ir_eval::{self, FnEvalResult};
+use xlsynth_pir::ir_random::{
+    DepletableBytes, OperationSet, RandomBlockOptions, RandomFnOptions, RandomOperation,
+    RandomBlockResetTiming, StopPolicy, generate_block_package,
+};
+use xlsynth_pir::ir_value_utils::flatten_ir_value_to_lsb0_bits_for_type;
+use xlsynth_pir::random_inputs::generate_uniform_value_with_rng;
+
+const CYCLE_COUNT: usize = 32;
+
+#[derive(Debug, Clone, Copy)]
+struct RegisterWriteRefs {
+    arg: NodeRef,
+    load_enable: Option<NodeRef>,
+    reset: Option<NodeRef>,
+}
+
+fn fuzz_block_options() -> RandomBlockOptions {
+    let operations = OperationSet::new(
+        OperationSet::all_supported()
+            .iter()
+            .filter(|operation| {
+                !matches!(
+                    operation,
+                    RandomOperation::Umulp | RandomOperation::Smulp
+                )
+            }),
+    );
+    RandomBlockOptions {
+        max_input_ports: 6,
+        max_output_ports: 4,
+        max_registers: 4,
+        reset_timing: RandomBlockResetTiming::Synchronous,
+        function_options: RandomFnOptions {
+            max_nodes: 64,
+            max_bit_width: 16,
+            allow_arbitrary_width_multiply: true,
+            enabled_operations: operations,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    }
+}
+
+fn block_output_refs(block: &Fn, metadata: &BlockMetadata) -> Vec<NodeRef> {
+    let ret_ref = block
+        .ret_node_ref
+        .expect("generated block should have a return node");
+    match metadata.output_names.len() {
+        0 => Vec::new(),
+        1 => vec![ret_ref],
+        _ => {
+            let NodePayload::Tuple(outputs) = &block.get_node(ret_ref).payload else {
+                panic!("generated multi-output block should return a tuple");
+            };
+            outputs.clone()
+        }
+    }
+}
+
+fn block_output_types<'a>(block: &'a Fn, metadata: &BlockMetadata) -> Vec<&'a Type> {
+    match metadata.output_names.len() {
+        0 => Vec::new(),
+        1 => vec![&block.ret_ty],
+        _ => {
+            let Type::Tuple(types) = &block.ret_ty else {
+                panic!("generated multi-output block should return a tuple type");
+            };
+            types.iter().map(|ty| &**ty).collect()
+        }
+    }
+}
+
+fn collect_register_writes(block: &Fn) -> BTreeMap<String, RegisterWriteRefs> {
+    block
+        .nodes
+        .iter()
+        .filter_map(|node| match &node.payload {
+            NodePayload::RegisterWrite {
+                arg,
+                register,
+                load_enable,
+                reset,
+            } => Some((
+                register.clone(),
+                RegisterWriteRefs {
+                    arg: *arg,
+                    load_enable: *load_enable,
+                    reset: *reset,
+                },
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+fn cycle_eval_fn(block: &Fn, metadata: &BlockMetadata, state: &[IrValue]) -> Fn {
+    let state_by_register: BTreeMap<&str, &IrValue> = metadata
+        .registers
+        .iter()
+        .zip(state)
+        .map(|(register, value)| (register.name.as_str(), value))
+        .collect();
+    let mut result = block.clone();
+    for node in &mut result.nodes {
+        match &node.payload {
+            NodePayload::RegisterRead { register } => {
+                node.payload = NodePayload::Literal(
+                    (*state_by_register
+                        .get(register.as_str())
+                        .expect("generated register read should have state"))
+                    .clone(),
+                );
+            }
+            NodePayload::RegisterWrite { .. } => {
+                node.ty = Type::nil();
+                node.payload = NodePayload::Nil;
+            }
+            _ => {}
+        }
+    }
+    result
+}
+
+fn eval_ref(cycle_fn: &mut Fn, node_ref: NodeRef, inputs: &[IrValue], ir_text: &str) -> IrValue {
+    cycle_fn.ret_ty = cycle_fn.get_node(node_ref).ty.clone();
+    cycle_fn.ret_node_ref = Some(node_ref);
+    match ir_eval::eval_fn(cycle_fn, inputs) {
+        FnEvalResult::Success(success) => success.value,
+        failure @ FnEvalResult::Failure(_) => {
+            panic!("block PIR evaluation failed:\nIR:\n{ir_text}\nresult={failure:?}")
+        }
+    }
+}
+
+fn bool_value(value: &IrValue) -> bool {
+    value
+        .to_bool()
+        .expect("generated reset/load-enable value should be bits[1]")
+}
+
+fn evaluate_block_cycle(
+    block: &Fn,
+    metadata: &BlockMetadata,
+    inputs: &[IrValue],
+    state: &[IrValue],
+    ir_text: &str,
+) -> (Vec<IrValue>, Vec<IrValue>) {
+    let output_refs = block_output_refs(block, metadata);
+    let writes = collect_register_writes(block);
+    let mut cycle_fn = cycle_eval_fn(block, metadata, state);
+    if output_refs.is_empty() {
+        // Evaluate the explicit empty-tuple block return even though it does
+        // not contribute a visible value. This keeps stateless, outputless
+        // blocks in the PIR evaluator portion of the fuzz property.
+        let ret_ref = block
+            .ret_node_ref
+            .expect("generated block should have a return node");
+        let _ = eval_ref(&mut cycle_fn, ret_ref, inputs, ir_text);
+    }
+    let outputs = output_refs
+        .into_iter()
+        .map(|output_ref| eval_ref(&mut cycle_fn, output_ref, inputs, ir_text))
+        .collect();
+    let mut next_state = Vec::with_capacity(metadata.registers.len());
+
+    for (register_index, register) in metadata.registers.iter().enumerate() {
+        let Some(write) = writes.get(&register.name) else {
+            next_state.push(state[register_index].clone());
+            continue;
+        };
+        let mut next_value = eval_ref(&mut cycle_fn, write.arg, inputs, ir_text);
+        if let Some(load_enable_ref) = write.load_enable
+            && !bool_value(&eval_ref(
+                &mut cycle_fn,
+                load_enable_ref,
+                inputs,
+                ir_text,
+            ))
+        {
+            next_value = state[register_index].clone();
+        }
+        if let (Some(reset_ref), Some(reset_value), Some(reset_metadata)) =
+            (write.reset, register.reset_value.as_ref(), metadata.reset.as_ref())
+        {
+            let reset_signal = bool_value(&eval_ref(&mut cycle_fn, reset_ref, inputs, ir_text));
+            let reset_asserted = if reset_metadata.active_low {
+                !reset_signal
+            } else {
+                reset_signal
+            };
+            if reset_asserted {
+                next_value = reset_value.clone();
+            }
+        }
+        next_state.push(next_value);
+    }
+
+    (outputs, next_state)
+}
+
+fn flatten_value(value: &IrValue, ty: &Type) -> IrBits {
+    let mut bits = Vec::with_capacity(ty.bit_count());
+    flatten_ir_value_to_lsb0_bits_for_type(value, ty, &mut bits)
+        .expect("generated value should match its PIR type");
+    IrBits::from_lsb_is_0(&bits)
+}
+
+fn generate_initial_state(metadata: &BlockMetadata, rng: &mut StdRng) -> Vec<IrValue> {
+    metadata
+        .registers
+        .iter()
+        .map(|register| {
+            register
+                .reset_value
+                .clone()
+                .unwrap_or_else(|| generate_uniform_value_with_rng(rng, &register.ty))
+        })
+        .collect()
+}
+
+fn generate_cycle_inputs(
+    block: &Fn,
+    metadata: &BlockMetadata,
+    rng: &mut StdRng,
+    cycle: usize,
+) -> Vec<IrValue> {
+    block
+        .params
+        .iter()
+        .map(|param| {
+            if let Some(reset) = metadata.reset.as_ref()
+                && param.name == reset.port_name
+            {
+                let asserted = if cycle == 0 {
+                    rng.gen_bool(0.5)
+                } else {
+                    rng.gen_ratio(1, 10)
+                };
+                let signal_high = if reset.active_low {
+                    !asserted
+                } else {
+                    asserted
+                };
+                return IrValue::make_ubits(1, u64::from(signal_high))
+                    .expect("bits[1] reset input should construct");
+            }
+            generate_uniform_value_with_rng(rng, &param.ty)
+        })
+        .collect()
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut entropy = DepletableBytes::new(data);
+    let generated = generate_block_package(
+        &mut entropy,
+        &fuzz_block_options(),
+        StopPolicy::WhenEntropyDepleted,
+    )
+    .expect("fixed random block options should construct a valid package");
+    let block_ir = generated.package.to_string();
+    let block = generated
+        .package
+        .get_top_block()
+        .expect("generated package should have a top block");
+    let xlsynth_pir::ir::PackageMember::Block { func, metadata } = block else {
+        unreachable!("generated package top should be a block");
+    };
+
+    if metadata
+        .reset
+        .as_ref()
+        .is_some_and(|reset| reset.asynchronous)
+    {
+        panic!("synchronous-only block generation emitted an asynchronous reset:\n{block_ir}");
+    }
+
+    let design = block_package_to_sequential_gate_fn(
+        &generated.package,
+        GatifyOptions::all_opts_disabled(),
+    )
+    .unwrap_or_else(|error| panic!("random block G8R lowering failed:\n{block_ir}\n{error}"));
+    let mut seed = [0_u8; 32];
+    seed.copy_from_slice(blake3::hash(block_ir.as_bytes()).as_bytes());
+    let mut rng = StdRng::from_seed(seed);
+    let mut block_state = generate_initial_state(metadata, &mut rng);
+    let initial_g8r_state = block_state
+        .iter()
+        .zip(&metadata.registers)
+        .map(|(value, register)| flatten_value(value, &register.ty))
+        .collect();
+    let mut g8r_state = SequentialState::from_register_values(&design, initial_g8r_state)
+        .expect("generated initial register state should match lowered G8R");
+    let output_types = block_output_types(func, metadata);
+
+    for cycle in 0..CYCLE_COUNT {
+        let inputs = generate_cycle_inputs(func, metadata, &mut rng, cycle);
+        let g8r_inputs = inputs
+            .iter()
+            .zip(&func.params)
+            .map(|(value, param)| flatten_value(value, &param.ty))
+            .collect::<Vec<_>>();
+        let (expected_outputs, next_block_state) =
+            evaluate_block_cycle(func, metadata, &inputs, &block_state, &block_ir);
+        let expected_output_bits = expected_outputs
+            .iter()
+            .zip(&output_types)
+            .map(|(value, ty)| flatten_value(value, ty))
+            .collect::<Vec<_>>();
+        let trace = sequential::simulate(&design, &[g8r_inputs], g8r_state)
+            .unwrap_or_else(|error| panic!("random block G8R simulation failed:\n{block_ir}\n{error}"));
+        assert_eq!(
+            trace.external_outputs()[0],
+            expected_output_bits,
+            "random block output mismatch at cycle {cycle}:\n{block_ir}"
+        );
+        let expected_state_bits = next_block_state
+            .iter()
+            .zip(&metadata.registers)
+            .map(|(value, register)| flatten_value(value, &register.ty))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            trace.final_state().values(),
+            expected_state_bits,
+            "random block register-state mismatch at cycle {cycle}:\n{block_ir}"
+        );
+        block_state = next_block_state;
+        g8r_state = trace.final_state().clone();
+    }
+});

--- a/xlsynth-pir/fuzz/fuzz_targets/fuzz_random_block_roundtrip.rs
+++ b/xlsynth-pir/fuzz/fuzz_targets/fuzz_random_block_roundtrip.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use pretty_assertions::assert_eq;
+use xlsynth_pir::ir_parser::Parser;
+use xlsynth_pir::ir_random::{
+    DepletableBytes, RandomBlockOptions, RandomFnOptions, StopPolicy, generate_block_package,
+};
+
+fuzz_target!(|data: &[u8]| {
+    let mut entropy = DepletableBytes::new(data);
+    let options = RandomBlockOptions {
+        max_input_ports: 6,
+        max_output_ports: 4,
+        max_registers: 4,
+        function_options: RandomFnOptions {
+            max_nodes: 64,
+            max_bit_width: 16,
+            allow_arbitrary_width_multiply: true,
+            allow_gate: true,
+            allow_assumed_in_bounds: true,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    };
+    let generated = generate_block_package(
+        &mut entropy,
+        &options,
+        StopPolicy::WhenEntropyDepleted,
+    )
+    .expect("fixed random block options should construct a valid package");
+    let ir_text = generated.package.to_string();
+    let reparsed = Parser::new(&ir_text)
+        .parse_and_validate_package()
+        .expect("generated random block package should parse and validate");
+
+    assert_eq!(reparsed.to_string(), ir_text);
+});

--- a/xlsynth-pir/src/ir_random.rs
+++ b/xlsynth-pir/src/ir_random.rs
@@ -2,7 +2,7 @@
 
 //! Direct construction of random, typed PIR functions.
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
@@ -10,8 +10,9 @@ use rand::RngCore;
 use xlsynth::IrValue;
 
 use crate::ir::{
-    Binop, ExtNaryAddArchitecture, ExtNaryAddTerm, FileTable, Fn, MemberType, NaryOp, Node,
-    NodePayload, NodeRef, Package, PackageMember, Param, ParamId, Type, Unop,
+    Binop, BlockMetadata, BlockResetMetadata, ExtNaryAddArchitecture, ExtNaryAddTerm, FileTable,
+    Fn, MemberType, NaryOp, Node, NodePayload, NodeRef, Package, PackageMember, Param, ParamId,
+    Register, Type, Unop,
 };
 use crate::ir_rebase_ids::rebase_fn_ids;
 use crate::ir_utils::{is_observable_effect_root, operands};
@@ -590,6 +591,141 @@ pub struct GeneratedPackage {
     pub function_stats: Vec<GeneratedFnStats>,
 }
 
+/// Controls reset timing metadata for generated random PIR blocks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RandomBlockResetTiming {
+    /// Generates only synchronous block reset metadata.
+    Synchronous,
+    /// Generates only asynchronous block reset metadata.
+    Asynchronous,
+    /// Chooses synchronous or asynchronous block reset metadata with equal
+    /// probability.
+    Either,
+}
+
+/// Configures shape and state limits for random PIR blocks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RandomBlockOptions {
+    /// Options used for random data types and combinational body operations.
+    pub function_options: RandomFnOptions,
+    /// Minimum number of data input ports, excluding any generated reset port.
+    pub min_input_ports: usize,
+    /// Maximum number of data input ports, excluding any generated reset port.
+    pub max_input_ports: usize,
+    /// Minimum number of output ports; zero-output blocks are supported.
+    pub min_output_ports: usize,
+    pub max_output_ports: usize,
+    pub min_registers: usize,
+    pub max_registers: usize,
+    /// Permits port and register types whose flattened bit count is zero,
+    /// including zero-width aggregates such as arrays of empty tuples.
+    pub allow_zero_width_ports_and_registers: bool,
+    /// Permits generated register writes to use an available `bits[1]` value as
+    /// a load-enable.
+    pub allow_load_enable: bool,
+    /// Permits generated blocks with registers to add a reset port and use it
+    /// on some register writes.
+    pub allow_reset: bool,
+    /// Controls the timing kind when a reset port is generated.
+    pub reset_timing: RandomBlockResetTiming,
+}
+
+impl Default for RandomBlockOptions {
+    fn default() -> Self {
+        Self {
+            function_options: RandomFnOptions::default(),
+            min_input_ports: 0,
+            max_input_ports: 5,
+            min_output_ports: 0,
+            max_output_ports: 3,
+            min_registers: 0,
+            max_registers: 3,
+            allow_zero_width_ports_and_registers: false,
+            allow_load_enable: true,
+            allow_reset: true,
+            reset_timing: RandomBlockResetTiming::Either,
+        }
+    }
+}
+
+impl RandomBlockOptions {
+    fn validate(&self) -> Result<(), GenerationError> {
+        self.function_options.validate()?;
+        if self.min_input_ports > self.max_input_ports {
+            return Err(GenerationError::InvalidOptions(format!(
+                "min_input_ports {} exceeds max_input_ports {}",
+                self.min_input_ports, self.max_input_ports
+            )));
+        }
+        if self.min_output_ports > self.max_output_ports {
+            return Err(GenerationError::InvalidOptions(format!(
+                "min_output_ports {} exceeds max_output_ports {}",
+                self.min_output_ports, self.max_output_ports
+            )));
+        }
+        if self.min_registers > self.max_registers {
+            return Err(GenerationError::InvalidOptions(format!(
+                "min_registers {} exceeds max_registers {}",
+                self.min_registers, self.max_registers
+            )));
+        }
+        if self.min_input_ports > self.function_options.max_params {
+            return Err(GenerationError::InvalidOptions(format!(
+                "min_input_ports {} exceeds function_options.max_params {}",
+                self.min_input_ports, self.function_options.max_params
+            )));
+        }
+
+        let min_output_tuple_node = usize::from(self.min_output_ports != 1);
+        let min_seed_node = usize::from(
+            self.min_output_ports > 0 && self.min_input_ports == 0 && self.min_registers == 0,
+        );
+        let required_nodes = self
+            .min_input_ports
+            .saturating_add(self.min_registers.saturating_mul(2))
+            .saturating_add(min_output_tuple_node)
+            .saturating_add(min_seed_node);
+        if required_nodes > self.function_options.max_nodes {
+            return Err(GenerationError::InvalidOptions(format!(
+                "minimum block shape requires {required_nodes} nodes but max_nodes is {}",
+                self.function_options.max_nodes
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// A directly constructed PIR block and its generation statistics.
+#[derive(Debug, Clone)]
+pub struct GeneratedBlock {
+    pub function: Fn,
+    pub metadata: BlockMetadata,
+    pub stats: GeneratedFnStats,
+}
+
+impl GeneratedBlock {
+    /// Moves the generated block into a package with that block marked top.
+    pub fn into_top_package(self, package_name: impl Into<String>) -> Package {
+        let block_name = self.function.name.clone();
+        Package {
+            name: package_name.into(),
+            file_table: FileTable::new(),
+            members: vec![PackageMember::Block {
+                func: self.function,
+                metadata: self.metadata,
+            }],
+            top: Some((block_name, MemberType::Block)),
+        }
+    }
+}
+
+/// A directly constructed PIR block package and per-block statistics.
+#[derive(Debug, Clone)]
+pub struct GeneratedBlockPackage {
+    pub package: Package,
+    pub block_stats: Vec<GeneratedFnStats>,
+}
+
 /// Parameter and return types required for constrained random function
 /// generation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -658,6 +794,489 @@ pub fn generate_package<S: EntropySource>(
     options.validate()?;
     validate_stop_policy(stop_policy)?;
     PackageGenerator::new(source, options, stop_policy).generate()
+}
+
+/// Generates a typed PIR block directly from an entropy source.
+pub fn generate_block<S: EntropySource>(
+    source: &mut S,
+    options: &RandomBlockOptions,
+    stop_policy: StopPolicy,
+) -> Result<GeneratedBlock, GenerationError> {
+    options.validate()?;
+    validate_stop_policy(stop_policy)?;
+    BlockGenerator::new(source, options, stop_policy).generate_block("random_block_0".to_string())
+}
+
+/// Generates a package containing one top block directly from an entropy
+/// source.
+pub fn generate_block_package<S: EntropySource>(
+    source: &mut S,
+    options: &RandomBlockOptions,
+    stop_policy: StopPolicy,
+) -> Result<GeneratedBlockPackage, GenerationError> {
+    let generated = generate_block(source, options, stop_policy)?;
+    let stats = generated.stats.clone();
+    let package = generated.into_top_package("random_block_package");
+    crate::ir_verify::verify_package(&package)
+        .map_err(|error| GenerationError::Construction(error.to_string()))?;
+    Ok(GeneratedBlockPackage {
+        package,
+        block_stats: vec![stats],
+    })
+}
+
+#[derive(Debug, Clone)]
+struct GeneratedRegisterState {
+    name: String,
+    ty: Type,
+    read_ref: NodeRef,
+    reset_ref: Option<NodeRef>,
+}
+
+struct BlockGenerator<'a, S> {
+    source: &'a mut S,
+    options: &'a RandomBlockOptions,
+    stop_policy: StopPolicy,
+}
+
+impl<'a, S: EntropySource> BlockGenerator<'a, S> {
+    fn new(source: &'a mut S, options: &'a RandomBlockOptions, stop_policy: StopPolicy) -> Self {
+        Self {
+            source,
+            options,
+            stop_policy,
+        }
+    }
+
+    fn generate_block(&mut self, name: String) -> Result<GeneratedBlock, GenerationError> {
+        let mut generator = FunctionGenerator::new(&self.options.function_options);
+        let mut metadata = BlockMetadata {
+            clock_port_name: None,
+            input_port_ids: HashMap::new(),
+            output_port_ids: HashMap::new(),
+            output_names: Vec::new(),
+            reset: None,
+            registers: Vec::new(),
+            instantiations: Vec::new(),
+        };
+
+        let input_count = self.choose_input_count()?;
+        for index in 0..input_count {
+            let ty = random_block_interface_type(
+                self.source,
+                &self.options.function_options,
+                self.options.allow_zero_width_ports_and_registers,
+            );
+            self.add_block_param(&mut generator, &mut metadata, format!("in{index}"), ty);
+        }
+
+        let register_count = self.choose_register_count(generator.params.len())?;
+        let output_tuple_reserve = usize::from(self.options.min_output_ports != 1);
+        let reset_ref = self.maybe_add_reset_port(
+            &mut generator,
+            &mut metadata,
+            register_count,
+            output_tuple_reserve,
+        );
+        let registers =
+            self.add_registers(&mut generator, &mut metadata, register_count, reset_ref);
+
+        self.generate_body(&mut generator, register_count, output_tuple_reserve)?;
+
+        let output_count = self.choose_output_count(&generator, register_count)?;
+        let output_refs = self.choose_output_refs(&generator, output_count)?;
+        let ret_node_ref = self.materialize_block_return(&mut generator, &output_refs)?;
+
+        for register in &registers {
+            let next_ref = self.choose_register_next_ref(&generator, register)?;
+            let load_enable = self.maybe_choose_load_enable_ref(&generator);
+            generator.add_node(
+                Type::nil(),
+                NodePayload::RegisterWrite {
+                    arg: next_ref,
+                    register: register.name.clone(),
+                    load_enable,
+                    reset: register.reset_ref,
+                },
+                Some(format!("{}_d", register.name)),
+            );
+        }
+
+        self.populate_output_metadata(&generator, &mut metadata, output_count);
+        let mut function = generator.finish_with_return(ret_node_ref)?;
+        function.name = name;
+        let stats = gather_block_stats(&function);
+
+        Ok(GeneratedBlock {
+            function,
+            metadata,
+            stats,
+        })
+    }
+
+    fn choose_input_count(&mut self) -> Result<usize, GenerationError> {
+        let output_tuple_reserve = usize::from(self.options.min_output_ports != 1);
+        let reserved_nodes = self
+            .options
+            .min_registers
+            .saturating_mul(2)
+            .saturating_add(output_tuple_reserve);
+        let max_by_nodes = self
+            .options
+            .function_options
+            .max_nodes
+            .saturating_sub(reserved_nodes);
+        let max_input_count = self
+            .options
+            .max_input_ports
+            .min(self.options.function_options.max_params)
+            .min(max_by_nodes);
+        if max_input_count < self.options.min_input_ports {
+            return Err(GenerationError::InvalidOptions(format!(
+                "minimum block input count {} cannot fit with max_nodes {}",
+                self.options.min_input_ports, self.options.function_options.max_nodes
+            )));
+        }
+        Ok(choose_between(
+            self.source,
+            self.options.min_input_ports,
+            max_input_count,
+        ))
+    }
+
+    fn choose_register_count(&mut self, input_count: usize) -> Result<usize, GenerationError> {
+        let output_tuple_reserve = usize::from(self.options.min_output_ports != 1);
+        let max_by_nodes = self
+            .options
+            .function_options
+            .max_nodes
+            .saturating_sub(input_count.saturating_add(output_tuple_reserve))
+            / 2;
+        let max_register_count = self.options.max_registers.min(max_by_nodes);
+        if max_register_count < self.options.min_registers {
+            return Err(GenerationError::InvalidOptions(format!(
+                "minimum register count {} cannot fit with {} input nodes and max_nodes {}",
+                self.options.min_registers, input_count, self.options.function_options.max_nodes
+            )));
+        }
+        Ok(choose_between(
+            self.source,
+            self.options.min_registers,
+            max_register_count,
+        ))
+    }
+
+    fn add_block_param(
+        &mut self,
+        generator: &mut FunctionGenerator<'_>,
+        metadata: &mut BlockMetadata,
+        name: String,
+        ty: Type,
+    ) -> NodeRef {
+        let node_ref = generator.add_named_param(name.clone(), ty);
+        metadata
+            .input_port_ids
+            .insert(name, generator.params.last().unwrap().id.get_wrapped_id());
+        node_ref
+    }
+
+    fn maybe_add_reset_port(
+        &mut self,
+        generator: &mut FunctionGenerator<'_>,
+        metadata: &mut BlockMetadata,
+        register_count: usize,
+        output_tuple_reserve: usize,
+    ) -> Option<NodeRef> {
+        if register_count == 0 || !self.options.allow_reset || self.source.take_u64() & 1 == 0 {
+            return None;
+        }
+        let used_nodes = generator.nodes.len().saturating_sub(1);
+        let reserved_nodes = register_count
+            .saturating_mul(2)
+            .saturating_add(output_tuple_reserve);
+        if generator.params.len() >= self.options.function_options.max_params
+            || used_nodes.saturating_add(1).saturating_add(reserved_nodes)
+                > self.options.function_options.max_nodes
+        {
+            return None;
+        }
+
+        let reset_ref = self.add_block_param(generator, metadata, "rst".to_string(), Type::Bits(1));
+        let asynchronous = match self.options.reset_timing {
+            RandomBlockResetTiming::Synchronous => false,
+            RandomBlockResetTiming::Asynchronous => true,
+            RandomBlockResetTiming::Either => self.source.take_u64() & 1 != 0,
+        };
+        metadata.reset = Some(BlockResetMetadata {
+            port_name: "rst".to_string(),
+            asynchronous,
+            active_low: self.source.take_u64() & 1 != 0,
+        });
+        Some(reset_ref)
+    }
+
+    fn add_registers(
+        &mut self,
+        generator: &mut FunctionGenerator<'_>,
+        metadata: &mut BlockMetadata,
+        register_count: usize,
+        reset_ref: Option<NodeRef>,
+    ) -> Vec<GeneratedRegisterState> {
+        if register_count != 0 {
+            metadata.clock_port_name = Some("clk".to_string());
+        }
+
+        let reset_enabled = self.choose_register_reset_enabled(register_count, reset_ref);
+        let mut registers = Vec::with_capacity(register_count);
+        for index in 0..register_count {
+            let name = format!("r{index}");
+            let ty = random_block_interface_type(
+                self.source,
+                &self.options.function_options,
+                self.options.allow_zero_width_ports_and_registers,
+            );
+            let register_reset_ref = if reset_enabled[index] {
+                reset_ref
+            } else {
+                None
+            };
+            let reset_value = register_reset_ref.map(|_| generate_uniform_value(self.source, &ty));
+            metadata.registers.push(Register {
+                name: name.clone(),
+                ty: ty.clone(),
+                reset_value,
+            });
+            let read_ref = generator.add_node(
+                ty.clone(),
+                NodePayload::RegisterRead {
+                    register: name.clone(),
+                },
+                Some(format!("{name}_q")),
+            );
+            registers.push(GeneratedRegisterState {
+                name,
+                ty,
+                read_ref,
+                reset_ref: register_reset_ref,
+            });
+        }
+        registers
+    }
+
+    fn choose_register_reset_enabled(
+        &mut self,
+        register_count: usize,
+        reset_ref: Option<NodeRef>,
+    ) -> Vec<bool> {
+        if reset_ref.is_none() {
+            return vec![false; register_count];
+        }
+        let mut enabled: Vec<bool> = (0..register_count)
+            .map(|_| self.source.take_u64() & 1 != 0)
+            .collect();
+        if register_count > 1 {
+            if enabled.iter().all(|value| *value) {
+                enabled[register_count - 1] = false;
+            } else if enabled.iter().all(|value| !*value) {
+                enabled[0] = true;
+            }
+        }
+        enabled
+    }
+
+    fn generate_body(
+        &mut self,
+        generator: &mut FunctionGenerator<'_>,
+        register_count: usize,
+        output_tuple_reserve: usize,
+    ) -> Result<(), GenerationError> {
+        let used_nodes = generator.nodes.len().saturating_sub(1);
+        let reserved_nodes = register_count.saturating_add(output_tuple_reserve);
+        let body_capacity = self
+            .options
+            .function_options
+            .max_nodes
+            .saturating_sub(used_nodes.saturating_add(reserved_nodes));
+        let mut body_nodes = 0;
+        if block_data_types(generator, self.options.allow_zero_width_ports_and_registers).is_empty()
+            && self.options.max_output_ports > 0
+        {
+            if body_capacity == 0 {
+                if self.options.min_output_ports == 0 {
+                    return Ok(());
+                }
+                return Err(GenerationError::Construction(
+                    "block has no data value available for an output".to_string(),
+                ));
+            }
+            self.add_random_data_literal(generator);
+            body_nodes += 1;
+        }
+
+        while body_nodes < body_capacity
+            && should_add_node(self.source, self.stop_policy, body_nodes)
+        {
+            generator.add_random_body_node(self.source)?;
+            body_nodes += 1;
+        }
+        Ok(())
+    }
+
+    fn add_random_data_literal(&mut self, generator: &mut FunctionGenerator<'_>) -> NodeRef {
+        let ty = random_block_interface_type(
+            self.source,
+            &self.options.function_options,
+            self.options.allow_zero_width_ports_and_registers,
+        );
+        generator.add_node(
+            ty.clone(),
+            NodePayload::Literal(generate_uniform_value(self.source, &ty)),
+            None,
+        )
+    }
+
+    fn choose_output_count(
+        &mut self,
+        generator: &FunctionGenerator<'_>,
+        register_count: usize,
+    ) -> Result<usize, GenerationError> {
+        let used_nodes = generator.nodes.len().saturating_sub(1);
+        let remaining_after_register_writes = self
+            .options
+            .function_options
+            .max_nodes
+            .saturating_sub(used_nodes.saturating_add(register_count));
+        let data_available =
+            !block_data_types(generator, self.options.allow_zero_width_ports_and_registers)
+                .is_empty();
+        let (min_output_count, max_output_count) = if !data_available {
+            (self.options.min_output_ports, 0)
+        } else if remaining_after_register_writes == 0 {
+            (self.options.min_output_ports.max(1), 1)
+        } else {
+            (self.options.min_output_ports, self.options.max_output_ports)
+        };
+        if max_output_count < min_output_count {
+            return Err(GenerationError::Construction(format!(
+                "minimum output count {} cannot fit after generated body",
+                self.options.min_output_ports
+            )));
+        }
+        Ok(choose_between(
+            self.source,
+            min_output_count,
+            max_output_count,
+        ))
+    }
+
+    fn choose_output_refs(
+        &mut self,
+        generator: &FunctionGenerator<'_>,
+        output_count: usize,
+    ) -> Result<Vec<NodeRef>, GenerationError> {
+        if output_count == 0 {
+            return Ok(Vec::new());
+        }
+        if block_data_types(generator, self.options.allow_zero_width_ports_and_registers).is_empty()
+        {
+            return Err(GenerationError::Construction(
+                "block has no data value available for an output".to_string(),
+            ));
+        }
+        Ok((0..output_count)
+            .map(|_| self.choose_block_data_ref(generator))
+            .collect())
+    }
+
+    fn choose_block_data_ref(&mut self, generator: &FunctionGenerator<'_>) -> NodeRef {
+        let types = block_data_types(generator, self.options.allow_zero_width_ports_and_registers);
+        let ty = &types[choose_count(self.source, types.len())];
+        generator.choose_ref_for_type(self.source, ty)
+    }
+
+    fn materialize_block_return(
+        &mut self,
+        generator: &mut FunctionGenerator<'_>,
+        output_refs: &[NodeRef],
+    ) -> Result<NodeRef, GenerationError> {
+        if output_refs.len() == 1 {
+            return Ok(output_refs[0]);
+        }
+        let fields = output_refs
+            .iter()
+            .map(|node_ref| Box::new(generator.get_node(*node_ref).ty.clone()))
+            .collect();
+        Ok(generator.add_node(
+            Type::Tuple(fields),
+            NodePayload::Tuple(output_refs.to_vec()),
+            Some("outputs".to_string()),
+        ))
+    }
+
+    fn choose_register_next_ref(
+        &mut self,
+        generator: &FunctionGenerator<'_>,
+        register: &GeneratedRegisterState,
+    ) -> Result<NodeRef, GenerationError> {
+        let refs = generator.nodes_by_type.get(&register.ty).ok_or_else(|| {
+            GenerationError::Construction(format!(
+                "no value available for register write '{}'",
+                register.name
+            ))
+        })?;
+        let feedback_refs: Vec<NodeRef> = refs
+            .iter()
+            .copied()
+            .filter(|candidate| generator.node_depends_on(*candidate, register.read_ref))
+            .collect();
+        let choices = if !feedback_refs.is_empty()
+            && (self.source.take_u64() & 1 == 0 || feedback_refs.len() == refs.len())
+        {
+            &feedback_refs
+        } else {
+            refs
+        };
+        Ok(choices[choose_count(self.source, choices.len())])
+    }
+
+    fn maybe_choose_load_enable_ref(
+        &mut self,
+        generator: &FunctionGenerator<'_>,
+    ) -> Option<NodeRef> {
+        if !self.options.allow_load_enable || self.source.take_u64() & 1 == 0 {
+            return None;
+        }
+        generator
+            .nodes_by_type
+            .get(&Type::Bits(1))
+            .map(|refs| refs[choose_count(self.source, refs.len())])
+    }
+
+    fn populate_output_metadata(
+        &self,
+        generator: &FunctionGenerator<'_>,
+        metadata: &mut BlockMetadata,
+        output_count: usize,
+    ) {
+        metadata.output_names = if output_count == 1 {
+            vec!["out".to_string()]
+        } else {
+            (0..output_count)
+                .map(|index| format!("out{index}"))
+                .collect()
+        };
+        let mut next_id = generator
+            .nodes
+            .iter()
+            .map(|node| node.text_id)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1);
+        for name in &metadata.output_names {
+            metadata.output_port_ids.insert(name.clone(), next_id);
+            next_id = next_id.saturating_add(1);
+        }
+    }
 }
 
 struct PackageGenerator<'a, S> {
@@ -1499,6 +2118,46 @@ fn random_type<S: EntropySource>(source: &mut S, options: &RandomFnOptions, dept
     Type::Tuple(fields)
 }
 
+fn random_data_type<S: EntropySource>(
+    source: &mut S,
+    options: &RandomFnOptions,
+    depth: usize,
+) -> Type {
+    let mut data_options = options.clone();
+    data_options.allow_events = false;
+    random_type(source, &data_options, depth)
+}
+
+/// Chooses a block port/register type, falling back after bounded rejection
+/// sampling so pathological entropy cannot loop forever.
+fn random_block_interface_type<S: EntropySource>(
+    source: &mut S,
+    options: &RandomFnOptions,
+    allow_zero_width: bool,
+) -> Type {
+    const MAX_ATTEMPTS: usize = 16;
+    for _ in 0..MAX_ATTEMPTS {
+        let ty = random_data_type(source, options, 0);
+        if allow_zero_width || ty.bit_count() != 0 {
+            return ty;
+        }
+    }
+    Type::Bits(1)
+}
+
+fn type_is_block_data(ty: &Type) -> bool {
+    !ty.is_nil() && !type_contains_token(ty)
+}
+
+fn block_data_types(generator: &FunctionGenerator<'_>, allow_zero_width: bool) -> Vec<Type> {
+    generator
+        .nodes_by_type
+        .keys()
+        .filter(|ty| type_is_block_data(ty) && (allow_zero_width || ty.bit_count() != 0))
+        .cloned()
+        .collect()
+}
+
 fn type_leaf_count(ty: &Type) -> usize {
     match ty {
         Type::Token | Type::Bits(_) => 1,
@@ -1583,8 +2242,12 @@ impl<'a> FunctionGenerator<'a> {
     }
 
     fn add_param(&mut self, ty: Type) {
-        let id = ParamId::new(self.params.len() + 1);
         let name = format!("p{}", self.params.len());
+        self.add_named_param(name, ty);
+    }
+
+    fn add_named_param(&mut self, name: String, ty: Type) -> NodeRef {
+        let id = ParamId::new(self.params.len() + 1);
         let node_ref = self.add_node(
             ty.clone(),
             NodePayload::GetParam(id.clone()),
@@ -1592,6 +2255,7 @@ impl<'a> FunctionGenerator<'a> {
         );
         self.params.push(Param { name, ty, id });
         debug_assert_eq!(node_ref.index, self.params.len());
+        node_ref
     }
 
     fn add_node(&mut self, ty: Type, payload: NodePayload, name: Option<String>) -> NodeRef {
@@ -2493,6 +3157,20 @@ impl<'a> FunctionGenerator<'a> {
         &self.nodes[node_ref.index]
     }
 
+    fn node_depends_on(&self, start: NodeRef, target: NodeRef) -> bool {
+        let mut stack = vec![start];
+        let mut seen = HashSet::new();
+        while let Some(node_ref) = stack.pop() {
+            if node_ref == target {
+                return true;
+            }
+            if seen.insert(node_ref.index) {
+                stack.extend(operands(&self.nodes[node_ref.index].payload));
+            }
+        }
+        false
+    }
+
     fn token_refs(&self) -> Vec<NodeRef> {
         self.nodes_by_type
             .get(&Type::Token)
@@ -2849,6 +3527,19 @@ impl<'a> FunctionGenerator<'a> {
 }
 
 fn gather_stats(function: &Fn) -> GeneratedFnStats {
+    gather_stats_with_roots(function, |payload| is_observable_effect_root(payload))
+}
+
+fn gather_block_stats(function: &Fn) -> GeneratedFnStats {
+    gather_stats_with_roots(function, |payload| {
+        is_observable_effect_root(payload) || matches!(payload, NodePayload::RegisterWrite { .. })
+    })
+}
+
+fn gather_stats_with_roots(
+    function: &Fn,
+    is_extra_root: impl std::ops::Fn(&NodePayload) -> bool,
+) -> GeneratedFnStats {
     let mut live_indices = HashSet::new();
     let mut pending = vec![
         function
@@ -2860,7 +3551,7 @@ fn gather_stats(function: &Fn) -> GeneratedFnStats {
             .nodes
             .iter()
             .enumerate()
-            .filter(|(_, node)| is_observable_effect_root(&node.payload))
+            .filter(|(_, node)| is_extra_root(&node.payload))
             .map(|(index, _)| NodeRef { index }),
     );
     while let Some(node_ref) = pending.pop() {

--- a/xlsynth-pir/src/ir_random.rs
+++ b/xlsynth-pir/src/ir_random.rs
@@ -833,6 +833,11 @@ struct GeneratedRegisterState {
     reset_ref: Option<NodeRef>,
 }
 
+struct GeneratedRegisterWrite {
+    next_ref: NodeRef,
+    load_enable: Option<NodeRef>,
+}
+
 struct BlockGenerator<'a, S> {
     source: &'a mut S,
     options: &'a RandomBlockOptions,
@@ -885,17 +890,29 @@ impl<'a, S: EntropySource> BlockGenerator<'a, S> {
 
         let output_count = self.choose_output_count(&generator, register_count)?;
         let output_refs = self.choose_output_refs(&generator, output_count)?;
-        let ret_node_ref = self.materialize_block_return(&mut generator, &output_refs)?;
-
+        let mut register_writes = Vec::with_capacity(registers.len());
         for register in &registers {
             let next_ref = self.choose_register_next_ref(&generator, register)?;
             let load_enable = self.maybe_choose_load_enable_ref(&generator);
+            register_writes.push(GeneratedRegisterWrite {
+                next_ref,
+                load_enable,
+            });
+        }
+
+        // For zero or multiple outputs, the synthetic tuple return is omitted
+        // when the function is emitted as a block. Keep it out of the register
+        // D-value candidate set so register writes cannot reference that
+        // suppressed internal node.
+        let ret_node_ref = self.materialize_block_return(&mut generator, &output_refs)?;
+
+        for (register, write) in registers.iter().zip(register_writes) {
             generator.add_node(
                 Type::nil(),
                 NodePayload::RegisterWrite {
-                    arg: next_ref,
+                    arg: write.next_ref,
                     register: register.name.clone(),
-                    load_enable,
+                    load_enable: write.load_enable,
                     reset: register.reset_ref,
                 },
                 Some(format!("{}_d", register.name)),

--- a/xlsynth-pir/tests/ir_random.rs
+++ b/xlsynth-pir/tests/ir_random.rs
@@ -5,8 +5,8 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use rand::RngCore;
 use rand_pcg::Pcg64Mcg;
 use xlsynth_pir::ir::{
-    Binop, ExtNaryAddArchitecture, FileTable, Fn, MemberType, NaryOp, NodePayload, NodeRef,
-    Package, PackageMember, Type, Unop,
+    Binop, BlockMetadata, ExtNaryAddArchitecture, FileTable, Fn, MemberType, NaryOp, NodePayload,
+    NodeRef, Package, PackageMember, Type, Unop,
 };
 use xlsynth_pir::ir_eval::{FnEvalResult, eval_fn_in_package};
 use xlsynth_pir::ir_parser::Parser;
@@ -45,10 +45,6 @@ fn validate_generated_block_package(package: &Package) {
     assert_eq!(reparsed.to_string(), ir_text);
 }
 
-fn entropy_bytes(words: &[u64]) -> Vec<u8> {
-    words.iter().flat_map(|word| word.to_le_bytes()).collect()
-}
-
 fn node_depends_on(function: &Fn, start: NodeRef, target: NodeRef) -> bool {
     let mut pending = vec![start];
     let mut seen = HashSet::new();
@@ -71,6 +67,44 @@ fn block_output_types<'a>(function: &'a Fn, output_count: usize) -> Vec<&'a Type
         panic!("multi-output generated block should return a tuple");
     };
     fields.iter().map(|field| &**field).collect()
+}
+
+fn assert_generated_block_register_wiring(function: &Fn, metadata: &BlockMetadata) {
+    assert_eq!(
+        metadata.clock_port_name.is_some(),
+        !metadata.registers.is_empty()
+    );
+    for register in &metadata.registers {
+        let read_count = function
+            .nodes
+            .iter()
+            .filter(|node| {
+                matches!(
+                    &node.payload,
+                    NodePayload::RegisterRead { register: read_register }
+                        if read_register == &register.name
+                )
+            })
+            .count();
+        let writes: Vec<_> = function
+            .nodes
+            .iter()
+            .filter_map(|node| match &node.payload {
+                NodePayload::RegisterWrite {
+                    arg,
+                    register: write_register,
+                    reset,
+                    ..
+                } if write_register == &register.name => Some((*arg, *reset)),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(read_count, 1);
+        assert_eq!(writes.len(), 1);
+        assert_eq!(function.get_node(writes[0].0).ty, register.ty);
+        assert_eq!(writes[0].1.is_some(), register.reset_value.is_some());
+    }
 }
 
 fn type_has_array(ty: &Type) -> bool {
@@ -316,178 +350,6 @@ fn depleted_entropy_constructs_a_minimal_deterministic_block() {
 }
 
 #[test]
-fn random_registered_block_generation_writes_every_register_with_reset_mix() {
-    let options = RandomBlockOptions {
-        min_input_ports: 0,
-        max_input_ports: 0,
-        min_registers: 2,
-        max_registers: 2,
-        min_output_ports: 1,
-        max_output_ports: 1,
-        allow_load_enable: false,
-        function_options: RandomFnOptions {
-            max_nodes: 10,
-            max_bit_width: 8,
-            ..RandomFnOptions::default()
-        },
-        ..RandomBlockOptions::default()
-    };
-    let entropy_words = [
-        1_u64, // Add a reset port.
-        0,     // Synchronous reset.
-        0,     // Active-high reset.
-        1,     // Reset r0.
-        0,     // Leave r1 unreset.
-        0,     // Make r0 bits-typed.
-        1,     // r0 width.
-        0,     // r0 reset value.
-        0,     // Make r1 bits-typed.
-        1,     // r1 width.
-    ];
-    let entropy_bytes = entropy_bytes(&entropy_words);
-    let mut entropy = DepletableBytes::new(&entropy_bytes);
-    let generated =
-        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
-
-    validate_generated_block_package(&generated.package);
-    let PackageMember::Block { func, metadata } = generated.package.get_top_block().unwrap() else {
-        unreachable!("generated package top should be a block");
-    };
-    assert_eq!(metadata.clock_port_name.as_deref(), Some("clk"));
-    assert!(metadata.reset.is_some());
-    assert_eq!(metadata.registers.len(), 2);
-    let reset_count = metadata
-        .registers
-        .iter()
-        .filter(|register| register.reset_value.is_some())
-        .count();
-    assert_eq!(reset_count, 1);
-
-    for register in &metadata.registers {
-        let read_count = func
-            .nodes
-            .iter()
-            .filter(|node| {
-                matches!(
-                    &node.payload,
-                    NodePayload::RegisterRead { register: read_register }
-                        if read_register == &register.name
-                )
-            })
-            .count();
-        let writes: Vec<_> = func
-            .nodes
-            .iter()
-            .filter_map(|node| match &node.payload {
-                NodePayload::RegisterWrite {
-                    arg,
-                    register: write_register,
-                    reset,
-                    ..
-                } if write_register == &register.name => Some((*arg, *reset)),
-                _ => None,
-            })
-            .collect();
-
-        assert_eq!(read_count, 1);
-        assert_eq!(writes.len(), 1);
-        assert_eq!(func.get_node(writes[0].0).ty, register.ty);
-        assert_eq!(writes[0].1.is_some(), register.reset_value.is_some());
-    }
-}
-
-#[test]
-fn single_register_block_can_keep_an_unused_reset_port() {
-    let options = RandomBlockOptions {
-        min_input_ports: 0,
-        max_input_ports: 0,
-        min_registers: 1,
-        max_registers: 1,
-        min_output_ports: 1,
-        max_output_ports: 1,
-        allow_load_enable: false,
-        function_options: RandomFnOptions {
-            max_nodes: 4,
-            max_bit_width: 8,
-            ..RandomFnOptions::default()
-        },
-        ..RandomBlockOptions::default()
-    };
-    let entropy_words = [
-        1_u64, // Add a reset port.
-        0,     // Synchronous reset.
-        0,     // Active-high reset.
-        0,     // Leave the only register unreset.
-        0,     // Make the register bits-typed.
-        0,     // Register width.
-    ];
-    let entropy_bytes = entropy_bytes(&entropy_words);
-    let mut entropy = DepletableBytes::new(&entropy_bytes);
-    let generated =
-        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
-
-    validate_generated_block_package(&generated.package);
-    let PackageMember::Block { func, metadata } = generated.package.get_top_block().unwrap() else {
-        unreachable!("generated package top should be a block");
-    };
-    assert!(metadata.reset.is_some());
-    assert_eq!(metadata.registers.len(), 1);
-    assert!(metadata.registers[0].reset_value.is_none());
-    let write_reset = func
-        .nodes
-        .iter()
-        .find_map(|node| match &node.payload {
-            NodePayload::RegisterWrite { reset, .. } => Some(*reset),
-            _ => None,
-        })
-        .unwrap();
-    assert!(write_reset.is_none());
-}
-
-#[test]
-fn registered_block_generation_can_add_load_enable() {
-    let options = RandomBlockOptions {
-        min_input_ports: 0,
-        max_input_ports: 0,
-        min_registers: 1,
-        max_registers: 1,
-        min_output_ports: 1,
-        max_output_ports: 1,
-        allow_reset: false,
-        function_options: RandomFnOptions {
-            max_nodes: 4,
-            max_bit_width: 8,
-            ..RandomFnOptions::default()
-        },
-        ..RandomBlockOptions::default()
-    };
-    let entropy_words = [
-        0_u64, // Make the register bits-typed.
-        0,     // Register width bits[1].
-        0,     // Prefer the feedback candidate.
-        1,     // Add a load-enable.
-    ];
-    let entropy_bytes = entropy_bytes(&entropy_words);
-    let mut entropy = DepletableBytes::new(&entropy_bytes);
-    let generated =
-        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
-
-    validate_generated_block_package(&generated.package);
-    let PackageMember::Block { func, .. } = generated.package.get_top_block().unwrap() else {
-        unreachable!("generated package top should be a block");
-    };
-    let load_enable = func
-        .nodes
-        .iter()
-        .find_map(|node| match &node.payload {
-            NodePayload::RegisterWrite { load_enable, .. } => *load_enable,
-            _ => None,
-        })
-        .unwrap();
-    assert_eq!(func.get_node(load_enable).ty, Type::Bits(1));
-}
-
-#[test]
 fn generated_block_populates_multi_output_metadata() {
     let options = RandomBlockOptions {
         min_input_ports: 1,
@@ -502,109 +364,41 @@ fn generated_block_populates_multi_output_metadata() {
         },
         ..RandomBlockOptions::default()
     };
-    let mut entropy = DepletableBytes::new(&[]);
-    let generated =
-        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
-
-    validate_generated_block_package(&generated.package);
-    let PackageMember::Block { func, metadata } = generated.package.get_top_block().unwrap() else {
-        unreachable!("generated package top should be a block");
-    };
-    assert_eq!(
-        metadata.output_names,
-        vec!["out0".to_string(), "out1".to_string(), "out2".to_string()]
-    );
-    assert_eq!(metadata.output_port_ids.len(), 3);
-    assert_eq!(
-        metadata
-            .output_port_ids
-            .values()
-            .collect::<HashSet<_>>()
-            .len(),
-        3
-    );
-    let ret_ref = func.ret_node_ref.unwrap();
-    assert!(matches!(
-        &func.get_node(ret_ref).payload,
-        NodePayload::Tuple(outputs) if outputs.len() == 3
-    ));
-}
-
-#[test]
-fn registered_block_generation_supports_aggregate_registers() {
-    let options = RandomBlockOptions {
-        min_input_ports: 0,
-        max_input_ports: 0,
-        min_registers: 1,
-        max_registers: 1,
-        min_output_ports: 1,
-        max_output_ports: 1,
-        allow_load_enable: false,
-        function_options: RandomFnOptions {
-            max_nodes: 4,
-            max_bit_width: 8,
-            ..RandomFnOptions::default()
-        },
-        ..RandomBlockOptions::default()
-    };
-    let entropy_words = [
-        1_u64, // Add a reset port.
-        0,     // Synchronous reset.
-        0,     // Active-high reset.
-        1,     // Reset the register.
-        2,     // Make the register tuple-typed.
-        2,     // Give the tuple two fields.
-        0,     // Make field 0 bits-typed.
-        0,     // Field 0 width.
-        0,     // Make field 1 bits-typed.
-        0,     // Field 1 width.
-        0,     // Field 0 reset value.
-        0,     // Field 1 reset value.
-    ];
-    let entropy_bytes = entropy_bytes(&entropy_words);
-    let mut entropy = DepletableBytes::new(&entropy_bytes);
-    let generated =
-        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
-
-    validate_generated_block_package(&generated.package);
-    let PackageMember::Block { func, metadata } = generated.package.get_top_block().unwrap() else {
-        unreachable!("generated package top should be a block");
-    };
-    let register = &metadata.registers[0];
-    assert!(matches!(&register.ty, Type::Tuple(fields) if fields.len() == 2));
-    assert!(register.reset_value.is_some());
-    let write_arg = func
-        .nodes
-        .iter()
-        .find_map(|node| match &node.payload {
-            NodePayload::RegisterWrite { arg, .. } => Some(*arg),
-            _ => None,
-        })
-        .unwrap();
-    assert_eq!(func.get_node(write_arg).ty, register.ty);
+    let mut entropy = RngEntropy::new(Pcg64Mcg::new(0x0d70_0003));
+    for _ in 0..128 {
+        let generated =
+            generate_block(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+        let func = &generated.function;
+        let metadata = &generated.metadata;
+        assert_eq!(
+            metadata.output_names,
+            vec!["out0".to_string(), "out1".to_string(), "out2".to_string()]
+        );
+        assert_eq!(metadata.output_port_ids.len(), 3);
+        assert_eq!(
+            metadata
+                .output_port_ids
+                .values()
+                .collect::<HashSet<_>>()
+                .len(),
+            3
+        );
+        let ret_ref = func.ret_node_ref.unwrap();
+        assert!(matches!(
+            &func.get_node(ret_ref).payload,
+            NodePayload::Tuple(outputs) if outputs.len() == 3
+        ));
+    }
 }
 
 #[test]
 fn random_block_reset_timing_option_controls_generated_metadata() {
-    let cases: [(RandomBlockResetTiming, bool, &[u64]); 4] = [
-        (
-            RandomBlockResetTiming::Synchronous,
-            false,
-            &[1, 0, 1, 0, 0, 0],
-        ),
-        (
-            RandomBlockResetTiming::Asynchronous,
-            true,
-            &[1, 0, 1, 0, 0, 0],
-        ),
-        (
-            RandomBlockResetTiming::Either,
-            false,
-            &[1, 0, 0, 1, 0, 0, 0],
-        ),
-        (RandomBlockResetTiming::Either, true, &[1, 1, 0, 1, 0, 0, 0]),
+    let cases = [
+        (RandomBlockResetTiming::Synchronous, 0x51ac_0001),
+        (RandomBlockResetTiming::Asynchronous, 0x51ac_0002),
+        (RandomBlockResetTiming::Either, 0x51ac_0003),
     ];
-    for (reset_timing, expected_asynchronous, entropy_words) in cases {
+    for (reset_timing, seed) in cases {
         let options = RandomBlockOptions {
             min_input_ports: 0,
             max_input_ports: 0,
@@ -621,66 +415,83 @@ fn random_block_reset_timing_option_controls_generated_metadata() {
             },
             ..RandomBlockOptions::default()
         };
-        let entropy_bytes = entropy_bytes(entropy_words);
-        let mut entropy = DepletableBytes::new(&entropy_bytes);
-        let generated =
-            generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
-
-        validate_generated_block_package(&generated.package);
-        let PackageMember::Block { metadata, .. } = generated.package.get_top_block().unwrap()
-        else {
-            unreachable!("generated package top should be a block");
-        };
-        assert_eq!(
-            metadata.reset.as_ref().unwrap().asynchronous,
-            expected_asynchronous
-        );
+        let mut entropy = RngEntropy::new(Pcg64Mcg::new(seed));
+        let mut saw_reset = false;
+        let mut saw_synchronous = false;
+        let mut saw_asynchronous = false;
+        for _ in 0..256 {
+            let generated =
+                generate_block(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+            let Some(reset) = generated.metadata.reset.as_ref() else {
+                continue;
+            };
+            saw_reset = true;
+            saw_synchronous |= !reset.asynchronous;
+            saw_asynchronous |= reset.asynchronous;
+            match reset_timing {
+                RandomBlockResetTiming::Synchronous => assert!(!reset.asynchronous),
+                RandomBlockResetTiming::Asynchronous => assert!(reset.asynchronous),
+                RandomBlockResetTiming::Either => {}
+            }
+        }
+        assert!(saw_reset);
+        if reset_timing == RandomBlockResetTiming::Either {
+            assert!(saw_synchronous);
+            assert!(saw_asynchronous);
+        }
     }
 }
 
 #[test]
-fn block_generation_can_opt_into_zero_width_compound_interface_types() {
-    let options = RandomBlockOptions {
-        min_input_ports: 1,
-        max_input_ports: 1,
-        min_output_ports: 0,
-        max_output_ports: 0,
-        min_registers: 1,
-        max_registers: 1,
-        allow_zero_width_ports_and_registers: true,
-        allow_load_enable: false,
-        allow_reset: false,
-        function_options: RandomFnOptions {
-            max_params: 1,
-            max_nodes: 4,
-            ..RandomFnOptions::default()
-        },
-        ..RandomBlockOptions::default()
-    };
-    let entropy_words = [
-        1_u64, // Make the input array-typed.
-        2,     // Make its element tuple-typed.
-        0,     // Give the tuple no fields.
-        0,     // Give the array one element.
-        1,     // Make the register array-typed.
-        2,     // Make its element tuple-typed.
-        0,     // Give the tuple no fields.
-        0,     // Give the array one element.
-        0,     // Use the input as the register write argument.
-    ];
-    let entropy_bytes = entropy_bytes(&entropy_words);
-    let mut entropy = DepletableBytes::new(&entropy_bytes);
-    let generated =
-        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
-
-    validate_generated_block_package(&generated.package);
-    let PackageMember::Block { func, metadata } = generated.package.get_top_block().unwrap() else {
-        unreachable!("generated package top should be a block");
-    };
-    assert!(matches!(&func.params[0].ty, Type::Array(_)));
-    assert_eq!(func.params[0].ty.bit_count(), 0);
-    assert!(matches!(&metadata.registers[0].ty, Type::Array(_)));
-    assert_eq!(metadata.registers[0].ty.bit_count(), 0);
+fn random_block_zero_width_interface_option_controls_samples() {
+    let cases = [(false, 0x20f7_0001), (true, 0x20f7_0002)];
+    for (allow_zero_width, seed) in cases {
+        let options = RandomBlockOptions {
+            min_input_ports: 1,
+            max_input_ports: 1,
+            min_output_ports: 0,
+            max_output_ports: 1,
+            min_registers: 1,
+            max_registers: 1,
+            allow_zero_width_ports_and_registers: allow_zero_width,
+            allow_load_enable: false,
+            allow_reset: false,
+            function_options: RandomFnOptions {
+                max_params: 1,
+                max_nodes: 8,
+                ..RandomFnOptions::default()
+            },
+            ..RandomBlockOptions::default()
+        };
+        let mut entropy = RngEntropy::new(Pcg64Mcg::new(seed));
+        let mut saw_zero_width = false;
+        let mut saw_zero_width_compound = false;
+        for _ in 0..1_024 {
+            let generated =
+                generate_block(&mut entropy, &options, StopPolicy::ExactBodyNodes(4)).unwrap();
+            let function = &generated.function;
+            let metadata = &generated.metadata;
+            let output_types = block_output_types(function, metadata.output_names.len());
+            for ty in function
+                .params
+                .iter()
+                .map(|param| &param.ty)
+                .chain(metadata.registers.iter().map(|register| &register.ty))
+                .chain(output_types.iter().copied())
+            {
+                if allow_zero_width {
+                    saw_zero_width |= ty.bit_count() == 0;
+                    saw_zero_width_compound |= ty.bit_count() == 0 && type_has_array(ty);
+                } else {
+                    assert_ne!(ty.bit_count(), 0);
+                }
+            }
+        }
+        if allow_zero_width {
+            assert!(saw_zero_width);
+            assert!(saw_zero_width_compound);
+        }
+    }
 }
 
 #[test]
@@ -695,6 +506,7 @@ fn probabilistic_default_block_generation_covers_shapes_state_and_types() {
     let mut saw_no_load_enable = false;
     let mut saw_reset_register = false;
     let mut saw_nonreset_register = false;
+    let mut saw_unused_reset_port = false;
     let mut saw_synchronous_reset = false;
     let mut saw_asynchronous_reset = false;
     let mut saw_min_inputs = false;
@@ -737,11 +549,24 @@ fn probabilistic_default_block_generation_covers_shapes_state_and_types() {
             .registers
             .iter()
             .any(|register| register.reset_value.is_none());
+        saw_unused_reset_port |= metadata.reset.is_some()
+            && metadata.registers.len() == 1
+            && metadata.registers[0].reset_value.is_none();
         if let Some(reset) = metadata.reset.as_ref() {
             saw_synchronous_reset |= !reset.asynchronous;
             saw_asynchronous_reset |= reset.asynchronous;
+            if metadata.registers.len() > 1 {
+                let reset_count = metadata
+                    .registers
+                    .iter()
+                    .filter(|register| register.reset_value.is_some())
+                    .count();
+                assert!(reset_count > 0);
+                assert!(reset_count < metadata.registers.len());
+            }
         }
 
+        assert_generated_block_register_wiring(function, metadata);
         let output_types = block_output_types(function, output_count);
         assert!(
             function
@@ -792,6 +617,9 @@ fn probabilistic_default_block_generation_covers_shapes_state_and_types() {
             };
             saw_load_enable |= load_enable.is_some();
             saw_no_load_enable |= load_enable.is_none();
+            if let Some(load_enable_ref) = load_enable {
+                assert_eq!(function.get_node(*load_enable_ref).ty, Type::Bits(1));
+            }
             let read_ref = register_reads[register.as_str()];
             if node_depends_on(function, *arg, read_ref) {
                 saw_feedback = true;
@@ -814,6 +642,7 @@ fn probabilistic_default_block_generation_covers_shapes_state_and_types() {
     assert!(saw_no_load_enable);
     assert!(saw_reset_register);
     assert!(saw_nonreset_register);
+    assert!(saw_unused_reset_port);
     assert!(saw_synchronous_reset);
     assert!(saw_asynchronous_reset);
     assert!(saw_min_inputs);

--- a/xlsynth-pir/tests/ir_random.rs
+++ b/xlsynth-pir/tests/ir_random.rs
@@ -5,15 +5,18 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use rand::RngCore;
 use rand_pcg::Pcg64Mcg;
 use xlsynth_pir::ir::{
-    Binop, ExtNaryAddArchitecture, FileTable, MemberType, NaryOp, NodePayload, Package,
-    PackageMember, Type, Unop,
+    Binop, ExtNaryAddArchitecture, FileTable, Fn, MemberType, NaryOp, NodePayload, NodeRef,
+    Package, PackageMember, Type, Unop,
 };
 use xlsynth_pir::ir_eval::{FnEvalResult, eval_fn_in_package};
+use xlsynth_pir::ir_parser::Parser;
 use xlsynth_pir::ir_random::{
-    DepletableBytes, FunctionSignature, GenerationError, OperationSet, RandomFnOptions,
-    RandomOperation, RngEntropy, StopPolicy, generate_fn, generate_fn_with_signature,
+    DepletableBytes, FunctionSignature, GenerationError, OperationSet, RandomBlockOptions,
+    RandomBlockResetTiming, RandomFnOptions, RandomOperation, RngEntropy, StopPolicy,
+    generate_block, generate_block_package, generate_fn, generate_fn_with_signature,
     generate_package, generate_same_signature_pair,
 };
+use xlsynth_pir::ir_utils::operands;
 use xlsynth_pir::ir_verify::verify_package;
 use xlsynth_pir::random_inputs::{
     generate_argument_sets_from_seed, generate_biased_arguments, generate_biased_value,
@@ -29,6 +32,45 @@ fn validate_generated(function: &xlsynth_pir::ir::Fn) {
         top: Some((function.name.clone(), MemberType::Function)),
     };
     verify_package(&package).unwrap();
+}
+
+fn validate_generated_block_package(package: &Package) {
+    verify_package(package).unwrap();
+    let ir_text = package.to_string();
+    let reparsed = Parser::new(&ir_text)
+        .parse_and_validate_package()
+        .unwrap_or_else(|error| {
+            panic!("generated block package failed roundtrip:\n{ir_text}\n{error:?}")
+        });
+    assert_eq!(reparsed.to_string(), ir_text);
+}
+
+fn entropy_bytes(words: &[u64]) -> Vec<u8> {
+    words.iter().flat_map(|word| word.to_le_bytes()).collect()
+}
+
+fn node_depends_on(function: &Fn, start: NodeRef, target: NodeRef) -> bool {
+    let mut pending = vec![start];
+    let mut seen = HashSet::new();
+    while let Some(node_ref) = pending.pop() {
+        if node_ref == target {
+            return true;
+        }
+        if seen.insert(node_ref.index) {
+            pending.extend(operands(&function.get_node(node_ref).payload));
+        }
+    }
+    false
+}
+
+fn block_output_types<'a>(function: &'a Fn, output_count: usize) -> Vec<&'a Type> {
+    if output_count == 1 {
+        return vec![&function.ret_ty];
+    }
+    let Type::Tuple(fields) = &function.ret_ty else {
+        panic!("multi-output generated block should return a tuple");
+    };
+    fields.iter().map(|field| &**field).collect()
 }
 
 fn type_has_array(ty: &Type) -> bool {
@@ -229,6 +271,617 @@ fn depleted_entropy_constructs_a_minimal_deterministic_function() {
         second.function.nodes[1].ty.to_string()
     );
     assert_eq!(first.stats, second.stats);
+}
+
+#[test]
+fn depleted_entropy_constructs_a_minimal_deterministic_block() {
+    let options = RandomBlockOptions {
+        max_input_ports: 0,
+        max_output_ports: 0,
+        max_registers: 0,
+        function_options: RandomFnOptions {
+            max_nodes: 1,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    };
+    let mut first_source = DepletableBytes::new(&[]);
+    let mut second_source = DepletableBytes::new(&[]);
+    let first =
+        generate_block_package(&mut first_source, &options, StopPolicy::WhenEntropyDepleted)
+            .unwrap();
+    let second = generate_block_package(
+        &mut second_source,
+        &options,
+        StopPolicy::WhenEntropyDepleted,
+    )
+    .unwrap();
+
+    validate_generated_block_package(&first.package);
+    validate_generated_block_package(&second.package);
+    assert_eq!(first.package.to_string(), second.package.to_string());
+    let PackageMember::Block { metadata, .. } = first.package.get_top_block().unwrap() else {
+        unreachable!("generated package top should be a block");
+    };
+    assert!(metadata.registers.is_empty());
+    assert!(metadata.output_names.is_empty());
+    let PackageMember::Block { func, .. } = first.package.get_top_block().unwrap() else {
+        unreachable!("generated package top should be a block");
+    };
+    let ret_ref = func.ret_node_ref.unwrap();
+    assert!(matches!(
+        &func.get_node(ret_ref).payload,
+        NodePayload::Tuple(outputs) if outputs.is_empty()
+    ));
+}
+
+#[test]
+fn random_registered_block_generation_writes_every_register_with_reset_mix() {
+    let options = RandomBlockOptions {
+        min_input_ports: 0,
+        max_input_ports: 0,
+        min_registers: 2,
+        max_registers: 2,
+        min_output_ports: 1,
+        max_output_ports: 1,
+        allow_load_enable: false,
+        function_options: RandomFnOptions {
+            max_nodes: 10,
+            max_bit_width: 8,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    };
+    let entropy_words = [
+        1_u64, // Add a reset port.
+        0,     // Synchronous reset.
+        0,     // Active-high reset.
+        1,     // Reset r0.
+        0,     // Leave r1 unreset.
+        0,     // Make r0 bits-typed.
+        1,     // r0 width.
+        0,     // r0 reset value.
+        0,     // Make r1 bits-typed.
+        1,     // r1 width.
+    ];
+    let entropy_bytes = entropy_bytes(&entropy_words);
+    let mut entropy = DepletableBytes::new(&entropy_bytes);
+    let generated =
+        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+
+    validate_generated_block_package(&generated.package);
+    let PackageMember::Block { func, metadata } = generated.package.get_top_block().unwrap() else {
+        unreachable!("generated package top should be a block");
+    };
+    assert_eq!(metadata.clock_port_name.as_deref(), Some("clk"));
+    assert!(metadata.reset.is_some());
+    assert_eq!(metadata.registers.len(), 2);
+    let reset_count = metadata
+        .registers
+        .iter()
+        .filter(|register| register.reset_value.is_some())
+        .count();
+    assert_eq!(reset_count, 1);
+
+    for register in &metadata.registers {
+        let read_count = func
+            .nodes
+            .iter()
+            .filter(|node| {
+                matches!(
+                    &node.payload,
+                    NodePayload::RegisterRead { register: read_register }
+                        if read_register == &register.name
+                )
+            })
+            .count();
+        let writes: Vec<_> = func
+            .nodes
+            .iter()
+            .filter_map(|node| match &node.payload {
+                NodePayload::RegisterWrite {
+                    arg,
+                    register: write_register,
+                    reset,
+                    ..
+                } if write_register == &register.name => Some((*arg, *reset)),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(read_count, 1);
+        assert_eq!(writes.len(), 1);
+        assert_eq!(func.get_node(writes[0].0).ty, register.ty);
+        assert_eq!(writes[0].1.is_some(), register.reset_value.is_some());
+    }
+}
+
+#[test]
+fn single_register_block_can_keep_an_unused_reset_port() {
+    let options = RandomBlockOptions {
+        min_input_ports: 0,
+        max_input_ports: 0,
+        min_registers: 1,
+        max_registers: 1,
+        min_output_ports: 1,
+        max_output_ports: 1,
+        allow_load_enable: false,
+        function_options: RandomFnOptions {
+            max_nodes: 4,
+            max_bit_width: 8,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    };
+    let entropy_words = [
+        1_u64, // Add a reset port.
+        0,     // Synchronous reset.
+        0,     // Active-high reset.
+        0,     // Leave the only register unreset.
+        0,     // Make the register bits-typed.
+        0,     // Register width.
+    ];
+    let entropy_bytes = entropy_bytes(&entropy_words);
+    let mut entropy = DepletableBytes::new(&entropy_bytes);
+    let generated =
+        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+
+    validate_generated_block_package(&generated.package);
+    let PackageMember::Block { func, metadata } = generated.package.get_top_block().unwrap() else {
+        unreachable!("generated package top should be a block");
+    };
+    assert!(metadata.reset.is_some());
+    assert_eq!(metadata.registers.len(), 1);
+    assert!(metadata.registers[0].reset_value.is_none());
+    let write_reset = func
+        .nodes
+        .iter()
+        .find_map(|node| match &node.payload {
+            NodePayload::RegisterWrite { reset, .. } => Some(*reset),
+            _ => None,
+        })
+        .unwrap();
+    assert!(write_reset.is_none());
+}
+
+#[test]
+fn registered_block_generation_can_add_load_enable() {
+    let options = RandomBlockOptions {
+        min_input_ports: 0,
+        max_input_ports: 0,
+        min_registers: 1,
+        max_registers: 1,
+        min_output_ports: 1,
+        max_output_ports: 1,
+        allow_reset: false,
+        function_options: RandomFnOptions {
+            max_nodes: 4,
+            max_bit_width: 8,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    };
+    let entropy_words = [
+        0_u64, // Make the register bits-typed.
+        0,     // Register width bits[1].
+        0,     // Prefer the feedback candidate.
+        1,     // Add a load-enable.
+    ];
+    let entropy_bytes = entropy_bytes(&entropy_words);
+    let mut entropy = DepletableBytes::new(&entropy_bytes);
+    let generated =
+        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+
+    validate_generated_block_package(&generated.package);
+    let PackageMember::Block { func, .. } = generated.package.get_top_block().unwrap() else {
+        unreachable!("generated package top should be a block");
+    };
+    let load_enable = func
+        .nodes
+        .iter()
+        .find_map(|node| match &node.payload {
+            NodePayload::RegisterWrite { load_enable, .. } => *load_enable,
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(func.get_node(load_enable).ty, Type::Bits(1));
+}
+
+#[test]
+fn generated_block_populates_multi_output_metadata() {
+    let options = RandomBlockOptions {
+        min_input_ports: 1,
+        max_input_ports: 1,
+        min_output_ports: 3,
+        max_output_ports: 3,
+        max_registers: 0,
+        function_options: RandomFnOptions {
+            max_nodes: 3,
+            max_bit_width: 8,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    };
+    let mut entropy = DepletableBytes::new(&[]);
+    let generated =
+        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+
+    validate_generated_block_package(&generated.package);
+    let PackageMember::Block { func, metadata } = generated.package.get_top_block().unwrap() else {
+        unreachable!("generated package top should be a block");
+    };
+    assert_eq!(
+        metadata.output_names,
+        vec!["out0".to_string(), "out1".to_string(), "out2".to_string()]
+    );
+    assert_eq!(metadata.output_port_ids.len(), 3);
+    assert_eq!(
+        metadata
+            .output_port_ids
+            .values()
+            .collect::<HashSet<_>>()
+            .len(),
+        3
+    );
+    let ret_ref = func.ret_node_ref.unwrap();
+    assert!(matches!(
+        &func.get_node(ret_ref).payload,
+        NodePayload::Tuple(outputs) if outputs.len() == 3
+    ));
+}
+
+#[test]
+fn registered_block_generation_supports_aggregate_registers() {
+    let options = RandomBlockOptions {
+        min_input_ports: 0,
+        max_input_ports: 0,
+        min_registers: 1,
+        max_registers: 1,
+        min_output_ports: 1,
+        max_output_ports: 1,
+        allow_load_enable: false,
+        function_options: RandomFnOptions {
+            max_nodes: 4,
+            max_bit_width: 8,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    };
+    let entropy_words = [
+        1_u64, // Add a reset port.
+        0,     // Synchronous reset.
+        0,     // Active-high reset.
+        1,     // Reset the register.
+        2,     // Make the register tuple-typed.
+        2,     // Give the tuple two fields.
+        0,     // Make field 0 bits-typed.
+        0,     // Field 0 width.
+        0,     // Make field 1 bits-typed.
+        0,     // Field 1 width.
+        0,     // Field 0 reset value.
+        0,     // Field 1 reset value.
+    ];
+    let entropy_bytes = entropy_bytes(&entropy_words);
+    let mut entropy = DepletableBytes::new(&entropy_bytes);
+    let generated =
+        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+
+    validate_generated_block_package(&generated.package);
+    let PackageMember::Block { func, metadata } = generated.package.get_top_block().unwrap() else {
+        unreachable!("generated package top should be a block");
+    };
+    let register = &metadata.registers[0];
+    assert!(matches!(&register.ty, Type::Tuple(fields) if fields.len() == 2));
+    assert!(register.reset_value.is_some());
+    let write_arg = func
+        .nodes
+        .iter()
+        .find_map(|node| match &node.payload {
+            NodePayload::RegisterWrite { arg, .. } => Some(*arg),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(func.get_node(write_arg).ty, register.ty);
+}
+
+#[test]
+fn random_block_reset_timing_option_controls_generated_metadata() {
+    let cases: [(RandomBlockResetTiming, bool, &[u64]); 4] = [
+        (
+            RandomBlockResetTiming::Synchronous,
+            false,
+            &[1, 0, 1, 0, 0, 0],
+        ),
+        (
+            RandomBlockResetTiming::Asynchronous,
+            true,
+            &[1, 0, 1, 0, 0, 0],
+        ),
+        (
+            RandomBlockResetTiming::Either,
+            false,
+            &[1, 0, 0, 1, 0, 0, 0],
+        ),
+        (RandomBlockResetTiming::Either, true, &[1, 1, 0, 1, 0, 0, 0]),
+    ];
+    for (reset_timing, expected_asynchronous, entropy_words) in cases {
+        let options = RandomBlockOptions {
+            min_input_ports: 0,
+            max_input_ports: 0,
+            min_registers: 1,
+            max_registers: 1,
+            min_output_ports: 1,
+            max_output_ports: 1,
+            allow_load_enable: false,
+            reset_timing,
+            function_options: RandomFnOptions {
+                max_nodes: 4,
+                max_bit_width: 8,
+                ..RandomFnOptions::default()
+            },
+            ..RandomBlockOptions::default()
+        };
+        let entropy_bytes = entropy_bytes(entropy_words);
+        let mut entropy = DepletableBytes::new(&entropy_bytes);
+        let generated =
+            generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+
+        validate_generated_block_package(&generated.package);
+        let PackageMember::Block { metadata, .. } = generated.package.get_top_block().unwrap()
+        else {
+            unreachable!("generated package top should be a block");
+        };
+        assert_eq!(
+            metadata.reset.as_ref().unwrap().asynchronous,
+            expected_asynchronous
+        );
+    }
+}
+
+#[test]
+fn block_generation_can_opt_into_zero_width_compound_interface_types() {
+    let options = RandomBlockOptions {
+        min_input_ports: 1,
+        max_input_ports: 1,
+        min_output_ports: 0,
+        max_output_ports: 0,
+        min_registers: 1,
+        max_registers: 1,
+        allow_zero_width_ports_and_registers: true,
+        allow_load_enable: false,
+        allow_reset: false,
+        function_options: RandomFnOptions {
+            max_params: 1,
+            max_nodes: 4,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    };
+    let entropy_words = [
+        1_u64, // Make the input array-typed.
+        2,     // Make its element tuple-typed.
+        0,     // Give the tuple no fields.
+        0,     // Give the array one element.
+        1,     // Make the register array-typed.
+        2,     // Make its element tuple-typed.
+        0,     // Give the tuple no fields.
+        0,     // Give the array one element.
+        0,     // Use the input as the register write argument.
+    ];
+    let entropy_bytes = entropy_bytes(&entropy_words);
+    let mut entropy = DepletableBytes::new(&entropy_bytes);
+    let generated =
+        generate_block_package(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+
+    validate_generated_block_package(&generated.package);
+    let PackageMember::Block { func, metadata } = generated.package.get_top_block().unwrap() else {
+        unreachable!("generated package top should be a block");
+    };
+    assert!(matches!(&func.params[0].ty, Type::Array(_)));
+    assert_eq!(func.params[0].ty.bit_count(), 0);
+    assert!(matches!(&metadata.registers[0].ty, Type::Array(_)));
+    assert_eq!(metadata.registers[0].ty.bit_count(), 0);
+}
+
+#[test]
+fn probabilistic_default_block_generation_covers_shapes_state_and_types() {
+    let options = RandomBlockOptions::default();
+    let mut entropy = RngEntropy::new(Pcg64Mcg::new(0xb10c_5eed));
+    let mut saw_zero_registers = false;
+    let mut saw_max_registers = false;
+    let mut saw_feedback = false;
+    let mut saw_no_feedback = false;
+    let mut saw_load_enable = false;
+    let mut saw_no_load_enable = false;
+    let mut saw_reset_register = false;
+    let mut saw_nonreset_register = false;
+    let mut saw_synchronous_reset = false;
+    let mut saw_asynchronous_reset = false;
+    let mut saw_min_inputs = false;
+    let mut saw_max_inputs = false;
+    let mut saw_min_outputs = false;
+    let mut saw_max_outputs = false;
+    let mut saw_tuple_register = false;
+    let mut saw_array_register = false;
+    let mut saw_tuple_port = false;
+    let mut saw_array_port = false;
+
+    for _ in 0..2_000 {
+        let generated =
+            generate_block(&mut entropy, &options, StopPolicy::ExactBodyNodes(20)).unwrap();
+        let function = &generated.function;
+        let metadata = &generated.metadata;
+        let reset_port_count = usize::from(metadata.reset.is_some());
+        let data_input_count = function.params.len() - reset_port_count;
+        let output_count = metadata.output_names.len();
+
+        saw_zero_registers |= metadata.registers.is_empty();
+        saw_max_registers |= metadata.registers.len() == options.max_registers;
+        saw_min_inputs |= data_input_count == options.min_input_ports;
+        saw_max_inputs |= data_input_count == options.max_input_ports;
+        saw_min_outputs |= output_count == options.min_output_ports;
+        saw_max_outputs |= output_count == options.max_output_ports;
+        saw_tuple_register |= metadata
+            .registers
+            .iter()
+            .any(|register| type_has_tuple(&register.ty));
+        saw_array_register |= metadata
+            .registers
+            .iter()
+            .any(|register| type_has_array(&register.ty));
+        saw_reset_register |= metadata
+            .registers
+            .iter()
+            .any(|register| register.reset_value.is_some());
+        saw_nonreset_register |= metadata
+            .registers
+            .iter()
+            .any(|register| register.reset_value.is_none());
+        if let Some(reset) = metadata.reset.as_ref() {
+            saw_synchronous_reset |= !reset.asynchronous;
+            saw_asynchronous_reset |= reset.asynchronous;
+        }
+
+        let output_types = block_output_types(function, output_count);
+        assert!(
+            function
+                .params
+                .iter()
+                .all(|param| param.ty.bit_count() != 0)
+        );
+        assert!(output_types.iter().all(|ty| ty.bit_count() != 0));
+        assert!(
+            metadata
+                .registers
+                .iter()
+                .all(|register| register.ty.bit_count() != 0)
+        );
+        saw_tuple_port |= function
+            .params
+            .iter()
+            .map(|param| &param.ty)
+            .chain(output_types.iter().copied())
+            .any(type_has_tuple);
+        saw_array_port |= function
+            .params
+            .iter()
+            .map(|param| &param.ty)
+            .chain(output_types.iter().copied())
+            .any(type_has_array);
+
+        let register_reads: HashMap<&str, NodeRef> = function
+            .nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(index, node)| match &node.payload {
+                NodePayload::RegisterRead { register } => {
+                    Some((register.as_str(), NodeRef { index }))
+                }
+                _ => None,
+            })
+            .collect();
+        for node in &function.nodes {
+            let NodePayload::RegisterWrite {
+                arg,
+                register,
+                load_enable,
+                ..
+            } = &node.payload
+            else {
+                continue;
+            };
+            saw_load_enable |= load_enable.is_some();
+            saw_no_load_enable |= load_enable.is_none();
+            let read_ref = register_reads[register.as_str()];
+            if node_depends_on(function, *arg, read_ref) {
+                saw_feedback = true;
+            } else {
+                saw_no_feedback = true;
+            }
+        }
+
+        assert!(data_input_count <= options.max_input_ports);
+        assert!(output_count <= options.max_output_ports);
+        assert!(metadata.registers.len() <= options.max_registers);
+        assert!(generated.stats.emitted_node_count <= options.function_options.max_nodes);
+    }
+
+    assert!(saw_zero_registers);
+    assert!(saw_max_registers);
+    assert!(saw_feedback);
+    assert!(saw_no_feedback);
+    assert!(saw_load_enable);
+    assert!(saw_no_load_enable);
+    assert!(saw_reset_register);
+    assert!(saw_nonreset_register);
+    assert!(saw_synchronous_reset);
+    assert!(saw_asynchronous_reset);
+    assert!(saw_min_inputs);
+    assert!(saw_max_inputs);
+    assert!(saw_min_outputs);
+    assert!(saw_max_outputs);
+    assert!(saw_tuple_register);
+    assert!(saw_array_register);
+    assert!(saw_tuple_port);
+    assert!(saw_array_port);
+}
+
+#[test]
+fn registered_block_feedback_can_feed_next_state() {
+    let options = RandomBlockOptions {
+        min_input_ports: 0,
+        max_input_ports: 0,
+        min_registers: 1,
+        max_registers: 1,
+        min_output_ports: 1,
+        max_output_ports: 1,
+        allow_load_enable: false,
+        allow_reset: false,
+        function_options: RandomFnOptions {
+            max_nodes: 4,
+            max_bit_width: 8,
+            enabled_operations: OperationSet::new([RandomOperation::Literal]),
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    };
+    let mut entropy = DepletableBytes::new(&[]);
+    let generated = generate_block(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+    let package = generated.clone().into_top_package("feedback_block_package");
+
+    validate_generated_block_package(&package);
+    let register = &generated.metadata.registers[0];
+    let read_index = generated
+        .function
+        .nodes
+        .iter()
+        .position(|node| {
+            matches!(
+                &node.payload,
+                NodePayload::RegisterRead { register: read_register }
+                    if read_register == &register.name
+            )
+        })
+        .unwrap();
+    let write_arg = generated
+        .function
+        .nodes
+        .iter()
+        .find_map(|node| match &node.payload {
+            NodePayload::RegisterWrite {
+                arg,
+                register: write_register,
+                ..
+            } if write_register == &register.name => Some(*arg),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_eq!(write_arg.index, read_index);
+    assert_eq!(
+        generated.stats.live_operations.get("register_write"),
+        Some(&1)
+    );
 }
 
 #[test]

--- a/xlsynth-pir/tests/ir_random.rs
+++ b/xlsynth-pir/tests/ir_random.rs
@@ -350,6 +350,46 @@ fn depleted_entropy_constructs_a_minimal_deterministic_block() {
 }
 
 #[test]
+fn generated_zero_output_block_does_not_write_synthetic_return() {
+    let options = RandomBlockOptions {
+        max_input_ports: 0,
+        min_registers: 1,
+        max_registers: 1,
+        max_output_ports: 0,
+        allow_zero_width_ports_and_registers: true,
+        allow_load_enable: false,
+        allow_reset: false,
+        function_options: RandomFnOptions {
+            max_nodes: 3,
+            allow_arrays: false,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    };
+    // Select an empty-tuple register, then entropy that would select the
+    // same-typed synthetic zero-output return if it were a D-value candidate.
+    let entropy_bytes: Vec<u8> = [1_u64, 0, 1, 1]
+        .into_iter()
+        .flat_map(u64::to_le_bytes)
+        .collect();
+    let mut entropy = DepletableBytes::new(&entropy_bytes);
+    let generated = generate_block(&mut entropy, &options, StopPolicy::ExactBodyNodes(0)).unwrap();
+    let ret_ref = generated.function.ret_node_ref.unwrap();
+    let write_arg = generated
+        .function
+        .nodes
+        .iter()
+        .find_map(|node| match &node.payload {
+            NodePayload::RegisterWrite { arg, .. } => Some(*arg),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_ne!(write_arg, ret_ref);
+    validate_generated_block_package(&generated.into_top_package("zero_output_register_package"));
+}
+
+#[test]
 fn generated_block_populates_multi_output_metadata() {
     let options = RandomBlockOptions {
         min_input_ports: 1,


### PR DESCRIPTION
Also add a fuzz test which uses this generator to verify that block IR eval and g8r eval of the same block is equivalent.

Fix issue with download_release.py for macos.