### PR TITLE
Add a fuzz test which compares gv-eval and block ir eval.

### DIFF
--- a/scripts/run_all_fuzz_tests.py
+++ b/scripts/run_all_fuzz_tests.py
@@ -34,6 +34,10 @@ DEFAULT_FUZZ_RUN_ARGS: str = ""
 # solver timeouts.
 DEFAULT_FUZZ_BIN_ARGS: str = "-max_total_time=5 -timeout=60"
 DEFAULT_THREADS: int = 4
+DEFAULT_SKIPPED_FUZZ_TARGETS: set[str] = {
+    # Yosys is not always available, including in GitHub CI.
+    "fuzz_random_block_gv_eval_combo_equiv",
+}
 DONE_RUNS_RE = re.compile(r"^Done ([0-9]+) runs in ([0-9]+) second\(s\)$")
 
 
@@ -169,7 +173,24 @@ def main() -> int:
             text=True,
             stderr=subprocess.STDOUT,
         )
-        targets = [line.strip() for line in list_output.splitlines() if line.strip()]
+        listed_targets = [
+            line.strip() for line in list_output.splitlines() if line.strip()
+        ]
+        skipped_targets = [
+            target
+            for target in listed_targets
+            if target in DEFAULT_SKIPPED_FUZZ_TARGETS
+        ]
+        for target in skipped_targets:
+            print(
+                f"Skipping default-excluded fuzz target {target} in {fuzz_dir}",
+                file=sys.stderr,
+            )
+        targets = [
+            target
+            for target in listed_targets
+            if target not in DEFAULT_SKIPPED_FUZZ_TARGETS
+        ]
         if not targets:
             continue
         fuzz_targets.append((fuzz_dir, targets))

--- a/xlsynth-g8r/fuzz/Cargo.toml
+++ b/xlsynth-g8r/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ env_logger = "0.11"
 blake3 = "1"
 xlsynth = { path = "../../xlsynth", version = "0.61.0" }
 rand = "0.8"
+tempfile = "3.20"
 xlsynth-test-helpers = { path = "../../xlsynth-test-helpers" }
 xlsynth-pir = { path = "../../xlsynth-pir" }
 xlsynth-g8r = { path = "../../xlsynth-g8r" }
@@ -44,6 +45,13 @@ name = "fuzz_random_block_g8r_equiv"
 path = "fuzz_targets/fuzz_random_block_g8r_equiv.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_random_block_gv_eval_combo_equiv"
+path = "fuzz_targets/fuzz_random_block_gv_eval_combo_equiv.rs"
+test = false
+doc = false
+required-features = ["external-yosys"]
 
 [[bin]]
 name = "fuzz_g8r_formal"
@@ -151,6 +159,7 @@ doc = false
 [features]
 # No default optional features; required solver integrations are always enabled via dependency specification above.
 default = []
+external-yosys = []
 has-boolector = ["xlsynth-prover/has-boolector"]
 has-easy-smt = ["xlsynth-prover/has-easy-smt"]
 has-bitwuzla = ["xlsynth-g8r/has-bitwuzla", "xlsynth-prover/has-bitwuzla"]

--- a/xlsynth-g8r/fuzz/FUZZ.md
+++ b/xlsynth-g8r/fuzz/FUZZ.md
@@ -23,6 +23,24 @@ divergent visible outputs or committed register state on any simulated cycle;
 or generated block metadata that cannot be lowered by the supported
 synchronous block-to-G8R path.
 
+## `fuzz_random_block_gv_eval_combo_equiv`
+
+Generates bounded register-free block IR, lowers it to combinational G8R,
+emits packed-port Verilog, maps it through the Yosys executable named by
+`XLSYNTH_YOSYS_PATH` and ABC against the comma-separated Liberty files in
+`XLSYNTH_LIBERTY_FILES`, then loads the mapped netlist through `gv-eval`.
+The target is gated by the `external-yosys` feature because it requires
+that external toolchain and Liberty data at runtime. Input samples use a
+deterministic RNG seeded from the generated IR rather than coverage-guided
+bytes.
+
+The essential property is that combinational block IR evaluation and
+Liberty-backed `gv-eval` agree on every flattened output for each random input
+sample, including aggregate ports and zero-output blocks. Failures expose
+block-to-G8R flattening disagreements, RTL emission or Yosys/ABC mapping
+failures, unsupported mapped Liberty cell formulas, netlist input/output shape
+changes, or visible output divergence after technology mapping.
+
 ## `fuzz_gatify`
 
 Generates bounded gatify-supported PIR directly with

