### PR TITLE
xlsynth-sys: use XLS v0.54.3 and bind semantic sums

### DIFF
--- a/valgrind.supp
+++ b/valgrind.supp
@@ -29,6 +29,19 @@
    ...
 }
 {
+   xls_v0543_z3_solver_static_registration
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   obj:*/libxls-v0.54.3-ubuntu2004.so
+   fun:*PrepareInsertSmallNonSoo*
+   fun:*SolverFactoryRegistry*Register*
+   fun:_GLOBAL__sub_I_z3_ir_translator.cc
+   ...
+   fun:_dl_init
+   ...
+}
+{
    ortools_init
    Memcheck:Leak
    match-leak-kinds: possible

--- a/xlsynth-driver/tests/test_dslx2pipeline_array_index_bounds_checking_enum_cast_false.golden.sv
+++ b/xlsynth-driver/tests/test_dslx2pipeline_array_index_bounds_checking_enum_cast_false.golden.sv
@@ -20,7 +20,7 @@ module __enum_index__main(
   assign p0_concat_31_comb = {p0_literal_29_comb, sel};
   assign p0_literal_32_comb = 3'h1;
   assign p0_add_34_comb = p0_concat_31_comb + p0_literal_32_comb;
-  assign p0_array_index_37_comb = arr_unflattened[p0_add_34_comb];
+  assign p0_array_index_37_comb = arr_unflattened[p0_add_34_comb[1:0]];
   assign out = p0_array_index_37_comb;
 endmodule
 

--- a/xlsynth-driver/tests/test_dslx_stitch_pipeline_array_index_bounds_checking_enum_cast_false.golden.sv
+++ b/xlsynth-driver/tests/test_dslx_stitch_pipeline_array_index_bounds_checking_enum_cast_false.golden.sv
@@ -17,7 +17,7 @@ module foo_cycle0(
   assign concat_22 = {literal_20, sel};
   assign literal_23 = 3'h1;
   assign add_25 = concat_22 + literal_23;
-  assign array_index_28 = arr_unflattened[add_25];
+  assign array_index_28 = arr_unflattened[add_25[1:0]];
   assign out = array_index_28;
 endmodule
 

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.53.0";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.54.2";
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 6;
 
 #[derive(Clone, Copy)]

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.54.2";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.54.3";
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 6;
 
 #[derive(Clone, Copy)]

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -245,6 +245,11 @@ pub struct CDslxEnumDef {
 }
 
 #[repr(C)]
+pub struct CDslxSumDef {
+    _private: [u8; 0], // Ensures the struct cannot be instantiated
+}
+
+#[repr(C)]
 pub struct CDslxTypeAlias {
     _private: [u8; 0], // Ensures the struct cannot be instantiated
 }
@@ -1453,6 +1458,10 @@ unsafe extern "C" {
         module: *const CDslxModule,
         i: i64,
     ) -> *mut CDslxEnumDef;
+    pub fn xls_dslx_module_get_type_definition_as_sum_def(
+        module: *const CDslxModule,
+        i: i64,
+    ) -> *mut CDslxSumDef;
     pub fn xls_dslx_module_get_type_definition_as_type_alias(
         module: *const CDslxModule,
         i: i64,
@@ -1474,6 +1483,8 @@ unsafe extern "C" {
     pub fn xls_dslx_module_member_get_enum_def(
         member: *const CDslxModuleMember,
     ) -> *mut CDslxEnumDef;
+    pub fn xls_dslx_module_member_get_sum_def(member: *const CDslxModuleMember)
+    -> *mut CDslxSumDef;
     pub fn xls_dslx_module_member_get_function(
         member: *const CDslxModuleMember,
     ) -> *mut CDslxFunction;
@@ -1490,6 +1501,8 @@ unsafe extern "C" {
     pub fn xls_dslx_module_member_from_enum_def(
         enum_def: *mut CDslxEnumDef,
     ) -> *mut CDslxModuleMember;
+    pub fn xls_dslx_module_member_from_sum_def(sum_def: *mut CDslxSumDef)
+    -> *mut CDslxModuleMember;
     pub fn xls_dslx_module_member_from_type_alias(
         type_alias: *mut CDslxTypeAlias,
     ) -> *mut CDslxModuleMember;
@@ -1511,6 +1524,10 @@ unsafe extern "C" {
     pub fn xls_dslx_type_info_get_type_enum_def(
         type_info: *mut CDslxTypeInfo,
         node: *mut CDslxEnumDef,
+    ) -> *mut CDslxType;
+    pub fn xls_dslx_type_info_get_type_sum_def(
+        type_info: *mut CDslxTypeInfo,
+        node: *mut CDslxSumDef,
     ) -> *mut CDslxType;
     pub fn xls_dslx_type_info_get_type_struct_member(
         type_info: *mut CDslxTypeInfo,
@@ -1745,6 +1762,16 @@ unsafe extern "C" {
 
     pub fn xls_dslx_enum_member_get_value(member: *const CDslxEnumMember) -> *mut CDslxExpr;
 
+    // -- SumDef
+
+    pub fn xls_dslx_sum_def_get_identifier(
+        sum_def: *const CDslxSumDef,
+    ) -> *mut std::os::raw::c_char;
+
+    pub fn xls_dslx_sum_def_is_parametric(sum_def: *const CDslxSumDef) -> bool;
+
+    pub fn xls_dslx_sum_def_get_variant_count(sum_def: *const CDslxSumDef) -> i64;
+
     pub fn xls_dslx_expr_get_owner_module(expr: *mut CDslxExpr) -> *mut CDslxModule;
 
     // --
@@ -1837,6 +1864,7 @@ unsafe extern "C" {
         struct_def: *const CDslxStructDef,
     ) -> *mut std::os::raw::c_char;
     pub fn xls_dslx_enum_def_to_string(enum_def: *const CDslxEnumDef) -> *mut std::os::raw::c_char;
+    pub fn xls_dslx_sum_def_to_string(sum_def: *const CDslxSumDef) -> *mut std::os::raw::c_char;
     pub fn xls_dslx_type_alias_to_string(
         type_alias: *const CDslxTypeAlias,
     ) -> *mut std::os::raw::c_char;


### PR DESCRIPTION
## Summary

- Upgrade the underlying XLS release from `v0.53.0` to `v0.54.3` while preserving Rust crate and driver version `0.62.0`.
- Bind all eight newly exported semantic-sum C functions so the Rust FFI matches the released native library.
- Update the two SystemVerilog golden files for the upstream array-index width correction.
- Suppress only the known 80-byte Z3 startup allocation while preserving full Valgrind leak detection.

## Why This Change

XLS `v0.54.3` enables semantic sums and restores the existing Linux shared-library naming contract. Its new C exports must be declared together with the release upgrade: the Linux symbol test checks that the library and Rust bindings agree in both directions.

The released library also registers its Z3 solver at startup, leaving one process-lifetime 80-byte allocation that Valgrind classifies as possibly lost. As with the existing XLS startup-registry suppressions, the new rule matches only this release, leak kind, and Z3 registration stack. A deliberate, unrelated leak still fails Valgrind; it was part of the temporary verification harness, not this PR.

The upgraded code generator also explicitly narrows four-element array indices:

```systemverilog
arr_unflattened[index]       // XLS v0.53.0
arr_unflattened[index[1:0]]  // XLS v0.54.3
```

The two golden updates record this intentional upstream output change.

## Tests

- `cargo test -p xlsynth-sys --tests`
- `cargo clippy -p xlsynth-sys --lib`
- `python3 scripts/check_version_is.py 0.62.0`
- Verified that XLS `v0.54.3` publishes all 105 expected release assets.
- Verified that the Z3 rule suppresses exactly one 80-byte allocation and that an unrelated deliberate leak still fails full Valgrind checking.
- All 12 GitHub Actions checks pass, including Valgrind.
