### PR TITLE
A g8r lowering couple optimizations

### DIFF
--- a/xlsynth-g8r/src/aig/structural_hash_cons.rs
+++ b/xlsynth-g8r/src/aig/structural_hash_cons.rs
@@ -118,6 +118,13 @@ impl StructuralHashCons {
         );
     }
 
+    /// Returns the cached AIG depth for an already-registered operand.
+    pub(crate) fn depth(&self, operand: AigOperand) -> usize {
+        self.ref_data[operand.node.id]
+            .expect("hash-cons operand must have been registered")
+            .depth
+    }
+
     pub(crate) fn find_and(&self, lhs: AigOperand, rhs: AigOperand) -> Option<AigRef> {
         let key = self.and_key(lhs, rhs);
         let expression_id = self.key_to_expression_id.get(&key)?;

--- a/xlsynth-g8r/src/gate_builder.rs
+++ b/xlsynth-g8r/src/gate_builder.rs
@@ -164,6 +164,14 @@ impl GateBuilder {
         }
     }
 
+    /// Returns the cached AIG depth for `operand` when structural hashing is
+    /// enabled.
+    pub fn aig_depth(&self, operand: AigOperand) -> Option<usize> {
+        self.hash_cons
+            .as_ref()
+            .map(|hash_cons| hash_cons.depth(operand))
+    }
+
     pub fn get_false(&self) -> AigOperand {
         AigOperand {
             node: AigRef { id: 0 },
@@ -1391,5 +1399,27 @@ mod tests {
         let first = builder.add_and_binary(a0, b0);
         let second = builder.add_and_binary(duplicate_b0, duplicate_a0);
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_cached_aig_depth_tracks_complemented_edges_and_ands() {
+        let mut builder = GateBuilder::new("cached_depth".to_string(), GateBuilderOptions::opt());
+        let input = builder.add_input("input".to_string(), 3);
+        let a = *input.get_lsb(0);
+        let b = *input.get_lsb(1);
+        let c = *input.get_lsb(2);
+
+        assert_eq!(builder.aig_depth(a), Some(0));
+        let ab = builder.add_and_binary(a, b);
+        assert_eq!(builder.aig_depth(ab), Some(1));
+        let not_ab = builder.add_not(ab);
+        assert_eq!(builder.aig_depth(not_ab), Some(1));
+        let abc = builder.add_and_binary(not_ab, c);
+        assert_eq!(builder.aig_depth(abc), Some(2));
+
+        let mut no_hash =
+            GateBuilder::new("uncached_depth".to_string(), GateBuilderOptions::no_opt());
+        let input = no_hash.add_input("input".to_string(), 1);
+        assert_eq!(no_hash.aig_depth(*input.get_lsb(0)), None);
     }
 }

--- a/xlsynth-g8r/src/gatify/ir2gate.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate.rs
@@ -6,7 +6,9 @@
 use crate::aig::gate::{AigBitVector, AigOperand, GateFn, Split};
 use crate::check_equivalence;
 use crate::gate_builder::{GateBuilder, GateBuilderOptions};
-use crate::gatify::ir2gate_arithmetic::{gatify_add_binop, gatify_ext_nary_add, gatify_sub_binop};
+use crate::gatify::ir2gate_arithmetic::{
+    gatify_add_binop, gatify_ext_nary_add, gatify_sub_binop, try_gatify_selected_unit_delta,
+};
 use crate::gatify::mul_by_const_csd::{SignedDigitSign, decompose_umul_const_terms};
 use crate::gatify::prep_for_gatify::{PrepForGatifyOptions, prep_for_gatify};
 use std::collections::HashMap;
@@ -171,13 +173,35 @@ fn maybe_warn_shift_amount_truncatable(
 
 pub(super) struct GateEnv {
     ir_to_g8: HashMap<ir::NodeRef, GateOrVec>,
+    use_counts: Option<Vec<usize>>,
 }
 
 impl GateEnv {
-    fn new() -> Self {
+    fn new(f: &ir::Fn, track_use_counts: bool) -> Self {
+        let use_counts = if track_use_counts {
+            let mut use_counts = vec![0usize; f.nodes.len()];
+            for node in &f.nodes {
+                for operand in ir_utils::operands(&node.payload) {
+                    use_counts[operand.index] += 1;
+                }
+            }
+            if let Some(ret) = f.ret_node_ref {
+                use_counts[ret.index] += 1;
+            }
+            Some(use_counts)
+        } else {
+            None
+        };
         Self {
             ir_to_g8: HashMap::new(),
+            use_counts,
         }
+    }
+
+    pub(super) fn has_single_use(&self, ir_node_ref: ir::NodeRef) -> bool {
+        self.use_counts
+            .as_ref()
+            .is_some_and(|use_counts| use_counts[ir_node_ref.index] == 1)
     }
 
     fn contains(&self, ir_node_ref: ir::NodeRef) -> bool {
@@ -3197,6 +3221,19 @@ fn gatify_node(
                     suffix
                 );
             }
+            let early_unit_delta = if options.enable_rewrite_nary_add && default.is_none() {
+                try_gatify_selected_unit_delta(
+                    f,
+                    env,
+                    *selector,
+                    cases,
+                    node.ty.bit_count(),
+                    options.adder_mapping,
+                    g8_builder,
+                )
+            } else {
+                None
+            };
             let selector_bits = env
                 .get_bit_vector(*selector)
                 .expect("selector should be present");
@@ -3207,7 +3244,8 @@ fn gatify_node(
             let default_bits =
                 default.map(|d| env.get_bit_vector(d).expect("default should be present"));
 
-            let gates = gatify_sel(g8_builder, &selector_bits, &cases, default_bits);
+            let gates = early_unit_delta
+                .unwrap_or_else(|| gatify_sel(g8_builder, &selector_bits, &cases, default_bits));
 
             // Tag the result bits
             for (i, gate) in gates.iter_lsb_to_msb().enumerate() {
@@ -4363,7 +4401,7 @@ fn gatify_lower_prepared_fn(
             hash: options.hash,
         },
     );
-    let mut env = GateEnv::new();
+    let mut env = GateEnv::new(f, options.enable_rewrite_nary_add);
     let provenance_by_node = if options.track_pir_node_ids {
         orig_ref_by_text_id.map(|original| build_prepared_provenance_map(f, original))
     } else {
@@ -4503,7 +4541,9 @@ pub fn gatify_node_as_fn(
             hash: options.hash,
         },
     );
-    let mut env = GateEnv::new();
+    let track_use_counts =
+        options.enable_rewrite_nary_add && matches!(node.payload, ir::NodePayload::Sel { .. });
+    let mut env = GateEnv::new(f, track_use_counts);
 
     // Precompute a map from parameter id to its NodeRef in f.nodes. This is used
     // when lowering GetParam nodes.
@@ -6561,6 +6601,293 @@ top fn f(start: bits[4], a: bits[8], b: bits[8]) -> bits[8][1] {
         gatify(&ir_fn, GatifyOptions::all_opts_disabled())
             .unwrap()
             .gate_fn
+    }
+
+    fn gatify_selected_unit_delta(
+        ir_text: &str,
+        enable_arrival_aware_lowering: bool,
+        hash: bool,
+    ) -> GateFn {
+        let mut parser = ir_parser::Parser::new(ir_text);
+        let ir_package = parser.parse_and_validate_package().unwrap();
+        let ir_fn = ir_package.get_top_fn().unwrap();
+        super::gatify_prepared_fn(
+            ir_fn,
+            GatifyOptions {
+                hash,
+                enable_rewrite_nary_add: enable_arrival_aware_lowering,
+                ..GatifyOptions::all_opts_disabled()
+            },
+        )
+        .unwrap()
+        .gate_fn
+    }
+
+    #[test]
+    fn test_selected_unit_delta_arrival_aware_lowering_is_exhaustively_equivalent() {
+        for width in 1..=5 {
+            for (literal, is_decrement) in [(1u64, false), ((1u64 << width) - 1, true)] {
+                for swapped_cases in [false, true] {
+                    let cases = if swapped_cases {
+                        "changed, x"
+                    } else {
+                        "x, changed"
+                    };
+                    let ir_text = format!(
+                        r#"package sample
+
+top fn f(x: bits[{width}] id=1, en: bits[1] id=2) -> bits[{width}] {{
+  unit: bits[{width}] = literal(value={literal}, id=3)
+  changed: bits[{width}] = ext_nary_add(x, unit, signed=[false, false], negated=[false, false], id=4)
+  ret out: bits[{width}] = sel(en, cases=[{cases}], id=5)
+}}
+"#
+                    );
+                    let gate_fn = gatify_selected_unit_delta(&ir_text, true, true);
+                    let mask = (1u64 << width) - 1;
+                    for x in 0u64..=mask {
+                        for en in 0u64..2 {
+                            let active = if swapped_cases { 1 - en } else { en };
+                            let expected = if is_decrement {
+                                x.wrapping_sub(active) & mask
+                            } else {
+                                x.wrapping_add(active) & mask
+                            };
+                            let got = gate_sim::eval(
+                                &gate_fn,
+                                &[
+                                    IrBits::make_ubits(width, x).unwrap(),
+                                    IrBits::make_ubits(1, en).unwrap(),
+                                ],
+                                gate_sim::Collect::None,
+                            )
+                            .outputs[0]
+                                .clone();
+                            assert_eq!(
+                                got,
+                                IrBits::make_ubits(width, expected).unwrap(),
+                                "width={width} decrement={is_decrement} swapped={swapped_cases} x={x} en={en}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_selected_unit_delta_fuses_early_control_and_preserves_late_mux() {
+        let early_ir = r#"package sample
+
+top fn f(x: bits[16] id=1, en: bits[1] id=2) -> bits[16] {
+  one: bits[16] = literal(value=1, id=3)
+  changed: bits[16] = ext_nary_add(x, one, signed=[false, false], negated=[false, false], id=4)
+  ret out: bits[16] = sel(en, cases=[x, changed], id=5)
+}
+"#;
+        let early_fused = gatify_selected_unit_delta(early_ir, true, true);
+        let early_muxed = gatify_selected_unit_delta(early_ir, false, true);
+        let early_fused_stats = get_summary_stats(&early_fused);
+        let early_muxed_stats = get_summary_stats(&early_muxed);
+        assert!(
+            early_fused_stats.live_nodes < early_muxed_stats.live_nodes,
+            "early control should fuse: fused={early_fused_stats:?} muxed={early_muxed_stats:?}"
+        );
+
+        let late_ir = r#"package sample
+
+top fn f(x: bits[16] id=1, a: bits[16] id=2, b: bits[16] id=3) -> bits[16] {
+  sum: bits[16] = add(a, b, id=4)
+  en: bits[1] = bit_slice(sum, start=15, width=1, id=5)
+  one: bits[16] = literal(value=1, id=6)
+  changed: bits[16] = ext_nary_add(x, one, signed=[false, false], negated=[false, false], id=7)
+  ret out: bits[16] = sel(en, cases=[x, changed], id=8)
+}
+"#;
+        let late_guarded = gatify_selected_unit_delta(late_ir, true, true);
+        let late_muxed = gatify_selected_unit_delta(late_ir, false, true);
+        let late_guarded_stats = get_summary_stats(&late_guarded);
+        let late_muxed_stats = get_summary_stats(&late_muxed);
+        assert_eq!(
+            late_guarded_stats.live_nodes, late_muxed_stats.live_nodes,
+            "late control should preserve the speculative mux"
+        );
+        assert_eq!(
+            late_guarded_stats.deepest_path, late_muxed_stats.deepest_path,
+            "late control should preserve mux depth"
+        );
+    }
+
+    #[test]
+    fn test_selected_unit_delta_matches_zero_extended_base_and_wide_decrement() {
+        let zero_extended_ir = r#"package sample
+
+top fn f(x: bits[15] id=1, en: bits[1] id=2) -> bits[16] {
+  zero: bits[1] = literal(value=0, id=3)
+  base: bits[16] = concat(zero, x, id=4)
+  one: bits[16] = literal(value=1, id=5)
+  changed: bits[16] = ext_nary_add(x, one, signed=[false, false], negated=[false, false], id=6)
+  ret out: bits[16] = sel(en, cases=[base, changed], id=7)
+}
+"#;
+        let fused = gatify_selected_unit_delta(zero_extended_ir, true, true);
+        let muxed = gatify_selected_unit_delta(zero_extended_ir, false, true);
+        assert!(get_summary_stats(&fused).live_nodes < get_summary_stats(&muxed).live_nodes);
+
+        let wide_decrement_ir = r#"package sample
+
+top fn f(x: bits[128] id=1, en: bits[1] id=2) -> bits[128] {
+  minus_one: bits[128] = literal(value=0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff, id=3)
+  changed: bits[128] = ext_nary_add(x, minus_one, signed=[false, false], negated=[false, false], id=4)
+  ret out: bits[128] = sel(en, cases=[x, changed], id=5)
+}
+"#;
+        let fused = gatify_selected_unit_delta(wide_decrement_ir, true, true);
+        let muxed = gatify_selected_unit_delta(wide_decrement_ir, false, true);
+        assert!(get_summary_stats(&fused).live_nodes < get_summary_stats(&muxed).live_nodes);
+
+        let no_hash = gatify_selected_unit_delta(wide_decrement_ir, true, false);
+        let no_hash_stats = get_summary_stats(&no_hash);
+        assert!(no_hash_stats.live_nodes > 0);
+    }
+
+    #[test]
+    fn test_selected_unit_delta_matches_add_sub_spellings_and_keeps_shared_update() {
+        for changed_definition in [
+            "changed: bits[16] = add(x, one, id=4)",
+            "changed: bits[16] = add(one, x, id=4)",
+            "changed: bits[16] = sub(x, one, id=4)",
+        ] {
+            let ir_text = format!(
+                r#"package sample
+
+top fn f(x: bits[16] id=1, en: bits[1] id=2) -> bits[16] {{
+  one: bits[16] = literal(value=1, id=3)
+  {changed_definition}
+  ret out: bits[16] = sel(en, cases=[x, changed], id=5)
+}}
+"#
+            );
+            let fused = gatify_selected_unit_delta(&ir_text, true, true);
+            let muxed = gatify_selected_unit_delta(&ir_text, false, true);
+            assert!(
+                get_summary_stats(&fused).live_nodes < get_summary_stats(&muxed).live_nodes,
+                "expected early update to fuse for `{changed_definition}`"
+            );
+        }
+
+        let shared_ir = r#"package sample
+
+top fn f(x: bits[16] id=1, en: bits[1] id=2) -> (bits[16], bits[16]) {
+  one: bits[16] = literal(value=1, id=3)
+  changed: bits[16] = add(x, one, id=4)
+  selected: bits[16] = sel(en, cases=[x, changed], id=5)
+  ret out: (bits[16], bits[16]) = tuple(selected, changed, id=6)
+}
+"#;
+        let guarded = gatify_selected_unit_delta(shared_ir, true, true);
+        let muxed = gatify_selected_unit_delta(shared_ir, false, true);
+        let guarded_stats = get_summary_stats(&guarded);
+        let muxed_stats = get_summary_stats(&muxed);
+        assert_eq!(guarded_stats.live_nodes, muxed_stats.live_nodes);
+        assert_eq!(guarded_stats.deepest_path, muxed_stats.deepest_path);
+    }
+
+    #[test]
+    fn test_selected_unit_delta_composes_with_prep_and_preserves_explicit_arch() {
+        let unprepared_ir = r#"package sample
+
+top fn f(x: bits[16] id=1, en: bits[1] id=2) -> bits[16] {
+  one: bits[16] = literal(value=1, id=3)
+  changed: bits[16] = add(x, one, id=4)
+  ret out: bits[16] = sel(en, cases=[x, changed], id=5)
+}
+"#;
+        let mut parser = ir_parser::Parser::new(unprepared_ir);
+        let ir_package = parser.parse_and_validate_package().unwrap();
+        let ir_fn = ir_package.get_top_fn().unwrap();
+        let fused = gatify(
+            ir_fn,
+            GatifyOptions {
+                enable_rewrite_nary_add: true,
+                ..GatifyOptions::all_opts_disabled()
+            },
+        )
+        .unwrap()
+        .gate_fn;
+        let muxed = gatify(ir_fn, GatifyOptions::all_opts_disabled())
+            .unwrap()
+            .gate_fn;
+        assert!(get_summary_stats(&fused).live_nodes < get_summary_stats(&muxed).live_nodes);
+
+        let explicit_arch_ir = r#"package sample
+
+top fn f(x: bits[16] id=1, en: bits[1] id=2) -> bits[16] {
+  one: bits[16] = literal(value=1, id=3)
+  changed: bits[16] = ext_nary_add(x, one, signed=[false, false], negated=[false, false], arch=ripple_carry, id=4)
+  ret out: bits[16] = sel(en, cases=[x, changed], id=5)
+}
+"#;
+        let mut parser = ir_parser::Parser::new(explicit_arch_ir);
+        let ir_package = parser.parse_and_validate_package().unwrap();
+        let ir_fn = ir_package.get_top_fn().unwrap();
+        let explicit_ripple = super::gatify_prepared_fn(
+            ir_fn,
+            GatifyOptions {
+                adder_mapping: AdderMapping::KoggeStone,
+                enable_rewrite_nary_add: true,
+                ..GatifyOptions::all_opts_disabled()
+            },
+        )
+        .unwrap()
+        .gate_fn;
+        let implicit_ripple_ir = explicit_arch_ir.replace(", arch=ripple_carry", "");
+        let mut parser = ir_parser::Parser::new(&implicit_ripple_ir);
+        let ir_package = parser.parse_and_validate_package().unwrap();
+        let ir_fn = ir_package.get_top_fn().unwrap();
+        let implicit_ripple = super::gatify_prepared_fn(
+            ir_fn,
+            GatifyOptions {
+                adder_mapping: AdderMapping::RippleCarry,
+                enable_rewrite_nary_add: true,
+                ..GatifyOptions::all_opts_disabled()
+            },
+        )
+        .unwrap()
+        .gate_fn;
+        let explicit_stats = get_summary_stats(&explicit_ripple);
+        let implicit_stats = get_summary_stats(&implicit_ripple);
+        assert_eq!(explicit_stats.live_nodes, implicit_stats.live_nodes);
+        assert_eq!(explicit_stats.deepest_path, implicit_stats.deepest_path);
+    }
+
+    #[test]
+    fn test_selected_unit_delta_matches_signed_resize_and_literal_contribution() {
+        let signed_resize_ir = r#"package sample
+
+top fn f(x: bits[15] id=1, en: bits[1] id=2) -> bits[16] {
+  sign: bits[1] = bit_slice(x, start=14, width=1, id=3)
+  base: bits[16] = concat(sign, x, id=4)
+  one: bits[16] = literal(value=1, id=5)
+  changed: bits[16] = ext_nary_add(x, one, signed=[true, false], negated=[false, false], id=6)
+  ret out: bits[16] = sel(en, cases=[base, changed], id=7)
+}
+"#;
+        let fused = gatify_selected_unit_delta(signed_resize_ir, true, true);
+        let muxed = gatify_selected_unit_delta(signed_resize_ir, false, true);
+        assert!(get_summary_stats(&fused).live_nodes < get_summary_stats(&muxed).live_nodes);
+
+        let signed_literal_ir = r#"package sample
+
+top fn f(x: bits[16] id=1, en: bits[1] id=2) -> bits[16] {
+  minus_one: bits[1] = literal(value=1, id=3)
+  changed: bits[16] = ext_nary_add(x, minus_one, signed=[false, true], negated=[false, false], id=4)
+  ret out: bits[16] = sel(en, cases=[x, changed], id=5)
+}
+"#;
+        let fused = gatify_selected_unit_delta(signed_literal_ir, true, true);
+        let muxed = gatify_selected_unit_delta(signed_literal_ir, false, true);
+        assert!(get_summary_stats(&fused).live_nodes < get_summary_stats(&muxed).live_nodes);
     }
 
     #[test]

--- a/xlsynth-g8r/src/gatify/ir2gate.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate.rs
@@ -173,35 +173,30 @@ fn maybe_warn_shift_amount_truncatable(
 
 pub(super) struct GateEnv {
     ir_to_g8: HashMap<ir::NodeRef, GateOrVec>,
-    use_counts: Option<Vec<usize>>,
+    use_counts: Vec<usize>,
 }
 
 impl GateEnv {
-    fn new(f: &ir::Fn, track_use_counts: bool) -> Self {
-        let use_counts = if track_use_counts {
-            let mut use_counts = vec![0usize; f.nodes.len()];
-            for node in &f.nodes {
-                for operand in ir_utils::operands(&node.payload) {
-                    use_counts[operand.index] += 1;
-                }
+    /// Creates a lowering environment with use counts for prepared IR nodes.
+    fn new(f: &ir::Fn) -> Self {
+        let mut use_counts = vec![0usize; f.nodes.len()];
+        for node in &f.nodes {
+            for operand in ir_utils::operands(&node.payload) {
+                use_counts[operand.index] += 1;
             }
-            if let Some(ret) = f.ret_node_ref {
-                use_counts[ret.index] += 1;
-            }
-            Some(use_counts)
-        } else {
-            None
-        };
+        }
+        if let Some(ret) = f.ret_node_ref {
+            use_counts[ret.index] += 1;
+        }
         Self {
             ir_to_g8: HashMap::new(),
             use_counts,
         }
     }
 
+    /// Returns whether a prepared IR node has exactly one consumer.
     pub(super) fn has_single_use(&self, ir_node_ref: ir::NodeRef) -> bool {
-        self.use_counts
-            .as_ref()
-            .is_some_and(|use_counts| use_counts[ir_node_ref.index] == 1)
+        self.use_counts[ir_node_ref.index] == 1
     }
 
     fn contains(&self, ir_node_ref: ir::NodeRef) -> bool {
@@ -3557,6 +3552,7 @@ fn gatify_node(
                 *arch,
                 output_width,
                 options.adder_mapping,
+                options.enable_rewrite_nary_add,
                 g8_builder,
             );
             env.add(node_ref, GateOrVec::BitVector(gates));
@@ -4401,7 +4397,7 @@ fn gatify_lower_prepared_fn(
             hash: options.hash,
         },
     );
-    let mut env = GateEnv::new(f, options.enable_rewrite_nary_add);
+    let mut env = GateEnv::new(f);
     let provenance_by_node = if options.track_pir_node_ids {
         orig_ref_by_text_id.map(|original| build_prepared_provenance_map(f, original))
     } else {
@@ -4541,12 +4537,7 @@ pub fn gatify_node_as_fn(
             hash: options.hash,
         },
     );
-    let track_use_counts = options.enable_rewrite_nary_add
-        && matches!(
-            node.payload,
-            ir::NodePayload::Sel { .. } | ir::NodePayload::ExtNaryAdd { .. }
-        );
-    let mut env = GateEnv::new(f, track_use_counts);
+    let mut env = GateEnv::new(f);
 
     // Precompute a map from parameter id to its NodeRef in f.nodes. This is used
     // when lowering GetParam nodes.
@@ -6648,6 +6639,39 @@ top fn f(start: bits[4], a: bits[8], b: bits[8]) -> bits[8][1] {
         )
         .unwrap()
         .gate_fn
+    }
+
+    #[test]
+    fn test_gate_env_unconditionally_tracks_operand_and_return_uses() {
+        let ir_text = r#"package sample
+
+top fn f(x: bits[8] id=1) -> bits[8] {
+  doubled: bits[8] = add(x, x, id=2)
+  ret out: bits[8] = add(doubled, x, id=3)
+}
+"#;
+        let mut parser = ir_parser::Parser::new(ir_text);
+        let ir_package = parser.parse_and_validate_package().unwrap();
+        let ir_fn = ir_package.get_top_fn().unwrap();
+        let env = super::GateEnv::new(ir_fn);
+        let node_ref_with_text_id = |text_id| ir::NodeRef {
+            index: ir_fn
+                .nodes
+                .iter()
+                .position(|node| node.text_id == text_id)
+                .expect("test node should exist"),
+        };
+        let x = node_ref_with_text_id(1);
+        let doubled = node_ref_with_text_id(2);
+        let out = node_ref_with_text_id(3);
+
+        assert_eq!(env.use_counts.len(), ir_fn.nodes.len());
+        assert_eq!(env.use_counts[x.index], 3);
+        assert!(!env.has_single_use(x));
+        assert_eq!(env.use_counts[doubled.index], 1);
+        assert!(env.has_single_use(doubled));
+        assert_eq!(env.use_counts[out.index], 1);
+        assert!(env.has_single_use(out));
     }
 
     #[test]

--- a/xlsynth-g8r/src/gatify/ir2gate.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate.rs
@@ -4541,8 +4541,11 @@ pub fn gatify_node_as_fn(
             hash: options.hash,
         },
     );
-    let track_use_counts =
-        options.enable_rewrite_nary_add && matches!(node.payload, ir::NodePayload::Sel { .. });
+    let track_use_counts = options.enable_rewrite_nary_add
+        && matches!(
+            node.payload,
+            ir::NodePayload::Sel { .. } | ir::NodePayload::ExtNaryAdd { .. }
+        );
     let mut env = GateEnv::new(f, track_use_counts);
 
     // Precompute a map from parameter id to its NodeRef in f.nodes. This is used
@@ -4623,6 +4626,7 @@ mod tests {
     use crate::check_equivalence;
     use crate::gate_builder::{GateBuilder, GateBuilderOptions, ReductionKind};
     use crate::gatify::ir2gate::{GatifyOptions, gatify};
+    use crate::gatify::prep_for_gatify::{PrepForGatifyOptions, prep_for_gatify};
     use crate::ir2gate_utils::{AdderMapping, Direction, gatify_barrel_shifter};
     use xlsynth::{IrBits, IrValue};
     use xlsynth_pir::ir;
@@ -6621,6 +6625,205 @@ top fn f(start: bits[4], a: bits[8], b: bits[8]) -> bits[8][1] {
         )
         .unwrap()
         .gate_fn
+    }
+
+    fn gatify_selected_negate(ir_text: &str, enable_arrival_aware_lowering: bool) -> GateFn {
+        let mut parser = ir_parser::Parser::new(ir_text);
+        let ir_package = parser.parse_and_validate_package().unwrap();
+        let ir_fn = ir_package.get_top_fn().unwrap();
+        let prepared = prep_for_gatify(
+            ir_fn,
+            None,
+            PrepForGatifyOptions {
+                enable_rewrite_nary_add: true,
+                ..PrepForGatifyOptions::default()
+            },
+        );
+        super::gatify_prepared_fn(
+            &prepared,
+            GatifyOptions {
+                enable_rewrite_nary_add: enable_arrival_aware_lowering,
+                ..GatifyOptions::all_opts_disabled()
+            },
+        )
+        .unwrap()
+        .gate_fn
+    }
+
+    #[test]
+    fn test_selected_negate_arrival_aware_lowering_is_exhaustively_equivalent() {
+        for width in 1..=4 {
+            for swapped_cases in [false, true] {
+                for outer_sub in [false, true] {
+                    let cases = if swapped_cases {
+                        "negated, x"
+                    } else {
+                        "x, negated"
+                    };
+                    let operation = if outer_sub { "sub" } else { "add" };
+                    let ir_text = format!(
+                        r#"package sample
+
+top fn f(x: bits[{width}] id=1, en: bits[1] id=2, y: bits[{width}] id=3) -> bits[{width}] {{
+  negated: bits[{width}] = neg(x, id=4)
+  selected: bits[{width}] = sel(en, cases=[{cases}], id=5)
+  ret out: bits[{width}] = {operation}(y, selected, id=6)
+}}
+"#
+                    );
+                    let gate_fn = gatify_selected_negate(&ir_text, true);
+                    let mask = (1u64 << width) - 1;
+                    for x in 0u64..=mask {
+                        for en in 0u64..2 {
+                            for y in 0u64..=mask {
+                                let negate = if swapped_cases { 1 - en } else { en } != 0;
+                                let selected = if negate { x.wrapping_neg() & mask } else { x };
+                                let expected = if outer_sub {
+                                    y.wrapping_sub(selected) & mask
+                                } else {
+                                    y.wrapping_add(selected) & mask
+                                };
+                                let got = gate_sim::eval(
+                                    &gate_fn,
+                                    &[
+                                        IrBits::make_ubits(width, x).unwrap(),
+                                        IrBits::make_ubits(1, en).unwrap(),
+                                        IrBits::make_ubits(width, y).unwrap(),
+                                    ],
+                                    gate_sim::Collect::None,
+                                )
+                                .outputs[0]
+                                    .clone();
+                                assert_eq!(
+                                    got,
+                                    IrBits::make_ubits(width, expected).unwrap(),
+                                    "width={width} swapped={swapped_cases} sub={outer_sub} x={x} en={en} y={y}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_selected_negate_keeps_mux_when_other_addend_is_late() {
+        let ir_text = r#"package sample
+
+top fn f(x: bits[16] id=1, en: bits[1] id=2, y: bits[16] id=3, amount: bits[4] id=4) -> bits[16] {
+  negated: bits[16] = neg(x, id=5)
+  selected: bits[16] = sel(en, cases=[x, negated], id=6)
+  shifted: bits[16] = shrl(y, amount, id=7)
+  ret out: bits[16] = add(shifted, selected, id=8)
+}
+"#;
+        let guarded = gatify_selected_negate(ir_text, true);
+        let muxed = gatify_selected_negate(ir_text, false);
+        let guarded_stats = get_summary_stats(&guarded);
+        let muxed_stats = get_summary_stats(&muxed);
+        assert_eq!(guarded_stats.live_nodes, muxed_stats.live_nodes);
+        assert_eq!(guarded_stats.deepest_path, muxed_stats.deepest_path);
+    }
+
+    #[test]
+    fn test_selected_negate_fuses_multiple_selected_terms() {
+        let ir_text = r#"package sample
+
+top fn f(x: bits[8] id=1, px: bits[1] id=2, y: bits[8] id=3, py: bits[1] id=4) -> bits[8] {
+  nx: bits[8] = neg(x, id=5)
+  sx: bits[8] = sel(px, cases=[x, nx], id=6)
+  ny: bits[8] = neg(y, id=7)
+  sy: bits[8] = sel(py, cases=[y, ny], id=8)
+  ret out: bits[8] = add(sx, sy, id=9)
+}
+"#;
+        let fused = gatify_selected_negate(ir_text, true);
+        let muxed = gatify_selected_negate(ir_text, false);
+        let fused_stats = get_summary_stats(&fused);
+        let muxed_stats = get_summary_stats(&muxed);
+        assert!(
+            fused_stats.deepest_path < muxed_stats.deepest_path,
+            "jointly selected negations should reduce adder depth: fused={fused_stats:?} muxed={muxed_stats:?}"
+        );
+        for x in 0u64..16 {
+            for y in 0u64..16 {
+                for px in 0u64..2 {
+                    for py in 0u64..2 {
+                        let sx = if px == 0 { x } else { x.wrapping_neg() & 0xff };
+                        let sy = if py == 0 { y } else { y.wrapping_neg() & 0xff };
+                        let got = gate_sim::eval(
+                            &fused,
+                            &[
+                                IrBits::make_ubits(8, x).unwrap(),
+                                IrBits::make_ubits(1, px).unwrap(),
+                                IrBits::make_ubits(8, y).unwrap(),
+                                IrBits::make_ubits(1, py).unwrap(),
+                            ],
+                            gate_sim::Collect::None,
+                        )
+                        .outputs[0]
+                            .clone();
+                        assert_eq!(got, IrBits::make_ubits(8, (sx + sy) & 0xff).unwrap());
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_selected_negate_handles_safe_signed_widening() {
+        let ir_text = r#"package sample
+
+top fn f(x: bits[4] id=1, en: bits[1] id=2, y: bits[6] id=3) -> bits[6] {
+  zero: bits[1] = literal(value=0, id=4)
+  base: bits[5] = concat(zero, x, id=5)
+  negated: bits[5] = neg(base, id=6)
+  selected: bits[5] = sel(en, cases=[base, negated], id=7)
+  extended: bits[6] = sign_ext(selected, new_bit_count=6, id=8)
+  ret out: bits[6] = add(y, extended, id=9)
+}
+"#;
+        let gate_fn = gatify_selected_negate(ir_text, true);
+        for x in 0u64..16 {
+            for en in 0u64..2 {
+                for y in 0u64..64 {
+                    let selected = if en == 0 { x } else { x.wrapping_neg() & 0x3f };
+                    let expected = (y + selected) & 0x3f;
+                    let got = gate_sim::eval(
+                        &gate_fn,
+                        &[
+                            IrBits::make_ubits(4, x).unwrap(),
+                            IrBits::make_ubits(1, en).unwrap(),
+                            IrBits::make_ubits(6, y).unwrap(),
+                        ],
+                        gate_sim::Collect::None,
+                    )
+                    .outputs[0]
+                        .clone();
+                    assert_eq!(got, IrBits::make_ubits(6, expected).unwrap());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_selected_negate_keeps_shared_negation() {
+        let ir_text = r#"package sample
+
+top fn f(x: bits[8] id=1, en: bits[1] id=2, y: bits[8] id=3) -> (bits[8], bits[8]) {
+  negated: bits[8] = neg(x, id=4)
+  selected: bits[8] = sel(en, cases=[x, negated], id=5)
+  sum: bits[8] = add(y, selected, id=6)
+  ret out: (bits[8], bits[8]) = tuple(sum, negated, id=7)
+}
+"#;
+        let guarded = gatify_selected_negate(ir_text, true);
+        let muxed = gatify_selected_negate(ir_text, false);
+        let guarded_stats = get_summary_stats(&guarded);
+        let muxed_stats = get_summary_stats(&muxed);
+        assert_eq!(guarded_stats.live_nodes, muxed_stats.live_nodes);
+        assert_eq!(guarded_stats.deepest_path, muxed_stats.deepest_path);
     }
 
     #[test]

--- a/xlsynth-g8r/src/gatify/ir2gate.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate.rs
@@ -6946,6 +6946,63 @@ top fn f(x: bits[16] id=1, a: bits[16] id=2, b: bits[16] id=3) -> bits[16] {
     }
 
     #[test]
+    fn test_selected_unit_delta_preserves_mux_for_ripple_carry() {
+        for (arch, adder_mapping) in [
+            (", arch=ripple_carry", AdderMapping::KoggeStone),
+            ("", AdderMapping::RippleCarry),
+        ] {
+            let ir_text = format!(
+                r#"package sample
+
+top fn f(x: bits[16] id=1, en: bits[6] id=2) -> bits[16] {{
+  e0: bits[1] = bit_slice(en, start=0, width=1, id=3)
+  e1: bits[1] = bit_slice(en, start=1, width=1, id=4)
+  e2: bits[1] = bit_slice(en, start=2, width=1, id=5)
+  e3: bits[1] = bit_slice(en, start=3, width=1, id=6)
+  e4: bits[1] = bit_slice(en, start=4, width=1, id=7)
+  e5: bits[1] = bit_slice(en, start=5, width=1, id=8)
+  p1: bits[1] = and(e0, e1, id=9)
+  p2: bits[1] = and(p1, e2, id=10)
+  p3: bits[1] = and(p2, e3, id=11)
+  p4: bits[1] = and(p3, e4, id=12)
+  selector: bits[1] = and(p4, e5, id=13)
+  one: bits[16] = literal(value=1, id=14)
+  changed: bits[16] = ext_nary_add(x, one, signed=[false, false], negated=[false, false]{arch}, id=15)
+  ret out: bits[16] = sel(selector, cases=[x, changed], id=16)
+}}
+"#
+            );
+
+            let lower = |enable_rewrite_nary_add| {
+                let mut parser = ir_parser::Parser::new(&ir_text);
+                let ir_package = parser.parse_and_validate_package().unwrap();
+                let ir_fn = ir_package.get_top_fn().unwrap();
+                super::gatify_prepared_fn(
+                    ir_fn,
+                    GatifyOptions {
+                        adder_mapping,
+                        enable_rewrite_nary_add,
+                        ..GatifyOptions::all_opts_disabled()
+                    },
+                )
+                .unwrap()
+                .gate_fn
+            };
+
+            let guarded_stats = get_summary_stats(&lower(true));
+            let muxed_stats = get_summary_stats(&lower(false));
+            assert_eq!(
+                guarded_stats.live_nodes, muxed_stats.live_nodes,
+                "ripple-carry selected updates should preserve mux area: arch={arch:?} mapping={adder_mapping:?}"
+            );
+            assert_eq!(
+                guarded_stats.deepest_path, muxed_stats.deepest_path,
+                "ripple-carry selected updates should preserve mux depth: arch={arch:?} mapping={adder_mapping:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_selected_unit_delta_matches_zero_extended_base_and_wide_decrement() {
         let zero_extended_ir = r#"package sample
 

--- a/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
@@ -33,6 +33,20 @@ struct ExtNaryAddUnitCorrection {
     is_decrement: bool,
 }
 
+#[derive(Clone, Debug)]
+struct SelectedUnitDeltaMatch {
+    base_bits: AigBitVector,
+    changed_bits: AigBitVector,
+    is_decrement: bool,
+    invert_selector: bool,
+    adder_mapping: AdderMapping,
+}
+
+/// Returns the minimum selector-arrival margin for a selected unit update.
+fn selected_unit_delta_arrival_margin(output_width: usize) -> usize {
+    2.max(xlsynth_pir::math::ceil_log2(output_width))
+}
+
 /// Resizes a literal term to the `ExtNaryAdd` output width.
 fn resize_literal_bits_for_ext_nary_add(
     bits: &xlsynth::IrBits,
@@ -90,6 +104,219 @@ fn is_one(bits: &xlsynth::IrBits) -> bool {
         }
     }
     true
+}
+
+/// Returns whether two lowered bit vectors contain the same AIG operands.
+fn aig_bits_equal(lhs: &AigBitVector, rhs: &AigBitVector) -> bool {
+    lhs.get_bit_count() == rhs.get_bit_count()
+        && lhs
+            .iter_lsb_to_msb()
+            .zip(rhs.iter_lsb_to_msb())
+            .all(|(lhs_bit, rhs_bit)| lhs_bit == rhs_bit)
+}
+
+/// Resizes a dynamic arithmetic term without creating or tagging AIG nodes.
+fn resize_dynamic_term_for_match(
+    bits: &AigBitVector,
+    output_width: usize,
+    signed: bool,
+) -> AigBitVector {
+    match bits.get_bit_count().cmp(&output_width) {
+        std::cmp::Ordering::Less if signed && bits.get_bit_count() != 0 => {
+            let sign = *bits.get_msb(0);
+            let extension =
+                AigBitVector::from_lsb_is_index_0(&vec![sign; output_width - bits.get_bit_count()]);
+            AigBitVector::concat(extension, bits.clone())
+        }
+        std::cmp::Ordering::Less => gatify_zext_or_truncate(output_width, bits),
+        std::cmp::Ordering::Equal => bits.clone(),
+        std::cmp::Ordering::Greater => bits.get_lsb_slice(0, output_width),
+    }
+}
+
+/// Matches the prepared or unprepared spelling of a width-preserving unit
+/// delta.
+fn match_unit_delta_from_base_bits(
+    f: &ir::Fn,
+    env: &GateEnv,
+    changed: ir::NodeRef,
+    base_bits: &AigBitVector,
+    output_width: usize,
+) -> Option<bool> {
+    let (dynamic_operand, dynamic_signed, dynamic_negated, literal_contribution) =
+        match &f.get_node(changed).payload {
+            ir::NodePayload::Binop(ir::Binop::Add, lhs, rhs) => {
+                let (dynamic_operand, literal_bits) = normalize_add_literal_rhs(f, *lhs, *rhs)?;
+                (dynamic_operand, false, false, literal_bits)
+            }
+            ir::NodePayload::Binop(ir::Binop::Sub, lhs, rhs) => {
+                let literal_bits = literal_bits_if_bits_node(f, *rhs)?;
+                (*lhs, false, false, literal_bits.negate())
+            }
+            ir::NodePayload::ExtNaryAdd { terms, .. } if terms.len() == 2 => {
+                let mut dynamic_term = None;
+                let mut literal_sum = xlsynth::IrBits::zero(output_width);
+                for term in terms {
+                    if let Some(literal_bits) = literal_bits_if_bits_node(f, term.operand) {
+                        accumulate_ext_nary_add_literal(
+                            &mut literal_sum,
+                            &literal_bits,
+                            output_width,
+                            term.signed,
+                            term.negated,
+                        );
+                    } else if dynamic_term.replace(*term).is_some() {
+                        return None;
+                    }
+                }
+                let dynamic_term = dynamic_term?;
+                (
+                    dynamic_term.operand,
+                    dynamic_term.signed,
+                    dynamic_term.negated,
+                    literal_sum,
+                )
+            }
+            _ => return None,
+        };
+    if dynamic_negated {
+        return None;
+    }
+
+    let dynamic_bits = env.get_bit_vector(dynamic_operand).ok()?;
+    let resized_dynamic_bits =
+        resize_dynamic_term_for_match(&dynamic_bits, output_width, dynamic_signed);
+    if !aig_bits_equal(&resized_dynamic_bits, base_bits) {
+        return None;
+    }
+
+    if literal_contribution.equals_u64_value(1) {
+        Some(false)
+    } else if literal_contribution.negate().equals_u64_value(1) {
+        Some(true)
+    } else {
+        None
+    }
+}
+
+/// Finds `sel(p, cases=[x, x +/- 1])`, accounting for prep-induced resize
+/// aliases.
+fn match_selected_unit_delta(
+    f: &ir::Fn,
+    env: &GateEnv,
+    cases: &[ir::NodeRef],
+    output_width: usize,
+    default_adder_mapping: AdderMapping,
+) -> Option<SelectedUnitDeltaMatch> {
+    if cases.len() != 2 || output_width == 0 {
+        return None;
+    }
+    for (changed_index, base_index) in [(1usize, 0usize), (0, 1)] {
+        let changed = cases[changed_index];
+        if !env.has_single_use(changed) {
+            continue;
+        }
+        if !matches!(
+            &f.get_node(changed).payload,
+            ir::NodePayload::Binop(ir::Binop::Add | ir::Binop::Sub, _, _)
+                | ir::NodePayload::ExtNaryAdd { .. }
+        ) {
+            continue;
+        }
+        let base_bits = env.get_bit_vector(cases[base_index]).ok()?;
+        if base_bits.get_bit_count() != output_width {
+            continue;
+        }
+        let Some(is_decrement) =
+            match_unit_delta_from_base_bits(f, env, changed, &base_bits, output_width)
+        else {
+            continue;
+        };
+        let changed_bits = env.get_bit_vector(changed).ok()?;
+        if changed_bits.get_bit_count() != output_width {
+            continue;
+        }
+        let adder_mapping = match &f.get_node(changed).payload {
+            ir::NodePayload::ExtNaryAdd {
+                arch: Some(arch), ..
+            } => AdderMapping::from(*arch),
+            _ => default_adder_mapping,
+        };
+        return Some(SelectedUnitDeltaMatch {
+            base_bits,
+            changed_bits,
+            is_decrement,
+            invert_selector: changed_index == 0,
+            adder_mapping,
+        });
+    }
+    None
+}
+
+/// Lowers an early selected unit update by injecting the predicate as carry-in.
+pub(super) fn try_gatify_selected_unit_delta(
+    f: &ir::Fn,
+    env: &GateEnv,
+    selector: ir::NodeRef,
+    cases: &[ir::NodeRef],
+    output_width: usize,
+    adder_mapping: AdderMapping,
+    gb: &mut GateBuilder,
+) -> Option<AigBitVector> {
+    let selector_bits = env.get_bit_vector(selector).ok()?;
+    if selector_bits.get_bit_count() != 1 {
+        return None;
+    }
+    let matched = match_selected_unit_delta(f, env, cases, output_width, adder_mapping)?;
+    let selector_bit = *selector_bits.get_lsb(0);
+    let selector_depth = gb.aig_depth(selector_bit)?;
+    let changed_depth = matched
+        .changed_bits
+        .iter_lsb_to_msb()
+        .map(|bit| gb.aig_depth(*bit))
+        .max()??;
+
+    // The carry-in must be early enough to propagate through the selected
+    // update; require at least the prefix depth or the two-level mux cost.
+    let margin = selected_unit_delta_arrival_margin(output_width);
+    if selector_depth.saturating_add(margin) >= changed_depth {
+        log::debug!(
+            "selected-unit lowering: selector={} width={} selector_depth={} changed_depth={} margin={} choice=mux",
+            f.get_node(selector).text_id,
+            output_width,
+            selector_depth,
+            changed_depth,
+            margin
+        );
+        return None;
+    }
+    log::debug!(
+        "selected-unit lowering: selector={} width={} selector_depth={} changed_depth={} margin={} choice=carry-in",
+        f.get_node(selector).text_id,
+        output_width,
+        selector_depth,
+        changed_depth,
+        margin
+    );
+
+    let control = if matched.invert_selector {
+        gb.add_not(selector_bit)
+    } else {
+        selector_bit
+    };
+    let base_bits = if matched.is_decrement {
+        gb.add_not_vec(&matched.base_bits)
+    } else {
+        matched.base_bits
+    };
+    let zeros = AigBitVector::zeros(output_width);
+    let (_, sum) =
+        gatify_add_with_mapping(matched.adder_mapping, &base_bits, &zeros, control, None, gb);
+    if matched.is_decrement {
+        Some(gb.add_not_vec(&sum))
+    } else {
+        Some(sum)
+    }
 }
 
 fn normalize_add_literal_rhs(
@@ -273,6 +500,24 @@ fn gatify_add_literal_to_dynamic_sum(
         gb,
     );
     sum
+}
+
+#[cfg(test)]
+mod tests {
+    use super::selected_unit_delta_arrival_margin;
+
+    #[test]
+    fn selected_unit_delta_arrival_margin_scales_with_output_width() {
+        assert_eq!(selected_unit_delta_arrival_margin(0), 2);
+        assert_eq!(selected_unit_delta_arrival_margin(1), 2);
+        assert_eq!(selected_unit_delta_arrival_margin(4), 2);
+        assert_eq!(selected_unit_delta_arrival_margin(7), 3);
+        assert_eq!(selected_unit_delta_arrival_margin(8), 3);
+        assert_eq!(selected_unit_delta_arrival_margin(9), 4);
+        assert_eq!(selected_unit_delta_arrival_margin(12), 4);
+        assert_eq!(selected_unit_delta_arrival_margin(25), 5);
+        assert_eq!(selected_unit_delta_arrival_margin(54), 6);
+    }
 }
 
 fn classify_ext_nary_add_term_dimensions(

--- a/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
@@ -42,9 +42,82 @@ struct SelectedUnitDeltaMatch {
     adder_mapping: AdderMapping,
 }
 
+#[derive(Clone, Debug)]
+struct SelectedNegateMatch {
+    base_bits: AigBitVector,
+    selected_bits: AigBitVector,
+    control: AigOperand,
+    invert_control: bool,
+}
+
 /// Returns the minimum selector-arrival margin for a selected unit update.
 fn selected_unit_delta_arrival_margin(output_width: usize) -> usize {
     2.max(xlsynth_pir::math::ceil_log2(output_width))
+}
+
+/// Returns the maximum cached AIG depth of a bit vector.
+fn max_aig_depth(gb: &GateBuilder, bits: &AigBitVector) -> Option<usize> {
+    bits.iter_lsb_to_msb().map(|bit| gb.aig_depth(*bit)).max()?
+}
+
+/// Matches a safely fusable `sel(p, [x, -x])` arithmetic term.
+fn match_selected_negate_term(
+    f: &ir::Fn,
+    env: &GateEnv,
+    term: &ir::ExtNaryAddTerm,
+    output_width: usize,
+    false_bit: AigOperand,
+) -> Option<SelectedNegateMatch> {
+    if !env.has_single_use(term.operand) {
+        return None;
+    }
+    let ir::NodePayload::Sel {
+        selector,
+        cases,
+        default: None,
+    } = &f.get_node(term.operand).payload
+    else {
+        return None;
+    };
+    if cases.len() != 2 {
+        return None;
+    }
+    let selector_bits = env.get_bit_vector(*selector).ok()?;
+    if selector_bits.get_bit_count() != 1 {
+        return None;
+    }
+
+    for (neg_index, base_index) in [(1usize, 0usize), (0, 1)] {
+        let neg_node = cases[neg_index];
+        if !env.has_single_use(neg_node) {
+            continue;
+        }
+        let ir::NodePayload::Unop(ir::Unop::Neg, neg_arg) = f.get_node(neg_node).payload else {
+            continue;
+        };
+        if neg_arg != cases[base_index] {
+            continue;
+        }
+        let base_bits = env.get_bit_vector(cases[base_index]).ok()?;
+        let base_width = base_bits.get_bit_count();
+        if base_width == 0
+            || base_width > output_width
+            || (base_width < output_width && (!term.signed || *base_bits.get_msb(0) != false_bit))
+        {
+            continue;
+        }
+        let selected_bits = env.get_bit_vector(term.operand).ok()?;
+        if selected_bits.get_bit_count() != base_width {
+            continue;
+        }
+        return Some(SelectedNegateMatch {
+            base_bits,
+            selected_bits,
+            control: *selector_bits.get_lsb(0),
+            invert_control: neg_index == 0,
+        });
+    }
+    None
 }
 
 /// Resizes a literal term to the `ExtNaryAdd` output width.
@@ -792,11 +865,53 @@ pub(super) fn gatify_ext_nary_add(
         return AigBitVector::zeros(output_width);
     }
 
+    let false_bit = g8_builder.get_false();
+    let selected_negates: Vec<Option<SelectedNegateMatch>> = terms
+        .iter()
+        .map(|term| match_selected_negate_term(f, env, term, output_width, false_bit))
+        .collect();
+    let selected_negate_count = selected_negates.iter().flatten().count();
+    let selected_depth = selected_negates
+        .iter()
+        .flatten()
+        .filter_map(|matched| max_aig_depth(g8_builder, &matched.selected_bits))
+        .max();
+    let other_depth = terms
+        .iter()
+        .zip(&selected_negates)
+        .filter(|(term, matched)| {
+            matched.is_none() && literal_bits_if_bits_node(f, term.operand).is_none()
+        })
+        .filter_map(|(term, _)| env.get_bit_vector(term.operand).ok())
+        .filter_map(|bits| max_aig_depth(g8_builder, &bits))
+        .max();
+    let fuse_selected_negates = match selected_negate_count {
+        0 => false,
+        1 => selected_depth.is_some_and(|selected_depth| {
+            other_depth.unwrap_or(0).saturating_add(2) < selected_depth
+        }),
+        _ => true,
+    };
+    if selected_negate_count != 0 {
+        log::debug!(
+            "selected-negate lowering: adder={} width={} matches={} selected_depth={:?} other_depth={:?} choice={}",
+            text_id,
+            output_width,
+            selected_negate_count,
+            selected_depth,
+            other_depth,
+            if fuse_selected_negates {
+                "carry-in"
+            } else {
+                "mux"
+            }
+        );
+    }
+
     let mut literal_sum = xlsynth::IrBits::zero(output_width);
     let mut lowered_terms: Vec<AigBitVector> = Vec::with_capacity(terms.len());
     let mut carry_in: Option<AigOperand> = None;
-    let false_bit = g8_builder.get_false();
-    for term in terms {
+    for (term, selected_negate) in terms.iter().zip(selected_negates) {
         if let Some(literal_bits) = literal_bits_if_bits_node(f, term.operand) {
             accumulate_ext_nary_add_literal(
                 &mut literal_sum,
@@ -808,9 +923,35 @@ pub(super) fn gatify_ext_nary_add(
             continue;
         }
 
-        let bits = env
-            .get_bit_vector(term.operand)
-            .expect("ext_nary_add operand should be present");
+        let (bits, selected_correction) =
+            if fuse_selected_negates && let Some(matched) = selected_negate {
+                let control = if matched.invert_control {
+                    g8_builder.add_not(matched.control)
+                } else {
+                    matched.control
+                };
+                let conditional_complement = AigBitVector::from_lsb_is_index_0(
+                    &matched
+                        .base_bits
+                        .iter_lsb_to_msb()
+                        .map(|bit| g8_builder.add_xor_binary(*bit, control))
+                        .collect::<Vec<_>>(),
+                );
+                (
+                    conditional_complement,
+                    Some(ExtNaryAddUnitCorrection {
+                        control,
+                        weight_shift: 0,
+                        is_decrement: term.negated,
+                    }),
+                )
+            } else {
+                (
+                    env.get_bit_vector(term.operand)
+                        .expect("ext_nary_add operand should be present"),
+                    None,
+                )
+            };
         let resized = if term.signed {
             gatify_sext_or_truncate(g8_builder, text_id, output_width, &bits)
         } else {
@@ -835,14 +976,30 @@ pub(super) fn gatify_ext_nary_add(
                     &mut literal_sum,
                 );
             }
-            continue;
+        } else {
+            if term.negated {
+                lowered_terms.push(g8_builder.add_not_vec(&resized));
+                increment_literal_sum_by_one(&mut literal_sum);
+            } else {
+                lowered_terms.push(resized);
+            }
         }
 
-        if term.negated {
-            lowered_terms.push(g8_builder.add_not_vec(&resized));
-            increment_literal_sum_by_one(&mut literal_sum);
-        } else {
-            lowered_terms.push(resized);
+        if let Some(unit_correction) = selected_correction
+            && !try_fuse_ext_nary_add_unit_correction_into_carry_in(
+                g8_builder,
+                unit_correction,
+                &mut literal_sum,
+                &mut carry_in,
+            )
+        {
+            push_ext_nary_add_unit_correction_as_dense_term(
+                g8_builder,
+                output_width,
+                unit_correction,
+                &mut lowered_terms,
+                &mut literal_sum,
+            );
         }
     }
 

--- a/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
@@ -341,6 +341,15 @@ pub(super) fn try_gatify_selected_unit_delta(
         return None;
     }
     let matched = match_selected_unit_delta(f, env, cases, output_width, adder_mapping)?;
+    if matches!(matched.adder_mapping, AdderMapping::RippleCarry) {
+        log::debug!(
+            "selected-unit lowering: selector={} width={} adder={} choice=mux",
+            f.get_node(selector).text_id,
+            output_width,
+            matched.adder_mapping
+        );
+        return None;
+    }
     let selector_bit = *selector_bits.get_lsb(0);
     let selector_depth = gb.aig_depth(selector_bit)?;
     let changed_depth = matched

--- a/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
+++ b/xlsynth-g8r/src/gatify/ir2gate_arithmetic.rs
@@ -856,6 +856,7 @@ pub(super) fn gatify_ext_nary_add(
     arch: Option<ir::ExtNaryAddArchitecture>,
     output_width: usize,
     default_adder_mapping: AdderMapping,
+    enable_rewrite_nary_add: bool,
     g8_builder: &mut GateBuilder,
 ) -> AigBitVector {
     if output_width == 0 {
@@ -866,10 +867,14 @@ pub(super) fn gatify_ext_nary_add(
     }
 
     let false_bit = g8_builder.get_false();
-    let selected_negates: Vec<Option<SelectedNegateMatch>> = terms
-        .iter()
-        .map(|term| match_selected_negate_term(f, env, term, output_width, false_bit))
-        .collect();
+    let selected_negates: Vec<Option<SelectedNegateMatch>> = if enable_rewrite_nary_add {
+        terms
+            .iter()
+            .map(|term| match_selected_negate_term(f, env, term, output_width, false_bit))
+            .collect()
+    } else {
+        vec![None; terms.len()]
+    };
     let selected_negate_count = selected_negates.iter().flatten().count();
     let selected_depth = selected_negates
         .iter()

--- a/xlsynth-g8r/src/gatify/prep_for_gatify.rs
+++ b/xlsynth-g8r/src/gatify/prep_for_gatify.rs
@@ -3114,6 +3114,27 @@ top fn f(x: bits[8] id=1, en: bits[1] id=2) -> bits[8] {
     }
 
     #[test]
+    fn selected_negate_is_left_for_arrival_aware_gatification() {
+        let original = parse_test_fn(
+            r#"package sample
+
+top fn f(x: bits[8] id=1, en: bits[1] id=2, y: bits[8] id=3) -> bits[8] {
+  negated: bits[8] = neg(x, id=4)
+  selected: bits[8] = sel(en, cases=[x, negated], id=5)
+  ret out: bits[8] = add(y, selected, id=6)
+}"#,
+        );
+        let optimized = prep_nary_add_only(&original);
+        let optimized_text = optimized.to_string();
+        assert!(
+            optimized_text.contains("= neg(x,")
+                && optimized_text.contains("= sel(en,")
+                && optimized_text.contains("ret out: bits[8] = ext_nary_add(y, selected"),
+            "selected negation should remain a select for gatification; got:\n{optimized_text}"
+        );
+    }
+
+    #[test]
     fn nary_add_rewrite_grows_add_sub_tree_to_fixed_point() {
         let ir_text = r#"package sample
 

--- a/xlsynth-g8r/src/gatify/prep_for_gatify.rs
+++ b/xlsynth-g8r/src/gatify/prep_for_gatify.rs
@@ -3094,6 +3094,26 @@ top fn cone(p0: bits[9] id=1, p1: bits[9] id=2) -> bits[1] {
     }
 
     #[test]
+    fn selected_unit_delta_is_left_for_arrival_aware_gatification() {
+        let f = parse_test_fn(
+            r#"package sample
+
+top fn f(x: bits[8] id=1, en: bits[1] id=2) -> bits[8] {
+  one: bits[8] = literal(value=1, id=3)
+  changed: bits[8] = add(x, one, id=4)
+  ret out: bits[8] = sel(en, cases=[x, changed], id=5)
+}"#,
+        );
+        let optimized = prep_nary_add_only(&f);
+        let optimized_text = optimized.to_string();
+        assert!(
+            optimized_text.contains("ret out: bits[8] = sel(en, cases=[x, changed]")
+                && optimized_text.contains("changed: bits[8] = ext_nary_add(x, one"),
+            "selected increment should remain a select for gatification; got:\n{optimized_text}"
+        );
+    }
+
+    #[test]
     fn nary_add_rewrite_grows_add_sub_tree_to_fixed_point() {
         let ir_text = r#"package sample
 


### PR DESCRIPTION
Track AIG arrival times during gatification and use it to trigger a couple optimizations: lower selected increments and decrements as either a mux or adder carry-in using a width-aware arrival margin.

Improves average delay by 1% across a large corpus.