--- a/xlsynth-g8r/fuzz/fuzz_targets/fuzz_random_block_gv_eval_combo_equiv.rs
+++ b/xlsynth-g8r/fuzz/fuzz_targets/fuzz_random_block_gv_eval_combo_equiv.rs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+
+//! Differentially checks combinational block IR against Yosys-mapped gv-eval.
+
+use std::sync::OnceLock;
+
+use libfuzzer_sys::fuzz_target;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use xlsynth::{IrBits, IrValue};
+use xlsynth_g8r::aig_serdes::emit_netlist::{
+    NetlistPortStyle, emit_netlist_with_version_and_port_style,
+};
+use xlsynth_g8r::block2sequential::block_package_to_sequential_gate_fn;
+use xlsynth_g8r::gatify::ir2gate::GatifyOptions;
+use xlsynth_g8r::liberty::parser::{
+    LibertyPayloadOptions, parse_liberty_files_with_payload_options,
+};
+use xlsynth_g8r::liberty_model::Library;
+use xlsynth_g8r::netlist::gv_eval::{
+    GvEvalOptions, load_labeled_netlist_aig_with_liberty,
+};
+use xlsynth_g8r::netlist::yosys::YosysEnvironment;
+use xlsynth_g8r::verilog_version::VerilogVersion;
+use xlsynth_pir::ir::{BlockMetadata, Fn, NodePayload, NodeRef, Type};
+use xlsynth_pir::ir_eval::{self, FnEvalResult};
+use xlsynth_pir::ir_random::{
+    DepletableBytes, OperationSet, RandomBlockOptions, RandomFnOptions, RandomOperation,
+    StopPolicy, generate_block_package,
+};
+use xlsynth_pir::ir_value_utils::flatten_ir_value_to_lsb0_bits_for_type;
+use xlsynth_pir::random_inputs::generate_uniform_value_with_rng;
+
+const INPUT_SAMPLE_COUNT: usize = 16;
+
+struct ExternalYosysContext {
+    liberty: Library,
+    yosys: YosysEnvironment,
+}
+
+static EXTERNAL_YOSYS_CONTEXT: OnceLock<Result<ExternalYosysContext, String>> = OnceLock::new();
+static SKIP_REPORTED: OnceLock<()> = OnceLock::new();
+
+fn fuzz_block_options() -> RandomBlockOptions {
+    let operations = OperationSet::new(
+        OperationSet::all_supported()
+            .iter()
+            .filter(|operation| {
+                !matches!(
+                    operation,
+                    RandomOperation::Umulp | RandomOperation::Smulp
+                )
+            }),
+    );
+    RandomBlockOptions {
+        max_input_ports: 4,
+        max_output_ports: 4,
+        max_registers: 0,
+        allow_load_enable: false,
+        allow_reset: false,
+        function_options: RandomFnOptions {
+            max_nodes: 32,
+            max_bit_width: 8,
+            allow_arbitrary_width_multiply: true,
+            enabled_operations: operations,
+            ..RandomFnOptions::default()
+        },
+        ..RandomBlockOptions::default()
+    }
+}
+
+fn external_yosys_context() -> Option<&'static ExternalYosysContext> {
+    match EXTERNAL_YOSYS_CONTEXT.get_or_init(build_external_yosys_context) {
+        Ok(context) => Some(context),
+        Err(error) => {
+            if SKIP_REPORTED.set(()).is_ok() {
+                eprintln!("skipping external Yosys/Liberty fuzz target: {error}");
+            }
+            None
+        }
+    }
+}
+
+fn build_external_yosys_context() -> Result<ExternalYosysContext, String> {
+    let yosys = YosysEnvironment::from_env()?;
+    let liberty = parse_liberty_files_with_payload_options(
+        yosys.liberty_files().paths(),
+        LibertyPayloadOptions {
+            include_timing: false,
+            include_power: false,
+        },
+    )
+    .map_err(|e| format!("parse Liberty inputs: {e}"))?;
+    Ok(ExternalYosysContext { liberty, yosys })
+}
+
+fn block_output_refs(block: &Fn, metadata: &BlockMetadata) -> Vec<NodeRef> {
+    let ret_ref = block
+        .ret_node_ref
+        .expect("generated block should have a return node");
+    match metadata.output_names.len() {
+        0 => Vec::new(),
+        1 => vec![ret_ref],
+        _ => {
+            let NodePayload::Tuple(outputs) = &block.get_node(ret_ref).payload else {
+                panic!("generated multi-output block should return a tuple");
+            };
+            outputs.clone()
+        }
+    }
+}
+
+fn block_output_types<'a>(block: &'a Fn, metadata: &BlockMetadata) -> Vec<&'a Type> {
+    match metadata.output_names.len() {
+        0 => Vec::new(),
+        1 => vec![&block.ret_ty],
+        _ => {
+            let Type::Tuple(types) = &block.ret_ty else {
+                panic!("generated multi-output block should return a tuple type");
+            };
+            types.iter().map(|ty| &**ty).collect()
+        }
+    }
+}
+
+fn eval_ref(block: &Fn, node_ref: NodeRef, inputs: &[IrValue], ir_text: &str) -> IrValue {
+    let mut eval_fn = block.clone();
+    eval_fn.ret_ty = eval_fn.get_node(node_ref).ty.clone();
+    eval_fn.ret_node_ref = Some(node_ref);
+    match ir_eval::eval_fn(&eval_fn, inputs) {
+        FnEvalResult::Success(success) => success.value,
+        failure @ FnEvalResult::Failure(_) => {
+            panic!("block PIR evaluation failed:\nIR:\n{ir_text}\nresult={failure:?}")
+        }
+    }
+}
+
+fn evaluate_block_outputs(
+    block: &Fn,
+    metadata: &BlockMetadata,
+    inputs: &[IrValue],
+    ir_text: &str,
+) -> Vec<IrValue> {
+    let output_refs = block_output_refs(block, metadata);
+    if output_refs.is_empty() {
+        // Evaluate the explicit empty-tuple return even when the generated
+        // block has no visible outputs, so the PIR evaluator still participates.
+        let ret_ref = block
+            .ret_node_ref
+            .expect("generated block should have a return node");
+        let _ = eval_ref(block, ret_ref, inputs, ir_text);
+    }
+    output_refs
+        .into_iter()
+        .map(|output_ref| eval_ref(block, output_ref, inputs, ir_text))
+        .collect()
+}
+
+fn flatten_value(value: &IrValue, ty: &Type) -> IrBits {
+    let mut bits = Vec::with_capacity(ty.bit_count());
+    flatten_ir_value_to_lsb0_bits_for_type(value, ty, &mut bits)
+        .expect("generated value should match its PIR type");
+    IrBits::from_lsb_is_0(&bits)
+}
+
+fn generate_inputs(block: &Fn, rng: &mut StdRng) -> Vec<IrValue> {
+    block
+        .params
+        .iter()
+        .map(|param| generate_uniform_value_with_rng(rng, &param.ty))
+        .collect()
+}
+
+fuzz_target!(|data: &[u8]| {
+    // Missing Yosys or Liberty files are infrastructure conditions, not
+    // properties of an individual fuzz sample.
+    let Some(context) = external_yosys_context() else {
+        return;
+    };
+
+    let mut entropy = DepletableBytes::new(data);
+    let generated = generate_block_package(
+        &mut entropy,
+        &fuzz_block_options(),
+        StopPolicy::WhenEntropyDepleted,
+    )
+    .expect("fixed random block options should construct a valid package");
+    let block_ir = generated.package.to_string();
+    let block = generated
+        .package
+        .get_top_block()
+        .expect("generated package should have a top block");
+    let xlsynth_pir::ir::PackageMember::Block { func, metadata } = block else {
+        unreachable!("generated package top should be a block");
+    };
+    assert!(
+        metadata.registers.is_empty(),
+        "combinational-only generation emitted registers:\n{block_ir}"
+    );
+
+    let design = block_package_to_sequential_gate_fn(
+        &generated.package,
+        GatifyOptions::all_opts_disabled(),
+    )
+    .unwrap_or_else(|error| panic!("random block G8R lowering failed:\n{block_ir}\n{error}"));
+    assert!(
+        design.registers.is_empty() && design.clock.is_none(),
+        "combinational block lowered to sequential G8R:\n{block_ir}"
+    );
+    let rtl = emit_netlist_with_version_and_port_style(
+        &design,
+        VerilogVersion::Verilog,
+        NetlistPortStyle::PackedBits,
+    )
+    .unwrap_or_else(|error| panic!("random block RTL emission failed:\n{block_ir}\n{error}"));
+    let mapped_gv = context
+        .yosys
+        .synthesize_verilog_to_gv(&rtl, &design.name)
+        .unwrap_or_else(|error| {
+        panic!("random block Yosys mapping failed:\nIR:\n{block_ir}\nRTL:\n{rtl}\n{error}")
+    });
+    let netlist_dir = tempfile::tempdir().expect("create temporary mapped-netlist directory");
+    let netlist_path = netlist_dir.path().join("mapped.gv");
+    std::fs::write(&netlist_path, &mapped_gv).expect("write temporary mapped netlist");
+    let model = load_labeled_netlist_aig_with_liberty(
+        &netlist_path,
+        &context.liberty,
+        &GvEvalOptions {
+            module_name: Some(design.name.clone()),
+        },
+    )
+    .unwrap_or_else(|error| {
+        panic!(
+            "random block gv-eval loading failed:\nIR:\n{block_ir}\nRTL:\n{rtl}\nGV:\n{mapped_gv}\n{error}"
+        )
+    });
+
+    let expected_input_widths = design
+        .inputs
+        .iter()
+        .map(|input| design.transition.inputs[input.index()].get_bit_count())
+        .collect::<Vec<_>>();
+    let actual_input_widths = model
+        .gate_fn
+        .inputs
+        .iter()
+        .map(|input| input.get_bit_count())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        actual_input_widths, expected_input_widths,
+        "Yosys changed combinational block input shape:\nIR:\n{block_ir}\nGV:\n{mapped_gv}"
+    );
+    let expected_output_widths = design
+        .outputs
+        .iter()
+        .map(|output| design.transition.outputs[output.index()].get_bit_count())
+        .collect::<Vec<_>>();
+    let actual_output_widths = model
+        .gate_fn
+        .outputs
+        .iter()
+        .map(|output| output.get_bit_count())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        actual_output_widths, expected_output_widths,
+        "Yosys changed combinational block output shape:\nIR:\n{block_ir}\nGV:\n{mapped_gv}"
+    );
+
+    let mut seed = [0_u8; 32];
+    seed.copy_from_slice(blake3::hash(block_ir.as_bytes()).as_bytes());
+    let mut rng = StdRng::from_seed(seed);
+    let output_types = block_output_types(func, metadata);
+    for sample_index in 0..INPUT_SAMPLE_COUNT {
+        let inputs = generate_inputs(func, &mut rng);
+        let input_bits = inputs
+            .iter()
+            .zip(&func.params)
+            .map(|(value, param)| flatten_value(value, &param.ty))
+            .collect::<Vec<_>>();
+        let expected_output_bits = evaluate_block_outputs(func, metadata, &inputs, &block_ir)
+            .iter()
+            .zip(&output_types)
+            .map(|(value, ty)| flatten_value(value, ty))
+            .collect::<Vec<_>>();
+        let actual_output_bits = model.evaluate_bits(&input_bits).unwrap_or_else(|error| {
+            panic!(
+                "random block gv-eval failed at sample {sample_index}:\nIR:\n{block_ir}\nGV:\n{mapped_gv}\n{error}"
+            )
+        });
+        assert_eq!(
+            actual_output_bits, expected_output_bits,
+            "random block gv-eval mismatch at sample {sample_index}:\nIR:\n{block_ir}\nRTL:\n{rtl}\nGV:\n{mapped_gv}"
+        );
+    }
+});

