### PR TITLE
xlsynth-sys: select XLS v0.54.6 for cloned constants

### DIFF
--- a/valgrind.supp
+++ b/valgrind.supp
@@ -29,11 +29,11 @@
    ...
 }
 {
-   xls_v0543_z3_solver_static_registration
+   xls_v0546_z3_solver_static_registration
    Memcheck:Leak
    match-leak-kinds: possible
    fun:malloc
-   obj:*/libxls-v0.54.3-ubuntu2004.so
+   obj:*/libxls-v0.54.6-ubuntu2004.so
    fun:*PrepareInsertSmallNonSoo*
    fun:*SolverFactoryRegistry*Register*
    fun:_GLOBAL__sub_I_z3_ir_translator.cc

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-const RELEASE_LIB_VERSION_TAG: &str = "v0.54.3";
+const RELEASE_LIB_VERSION_TAG: &str = "v0.54.6";
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 6;
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary

- Update `xlsynth-sys` from XLS `v0.54.3` to the reviewed `v0.54.6` compiler.
- Keep the version-specific Z3 Valgrind suppression aligned with the new
  Linux shared-library filename.
- Preserve the existing independent `0.63.0` Rust crate and driver versions.

## Problem

The current published compiler can lose global constants after DSLX semantic-sum
construction clones a module:

```dslx
enum OptionalPayload { Missing, Present(u32) }
const ANSWER = u32:42;

fn make() -> OptionalPayload {
    OptionalPayload::Present(ANSWER)
}
```

The old compiler fails to resolve `ANSWER`. XLS `v0.54.6` reconnects each
cloned constant name to its cloned definition and preserves that reference.

The crate version and XLS compiler version are deliberately independent:

```text
xlsynth crates / driver: 0.63.0
underlying XLS compiler: 0.54.6
```

The existing Valgrind suppression names the exact producer DSO. Update both its
label and filename so the same known Z3 startup allocation remains suppressed
after the version bump.

## Validation

- `python3 scripts/get_required_libxls_dso_and_tools_release_tag.py`
- `DOCS_RS=1 cargo clippy -p xlsynth-sys --lib`
- `DOCS_RS=1 cargo clippy -p xlsynth-sys --tests -- -A clippy::collapsible_if
  -A clippy::err_expect`; both allowances are for existing unchanged tests.
- `cargo fmt --all -- --check`
- `cargo test -p xlsynth-sys` against the published, checksum-verified
  `v0.54.6` library; all five artifact-config tests, DSO-symbol coverage, and
  the macOS install-name check pass.
- `cargo nextest run --features with-bitwuzla-built` against the actual
  checksum-verified `v0.54.6` macOS tools, library, and DSLX standard library:
  **3,688 passed; 12 existing tests skipped**. The Bitwuzla feature matches the
  in-process solver capability enabled by the repository's publish workflow;
  all six live crates.io metadata checks also passed.


<!-- spr-stack:start -->
**Stack**:
- ➡ #1045
-   #1047

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->