### PR TITLE
xlsynth-sys: select XLS v0.54.4 for semantic sums

### DIFF
--- a/valgrind.supp
+++ b/valgrind.supp
@@ -29,11 +29,11 @@
    ...
 }
 {
-   xls_v0543_z3_solver_static_registration
+   xls_v0544_z3_solver_static_registration
    Memcheck:Leak
    match-leak-kinds: possible
    fun:malloc
-   obj:*/libxls-v0.54.3-ubuntu2004.so
+   obj:*/libxls-v0.54.4-ubuntu2004.so
    fun:*PrepareInsertSmallNonSoo*
    fun:*SolverFactoryRegistry*Register*
    fun:_GLOBAL__sub_I_z3_ir_translator.cc

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.54.3";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.54.4";
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 6;
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary

- Select XLS v0.54.4 for the next XLSynth crate and driver release.
- Make the repaired DSLX sum-type compiler available to downstream clients.

## Problem Solved

XLS v0.54.3 can crash when one DSLX module imports float32 and constructs a semantic sum from float32::F32. XLS v0.54.4 preserves the cloned module's source information, allowing the same combined implementation to compile.

<!-- spr-stack:start -->
**Stack**:
- ➡ #1044

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->