--- a/xlsynth-g8r/src/netlist/gatefn_from_netlist.rs
+++ b/xlsynth-g8r/src/netlist/gatefn_from_netlist.rs
@@ -912,6 +912,15 @@ fn project_gatefn_from_netlist_and_liberty_internal(
             gb.add_output(net_name.to_string(), bv);
         }
     }
+    let has_visible_outputs = normalized
+        .ports
+        .iter()
+        .any(|port| port.direction == PortDirection::Output);
+    if projection_mode == ProjectionMode::LabeledEval && !has_visible_outputs {
+        // GateBuilder requires an endpoint while it constructs the graph, but
+        // an outputless gv-eval module has no visible values to expose.
+        gb.add_output("__gv_eval_empty".to_string(), AigBitVector::zeros(0));
+    }
     let instances = if projection_mode == ProjectionMode::LabeledEval {
         labeled_instances
             .into_iter()
@@ -928,8 +937,12 @@ fn project_gatefn_from_netlist_and_liberty_internal(
     } else {
         Vec::new()
     };
+    let mut gate_fn = gb.build();
+    if projection_mode == ProjectionMode::LabeledEval && !has_visible_outputs {
+        gate_fn.outputs.clear();
+    }
     Ok(GateFnProjection {
-        gate_fn: gb.build(),
+        gate_fn,
         module_ports,
         instances,
     })
@@ -953,17 +966,6 @@ fn validate_labeled_eval_module(
             module_name
         ));
     }
