### PR TITLE
xlsynth-sys: keep downstream builds working with current Cargo nightly

### DIFF
--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -611,10 +611,11 @@ fn emit_link_directives_for_managed_dso(
 
 /// Returns Cargo's profile-level `deps` directory for this build script.
 ///
-/// Cargo sets `OUT_DIR` to:
+/// Depending on the Cargo version, `OUT_DIR` has one of these layouts:
 ///
 /// ```text
 /// target/<profile>/build/<pkg-hash>/out
+/// target/<profile>/build/<pkg>/<hash>/out
 /// ```
 ///
 /// When Cargo runs host binaries it just built, including downstream `build.rs`
@@ -623,11 +624,9 @@ fn emit_link_directives_for_managed_dso(
 /// that loader path, so a DSO that only lives in `OUT_DIR` can link
 /// successfully but fail when a dependent build script starts.
 fn cargo_profile_deps_dir(out_dir: &Path) -> Option<PathBuf> {
-    let build_script_dir = out_dir.parent()?;
-    let build_dir = build_script_dir.parent()?;
-    if build_dir.file_name()? != "build" {
-        return None;
-    }
+    let build_dir = out_dir
+        .ancestors()
+        .find(|ancestor| ancestor.file_name().is_some_and(|name| name == "build"))?;
     Some(build_dir.parent()?.join("deps"))
 }
 


### PR DESCRIPTION
## Summary

- Restore managed XLS shared-library discovery for downstream build scripts on
  current Cargo nightly.
- Preserve compatibility with the older Cargo build-output layout.

## Problem Solved

Recent Cargo nightly builds changed `OUT_DIR` from
`target/debug/build/xlsynth-sys-<hash>/out` to
`target/debug/build/xlsynth-sys/<hash>/out`. The existing build script assumes
that `build` is always exactly two parent directories above `OUT_DIR`, so it
cannot find `target/debug/deps` in the new layout. Consequently, Linux build
scripts cannot load the downloaded XLS library, and the existing macOS runtime
probe finds no staged library.

Find the actual `build` ancestor before deriving its sibling `deps` directory.
Both Cargo layouts now resolve to the same loader-visible directory without
changing release selection, workflows, or public APIs.

## Validation

- The existing `scripts/check_build_script_dso_runtime.sh` probe fails on
  unmodified main with current Cargo nightly and passes after the fix.
- Current Cargo: `cargo 1.99.0-nightly (c79e8f894 2026-08-04)`.
- Matching Rust: `rustc 1.99.0-nightly (84b36a78a 2026-08-06)`.
- The same checked-in probe also passes with the older installed Cargo layout.
- `cargo test -p xlsynth-sys`.
- `cargo clippy -p xlsynth-sys --lib`.
- `cargo nextest run --features with-bitwuzla-built`: all 3,688 tests passed;
  12 existing tests were skipped.

<!-- spr-stack:start -->
**Stack**:
-   #1045
- ➡ #1046

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->