-    if !normalized
-        .ports
-        .iter()
-        .any(|port| port.direction == PortDirection::Output)
-    {
-        return Err(format!(
-            "module '{}' has no output ports to evaluate",
-            module_name
-        ));
-    }
-
     for inst in &normalized.instances {
         let type_name = interner.resolve(inst.type_name).unwrap_or("<unknown>");
         let instance_name = interner.resolve(inst.instance_name).unwrap_or("<unknown>");

--- a/xlsynth-g8r/src/netlist/gv_eval.rs
+++ b/xlsynth-g8r/src/netlist/gv_eval.rs
@@ -12,7 +12,7 @@ use crate::aig::AigOperand;
 use crate::aig_sim::count_toggles;
 use crate::aig_sim::gate_sim::{self, Collect};
 use crate::aig_sim::gate_simd;
-use crate::liberty_model::PinDirection;
+use crate::liberty_model::{Library, PinDirection};
 use crate::netlist::gatefn_from_netlist::project_labeled_netlist_aig;
 use crate::netlist::io::{load_liberty_from_path, parse_netlist_from_path, select_module};
 use crate::netlist::parse::PortDirection;
@@ -105,10 +105,20 @@ pub fn load_labeled_netlist_aig(
     liberty_proto_path: &Path,
     options: &GvEvalOptions,
 ) -> Result<LabeledNetlistAig> {
+    let liberty = load_liberty_from_path(liberty_proto_path)?;
+    load_labeled_netlist_aig_with_liberty(netlist_path, &liberty, options)
+}
+
+/// Loads, validates, and projects one combinational netlist module using an
+/// already parsed Liberty model.
+pub fn load_labeled_netlist_aig_with_liberty(
+    netlist_path: &Path,
+    liberty: &Library,
+    options: &GvEvalOptions,
+) -> Result<LabeledNetlistAig> {
     let parsed = parse_netlist_from_path(netlist_path)?;
     let module = select_module(&parsed, options.module_name.as_deref())?;
-    let liberty = load_liberty_from_path(liberty_proto_path)?;
-    project_labeled_netlist_aig(module, &parsed.nets, &parsed.interner, &liberty)
+    project_labeled_netlist_aig(module, &parsed.nets, &parsed.interner, liberty)
         .map_err(|e| anyhow!(e))
 }
 

--- a/xlsynth-g8r/src/netlist/mod.rs
+++ b/xlsynth-g8r/src/netlist/mod.rs
@@ -22,3 +22,4 @@ pub mod stages;
 pub mod stats;
 pub mod techmap;
 pub mod utils;
+pub mod yosys;

--- a/xlsynth-g8r/src/netlist/yosys.rs
+++ b/xlsynth-g8r/src/netlist/yosys.rs
@@ -74,7 +74,7 @@ impl YosysLibertyFileSet {
         Self::from_comma_separated_paths(&raw_paths)
     }
 
-    /// Validates source Liberty files and preserves their order for Yosys.
+    /// Validates and canonicalizes source Liberty files while preserving order.
     pub fn new<P: AsRef<Path>>(liberty_files: &[P]) -> Result<Self, String> {
         if liberty_files.is_empty() {
             return Err("Yosys Liberty file set cannot be empty".to_string());
@@ -89,7 +89,10 @@ impl YosysLibertyFileSet {
                     path.display()
                 ));
             }
-            paths.push(path.to_path_buf());
+            let canonical_path = path.canonicalize().map_err(|e| {
+                format!("canonicalize Yosys Liberty input '{}': {e}", path.display())
+            })?;
+            paths.push(canonical_path);
         }
         Ok(Self { paths })
     }
@@ -255,7 +258,26 @@ mod tests {
         std::fs::write(&second, "library (second) {}\n").unwrap();
 
         let set = YosysLibertyFileSet::new(&[&first, &second]).unwrap();
-        assert_eq!(set.paths(), &[first, second]);
+        assert_eq!(
+            set.paths(),
+            &[
+                first.canonicalize().unwrap(),
+                second.canonicalize().unwrap()
+            ]
+        );
+    }
+
+    #[test]
+    fn liberty_file_set_canonicalizes_relative_paths() {
+        let current_dir = std::env::current_dir().unwrap();
+        let source_dir = tempfile::tempdir_in(&current_dir).unwrap();
+        let absolute_path = source_dir.path().join("cells.lib");
+        std::fs::write(&absolute_path, "library (cells) {}\n").unwrap();
+        let relative_path = absolute_path.strip_prefix(&current_dir).unwrap();
+        assert!(!relative_path.is_absolute());
+
+        let set = YosysLibertyFileSet::new(&[relative_path]).unwrap();
+        assert_eq!(set.paths(), &[absolute_path.canonicalize().unwrap()]);
     }
 
     #[test]
@@ -305,7 +327,13 @@ mod tests {
         let raw_paths = format!("{}, {}", first.display(), second.display());
 
         let set = YosysLibertyFileSet::from_comma_separated_paths(&raw_paths).unwrap();
-        assert_eq!(set.paths(), &[first, second]);
+        assert_eq!(
+            set.paths(),
+            &[
+                first.canonicalize().unwrap(),
+                second.canonicalize().unwrap()
+            ]
+        );
     }
 
     #[test]

--- a/xlsynth-g8r/src/netlist/yosys.rs
+++ b/xlsynth-g8r/src/netlist/yosys.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! External Yosys helpers for combinational Liberty technology mapping.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Environment variable naming the Yosys executable used for external mapping.
+pub const YOSYS_PATH_ENV: &str = "XLSYNTH_YOSYS_PATH";
+
+/// Environment variable containing comma-separated Liberty paths for Yosys.
+pub const LIBERTY_FILES_ENV: &str = "XLSYNTH_LIBERTY_FILES";
+
+/// Validated external Yosys executable and Liberty-library configuration.
+pub struct YosysEnvironment {
+    yosys_path: PathBuf,
+    liberty_files: YosysLibertyFileSet,
+}
+
+impl YosysEnvironment {
+    /// Validates an explicit external Yosys setup.
+    pub fn new<P: AsRef<Path>>(
+        yosys_path: P,
+        liberty_files: YosysLibertyFileSet,
+    ) -> Result<Self, String> {
+        let yosys_path = yosys_path.as_ref().to_path_buf();
+        validate_yosys_executable_path(&yosys_path)?;
+        Ok(Self {
+            yosys_path,
+            liberty_files,
+        })
+    }
+
+    /// Reads and validates the external Yosys setup from environment variables.
+    pub fn from_env() -> Result<Self, String> {
+        Self::new(yosys_path_from_env()?, YosysLibertyFileSet::from_env()?)
+    }
+
+    /// Returns the validated Yosys executable path.
+    pub fn yosys_path(&self) -> &Path {
+        &self.yosys_path
+    }
+
+    /// Returns the validated Liberty files used by Yosys and ABC.
+    pub fn liberty_files(&self) -> &YosysLibertyFileSet {
+        &self.liberty_files
+    }
+
+    /// Maps one combinational Verilog module with this external Yosys setup.
+    pub fn synthesize_verilog_to_gv(
+        &self,
+        verilog: &str,
+        top_module: &str,
+    ) -> Result<String, String> {
+        synthesize_verilog_to_gv_with_yosys(
+            &self.yosys_path,
+            verilog,
+            top_module,
+            &self.liberty_files,
+        )
+    }
+}
+
+/// A validated set of Liberty files passed directly to Yosys and ABC.
+pub struct YosysLibertyFileSet {
+    paths: Vec<PathBuf>,
+}
+
+impl YosysLibertyFileSet {
+    /// Reads comma-separated source Liberty paths from the environment.
+    pub fn from_env() -> Result<Self, String> {
+        let raw_paths = std::env::var(LIBERTY_FILES_ENV)
+            .map_err(|_| format!("{LIBERTY_FILES_ENV} is not set"))?;
+        Self::from_comma_separated_paths(&raw_paths)
+    }
+
+    /// Validates source Liberty files and preserves their order for Yosys.
+    pub fn new<P: AsRef<Path>>(liberty_files: &[P]) -> Result<Self, String> {
+        if liberty_files.is_empty() {
+            return Err("Yosys Liberty file set cannot be empty".to_string());
+        }
+
+        let mut paths = Vec::with_capacity(liberty_files.len());
+        for path in liberty_files {
+            let path = path.as_ref();
+            if !path.is_file() {
+                return Err(format!(
+                    "Yosys Liberty input is not a file: {}",
+                    path.display()
+                ));
+            }
+            paths.push(path.to_path_buf());
+        }
+        Ok(Self { paths })
+    }
+
+    /// Returns source Liberty paths in the order Yosys and ABC should load
+    /// them.
+    pub fn paths(&self) -> &[PathBuf] {
+        &self.paths
+    }
+
+    fn from_comma_separated_paths(raw_paths: &str) -> Result<Self, String> {
+        let mut paths = Vec::new();
+        for raw_path in raw_paths.split(',') {
+            let path = raw_path.trim();
+            if path.is_empty() {
+                return Err(format!(
+                    "{LIBERTY_FILES_ENV} contains an empty comma-separated entry"
+                ));
+            }
+            paths.push(PathBuf::from(path));
+        }
+        if paths.is_empty() {
+            return Err(format!("{LIBERTY_FILES_ENV} is empty"));
+        }
+        Self::new(&paths)
+    }
+}
+
+fn yosys_path_from_env() -> Result<PathBuf, String> {
+    std::env::var_os(YOSYS_PATH_ENV)
+        .map(PathBuf::from)
+        .ok_or_else(|| format!("{YOSYS_PATH_ENV} is not set"))
+}
+
+fn validate_yosys_executable_path(path: &Path) -> Result<(), String> {
+    if !path.is_file() {
+        return Err(format!(
+            "Yosys executable is not a file: {}",
+            path.display()
+        ));
+    }
+    let output = Command::new(path)
+        .arg("-V")
+        .output()
+        .map_err(|e| format!("run Yosys executable '{}': {e}", path.display()))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Yosys executable did not run successfully: {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Maps one combinational Verilog module through Yosys and its default ABC
+/// executable, returning the emitted Liberty-backed gate-level Verilog.
+fn synthesize_verilog_to_gv_with_yosys(
+    yosys_path: &Path,
+    verilog: &str,
+    top_module: &str,
+    liberty_files: &YosysLibertyFileSet,
+) -> Result<String, String> {
+    if !is_simple_yosys_identifier(top_module) {
+        return Err(format!(
+            "Yosys top module must be a simple identifier: '{top_module}'"
+        ));
+    }
+
+    let temp_dir =
+        tempfile::tempdir().map_err(|e| format!("create temporary Yosys directory: {e}"))?;
+    let input_path = temp_dir.path().join("dut.v");
+    let output_path = temp_dir.path().join("mapped.gv");
+    std::fs::write(&input_path, verilog)
+        .map_err(|e| format!("write temporary Yosys input Verilog: {e}"))?;
+    let yosys_program = render_combo_synthesis_program(top_module, liberty_files.paths());
+    let invocation_context = format_yosys_invocation_context(yosys_path, &yosys_program);
+
+    let output = Command::new(yosys_path)
+        .current_dir(temp_dir.path())
+        .arg("-Q")
+        .arg("-p")
+        .arg(&yosys_program)
+        .output()
+        .map_err(|e| format!("run Yosys: {e}\n{invocation_context}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Yosys combinational technology mapping failed\n{invocation_context}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        ));
+    }
+
+    std::fs::read_to_string(&output_path).map_err(|e| {
+        format!(
+            "read Yosys mapped netlist '{}': {e}\n{invocation_context}",
+            output_path.display()
+        )
+    })
+}
+
+fn format_yosys_invocation_context(yosys_path: &Path, yosys_program: &str) -> String {
+    format!(
+        "Yosys executable: {}\nYosys program:\n{}",
+        yosys_path.display(),
+        yosys_program.trim_end()
+    )
+}
+
+fn render_combo_synthesis_program(top_module: &str, liberty_paths: &[PathBuf]) -> String {
+    let read_liberty_commands = liberty_paths
+        .iter()
+        .map(|path| format!("read_liberty -lib {}", quote_yosys_path(path)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let abc_liberty_arguments = liberty_paths
+        .iter()
+        .map(|path| format!("-liberty {}", quote_yosys_path(path)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!(
+        "{read_liberty_commands}\n\
+         read_verilog dut.v\n\
+         hierarchy -check -top {top_module}\n\
+         proc\n\
+         flatten\n\
+         opt\n\
+         techmap\n\
+         opt\n\
+         abc {abc_liberty_arguments}\n\
+         clean -purge\n\
+         write_verilog -noattr mapped.gv\n"
+    )
+}
+
+fn quote_yosys_path(path: &Path) -> String {
+    format!(
+        "\"{}\"",
+        path.to_string_lossy()
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+    )
+}
+
+fn is_simple_yosys_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn liberty_file_set_preserves_files_in_order() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let first = source_dir.path().join("first.lib");
+        let second = source_dir.path().join("second.lib");
+        std::fs::write(&first, "library (first) {}\n").unwrap();
+        std::fs::write(&second, "library (second) {}\n").unwrap();
+
+        let set = YosysLibertyFileSet::new(&[&first, &second]).unwrap();
+        assert_eq!(set.paths(), &[first, second]);
+    }
+
+    #[test]
+    fn synthesis_program_passes_each_liberty_file_to_yosys_and_abc() {
+        let liberty_paths = vec![PathBuf::from("first.lib"), PathBuf::from("second.lib")];
+        let program = render_combo_synthesis_program("top", &liberty_paths);
+        assert_eq!(
+            program,
+            "read_liberty -lib \"first.lib\"\n\
+             read_liberty -lib \"second.lib\"\n\
+             read_verilog dut.v\n\
+             hierarchy -check -top top\n\
+             proc\n\
+             flatten\n\
+             opt\n\
+             techmap\n\
+             opt\n\
+             abc -liberty \"first.lib\" -liberty \"second.lib\"\n\
+             clean -purge\n\
+             write_verilog -noattr mapped.gv\n"
+        );
+    }
+
+    #[test]
+    fn invocation_context_includes_executable_and_program() {
+        let context =
+            format_yosys_invocation_context(Path::new("/path/to/yosys"), "abc -liberty cells.lib");
+        assert_eq!(
+            context,
+            "Yosys executable: /path/to/yosys\nYosys program:\nabc -liberty cells.lib"
+        );
+    }
+
+    #[test]
+    fn liberty_file_set_rejects_an_empty_input_list() {
+        let error = YosysLibertyFileSet::new::<&Path>(&[]).err().unwrap();
+        assert_eq!(error, "Yosys Liberty file set cannot be empty");
+    }
+
+    #[test]
+    fn liberty_file_set_parses_comma_separated_paths() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let first = source_dir.path().join("first.lib");
+        let second = source_dir.path().join("second.lib");
+        std::fs::write(&first, "library (first) {}\n").unwrap();
+        std::fs::write(&second, "library (second) {}\n").unwrap();
+        let raw_paths = format!("{}, {}", first.display(), second.display());
+
+        let set = YosysLibertyFileSet::from_comma_separated_paths(&raw_paths).unwrap();
+        assert_eq!(set.paths(), &[first, second]);
+    }
+
+    #[test]
+    fn liberty_file_set_rejects_an_empty_comma_separated_entry() {
+        let error = YosysLibertyFileSet::from_comma_separated_paths("first.lib,")
+            .err()
+            .unwrap();
+        assert_eq!(
+            error,
+            "XLSYNTH_LIBERTY_FILES contains an empty comma-separated entry"
+        );
+    }
+
+    #[test]
+    fn environment_rejects_a_missing_programmatic_yosys_path() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let liberty_path = source_dir.path().join("cells.lib");
+        std::fs::write(&liberty_path, "library (cells) {}\n").unwrap();
+        let liberty_files = YosysLibertyFileSet::new(&[&liberty_path]).unwrap();
+        let yosys_path = source_dir.path().join("missing-yosys");
+
+        let error = YosysEnvironment::new(&yosys_path, liberty_files)
+            .err()
+            .unwrap();
+        assert_eq!(
+            error,
+            format!("Yosys executable is not a file: {}", yosys_path.display())
+        );
+    }
+
+    #[test]
+    fn simple_yosys_identifier_rejects_script_syntax() {
+        assert!(is_simple_yosys_identifier("random_block_0"));
+        assert!(!is_simple_yosys_identifier(""));
+        assert!(!is_simple_yosys_identifier("random-block"));
+        assert!(!is_simple_yosys_identifier("top; shell echo nope"));
+    }
+}

--- a/xlsynth-g8r/tests/gv_eval_test.rs
+++ b/xlsynth-g8r/tests/gv_eval_test.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use xlsynth::{IrBits, IrValue};
-use xlsynth_g8r::liberty_model::PinDirection;
+use xlsynth_g8r::liberty::parser::{
+    LibertyPayloadOptions, parse_liberty_files_with_payload_options,
+};
+use xlsynth_g8r::liberty_model::{Library, PinDirection};
 use xlsynth_g8r::netlist::gv_eval::{
     GvEvalOptions, GvToggleAggregate, PinConnection, TogglePinConnection, load_labeled_netlist_aig,
+    load_labeled_netlist_aig_with_liberty,
 };
 use xlsynth_g8r::netlist::parse::PortDirection;
 use xlsynth_g8r::netlist::power::{GV_POWER_SLEW_BUCKET_COUNT, GvDynamicPowerOptions};
@@ -18,6 +22,79 @@ fn write_fixture(
     std::fs::write(&netlist_path, netlist).expect("write netlist");
     std::fs::write(&liberty_path, liberty).expect("write liberty");
     (temp_dir, netlist_path, liberty_path)
+}
+
+#[test]
+fn labeled_netlist_aig_accepts_an_in_memory_liberty_model() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let netlist_path = temp_dir.path().join("design.gv");
+    let liberty_path = temp_dir.path().join("cells.lib");
+    std::fs::write(
+        &netlist_path,
+        r#"
+module top (a, y);
+  input a;
+  output y;
+  INV u_inv (.A(a), .Y(y));
+endmodule
+"#,
+    )
+    .expect("write netlist");
+    std::fs::write(
+        &liberty_path,
+        r#"
+library (test) {
+  cell (INV) {
+    area: 1;
+    pin (A) { direction: input; }
+    pin (Y) { direction: output; function: "!A"; }
+  }
+}
+"#,
+    )
+    .expect("write liberty");
+    let liberty = parse_liberty_files_with_payload_options(
+        &[&liberty_path],
+        LibertyPayloadOptions {
+            include_timing: false,
+            include_power: false,
+        },
+    )
+    .expect("parse liberty");
+    let model =
+        load_labeled_netlist_aig_with_liberty(&netlist_path, &liberty, &GvEvalOptions::default())
+            .expect("build labeled evaluation model");
+
+    let output = model
+        .evaluate_bits(&[IrBits::make_ubits(1, 1).unwrap()])
+        .expect("evaluate inverter");
+    assert_eq!(output, vec![IrBits::make_ubits(1, 0).unwrap()]);
+}
+
+#[test]
+fn labeled_netlist_aig_accepts_a_module_without_outputs() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let netlist_path = temp_dir.path().join("design.gv");
+    std::fs::write(
+        &netlist_path,
+        r#"
+module top (a);
+  input a;
+endmodule
+"#,
+    )
+    .expect("write netlist");
+    let model = load_labeled_netlist_aig_with_liberty(
+        &netlist_path,
+        &Library::default(),
+        &GvEvalOptions::default(),
+    )
+    .expect("build outputless evaluation model");
+
+    let outputs = model
+        .evaluate_bits(&[IrBits::make_ubits(1, 1).unwrap()])
+        .expect("evaluate outputless module");
+    assert!(outputs.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
As part of the change, add a feature which enables the use of yosys. This is used in the fuzz test to generate a netlist from block ir (verilog).