### PR TITLE
xlsynth-sys: keep dependent build scripts runnable on nightly Cargo

### DIFF
--- a/scripts/check_build_script_dso_runtime.sh
+++ b/scripts/check_build_script_dso_runtime.sh
@@ -74,10 +74,10 @@ env \
   -u DEV_XLS_DSO_WORKSPACE \
   cargo check --manifest-path "${tmp_dir}/Cargo.toml"
 
-# The fix stages managed libxls DSOs into the downstream Cargo profile's deps
-# directory, which Cargo includes in the runtime loader environment for host
-# binaries it runs. Check for the staged DSO explicitly so the test fails if
-# Cargo happens to succeed for some unrelated reason.
+# Managed libxls DSOs are also staged into the downstream Cargo profile's deps
+# directory for older Cargo versions. Check for the staged DSO explicitly so
+# that compatibility remains covered even when a newer nightly executable can
+# locate the original managed DSO through its embedded runtime search path.
 #
 # Use a shell glob instead of find: the Rocky CI image used by this repo is
 # intentionally small and may not have find installed.
@@ -87,3 +87,37 @@ if [[ ! -e "${staged_dsos[0]}" ]]; then
   exit 1
 fi
 printf '%s\n' "${staged_dsos[0]}"
+
+# macOS DSOs already have absolute install names. On Linux, nightly Rust also
+# propagates the managed DSO directory into the final build-script executable.
+# Exercise both binaries outside Cargo so Cargo's loader environment cannot
+# hide a regression in startup-time native-library discovery. Stable Linux
+# retains the existing Cargo-provided loader-path behavior instead.
+runtime_os="$(uname -s)"
+rustc_version="$("${RUSTC:-rustc}" --version)"
+if [[ "${runtime_os}" == "Darwin" ]] ||
+  [[ "${runtime_os}" == "Linux" && "${rustc_version}" == *-nightly* ]]; then
+  build_script_executable=""
+  for candidate in \
+    "${tmp_dir}"/target/debug/build/xlsynth-build-script-dso-check-*/build-script-build \
+    "${tmp_dir}"/target/debug/build/xlsynth-build-script-dso-check/*/out/build_script_build; do
+    if [[ -x "${candidate}" ]]; then
+      if [[ -n "${build_script_executable}" ]]; then
+        echo "error: found multiple downstream build-script executables" >&2
+        exit 1
+      fi
+      build_script_executable="${candidate}"
+    fi
+  done
+
+  if [[ -z "${build_script_executable}" ]]; then
+    echo "error: could not locate the downstream build-script executable" >&2
+    exit 1
+  fi
+
+  env \
+    -u LD_LIBRARY_PATH \
+    -u DYLD_LIBRARY_PATH \
+    -u DYLD_FALLBACK_LIBRARY_PATH \
+    "${build_script_executable}"
+fi

--- a/xlsynth-sys/build.rs
+++ b/xlsynth-sys/build.rs
@@ -587,6 +587,45 @@ fn emit_explicit_artifact_override(
     }
 }
 
+/// Makes a managed Linux DSO discoverable in downstream nightly executables.
+///
+/// Cargo applies `cargo:rustc-link-arg` only to this package, so it cannot give
+/// dependent build-script executables an ELF runtime search path. Nightly Rust
+/// can propagate a source-level native linker argument through this library
+/// instead, allowing the operating-system loader to find the managed DSO
+/// before those executables start.
+fn emit_transitive_linux_runtime_path(out_dir: &Path) {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let rustc_version = Command::new(&rustc)
+            .arg("--version")
+            .output()
+            .unwrap_or_else(|error| panic!("failed to inspect Rust compiler {rustc:?}: {error}"));
+        assert!(
+            rustc_version.status.success(),
+            "Rust compiler {rustc:?} --version failed: {}",
+            String::from_utf8_lossy(&rustc_version.stderr)
+        );
+
+        if String::from_utf8_lossy(&rustc_version.stdout).contains("-nightly") {
+            let runtime_link_arg = format!("-rpath={}", out_dir.display());
+            let runtime_link_source = format!(
+                "#[link(kind = \"link-arg\", name = {runtime_link_arg:?})]\nunsafe extern \"C\" {{}}\n"
+            );
+            let runtime_link_source_path = out_dir.join("xlsynth_runtime_link_arg.rs");
+            std::fs::write(&runtime_link_source_path, runtime_link_source).unwrap_or_else(
+                |error| {
+                    panic!(
+                        "failed to write transitive runtime linker argument {}: {error}",
+                        runtime_link_source_path.display()
+                    )
+                },
+            );
+            println!("cargo:rustc-cfg=xlsynth_runtime_runpath");
+        }
+    }
+}
+
 fn emit_link_directives_for_managed_dso(
     out_dir: &Path,
     link_name: &str,
@@ -595,6 +634,7 @@ fn emit_link_directives_for_managed_dso(
 ) {
     match link_directive_mode {
         LinkDirectiveMode::Native => {
+            emit_transitive_linux_runtime_path(out_dir);
             if include_rpath {
                 println!("cargo:rustc-link-arg=-Wl,-rpath,{}", out_dir.display());
             }
@@ -618,11 +658,10 @@ fn emit_link_directives_for_managed_dso(
 /// target/<profile>/build/<pkg>/<hash>/out
 /// ```
 ///
-/// When Cargo runs host binaries it just built, including downstream `build.rs`
-/// executables, it includes `target/<profile>/deps` in
-/// `LD_LIBRARY_PATH`/`DYLD_FALLBACK_LIBRARY_PATH`. `OUT_DIR` itself is not in
-/// that loader path, so a DSO that only lives in `OUT_DIR` can link
-/// successfully but fail when a dependent build script starts.
+/// Older Cargo versions include `target/<profile>/deps` in the loader
+/// environment when running downstream `build.rs` executables. Newer nightly
+/// layouts can omit that directory, so managed Linux DSOs also need the
+/// propagated runtime search path when the compiler supports it.
 fn cargo_profile_deps_dir(out_dir: &Path) -> Option<PathBuf> {
     let build_dir = out_dir
         .ancestors()
@@ -639,7 +678,9 @@ fn cargo_profile_deps_dir(out_dir: &Path) -> Option<PathBuf> {
 /// `cargo:rustc-link-arg=-Wl,-rpath,...` helps binaries built directly from
 /// this package, but Cargo does not propagate that rpath into dependent
 /// build-script executables. Staging the managed DSO into Cargo's `deps`
-/// directory uses the loader path Cargo already provides for host binaries.
+/// directory preserves the loader path older Cargo versions provide for host
+/// binaries. Newer nightly layouts additionally use the propagated source-level
+/// linker argument emitted by `emit_transitive_linux_runtime_path`.
 fn stage_managed_dso_for_cargo_runtime(out_dir: &Path, dso_filename: &str) {
     let Some(deps_dir) = cargo_profile_deps_dir(out_dir) else {
         println!(
@@ -791,6 +832,7 @@ fn download_stdlib_if_dne(url_base: &str, out_dir: &Path) -> PathBuf {
 fn main() {
     // Ensure Cargo rebuilds this sys crate if caller-provided artifact paths
     // change, since they affect link args and rpath settings.
+    println!("cargo:rustc-check-cfg=cfg(xlsynth_runtime_runpath)");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=DEV_XLS_DSO_WORKSPACE");
     println!("cargo:rerun-if-env-changed=XLSYNTH_ARTIFACT_CONFIG");

--- a/xlsynth-sys/src/lib.rs
+++ b/xlsynth-sys/src/lib.rs
@@ -2,6 +2,11 @@
 
 //! Declarations for the C API for the XLS dynamic shared object.
 
+#![cfg_attr(xlsynth_runtime_runpath, feature(link_arg_attribute))]
+
+#[cfg(xlsynth_runtime_runpath)]
+include!(concat!(env!("OUT_DIR"), "/xlsynth_runtime_link_arg.rs"));
+
 extern crate libc;
 
 #[repr(C)]


### PR DESCRIPTION
## Summary

- Keep downloaded XLS shared libraries discoverable before dependent Linux build scripts start under Cargo's new nightly output layout.
- Preserve the existing library download location, stable Rust behavior, macOS loading, declared-link integrations, and `LD_LIBRARY_PATH` precedence.
- Extend the existing managed-download regression to launch the downstream build-script executable directly without loader environment overrides.

## Problem Solved

`xlsynth-sys` downloads `libxls` into its normal Cargo `OUT_DIR`. A downstream
crate can use `xlsynth` from its own `build.rs`, causing Cargo to link that build
script against the downloaded shared library.

With the current nightly Cargo output layout, the executable links successfully
but Cargo can start it without making the library directory visible to the
operating-system loader. The executable then fails before its `main` function
runs. This affects downstream XLSynth consumers as well as Rocky and Ubuntu CI.

```text
downstream build.rs -> xlsynth -> libxls-<version>-ubuntu2004.so

Before: linking succeeds; executable startup cannot locate libxls.
After:  executable RUNPATH points to the existing OUT_DIR; startup succeeds.
```

## How It Works

For Linux builds using nightly Rust, `xlsynth-sys/build.rs` identifies the same
`OUT_DIR` where it already downloaded the library and generates a source-level
`#[link(kind = "link-arg")]` directive. `xlsynth-sys/src/lib.rs` includes that
directive, allowing Rust to carry the library directory into the final
downstream executable as an ELF `RUNPATH`.

The library is not downloaded again or moved elsewhere. Existing staging into
Cargo's profile-level `deps` directory remains in place for older Cargo.
`RUNPATH` also preserves the existing ability for `LD_LIBRARY_PATH` to select a
replacement library first.

Stable Rust, macOS, and declared-link integrations do not enable the unstable
`link_arg_attribute` feature. If Cargo's new layout reaches stable Rust before
that feature stabilizes, the stable-channel strategy will need separate review.

## Tests

- `bash scripts/check_build_script_dso_runtime.sh` passed on affected Linux and macOS nightly toolchains, including direct executable startup with loader overrides removed.
- The same managed-download regression passed on stable Linux, and declared-link mode remained isolated from the nightly-only linker directive.
- `cargo test -p xlsynth-sys` passed all artifact-configuration, shared-library symbol, and macOS install-name coverage.
- `cargo test -p xlsynth-sys -p xlsynth --lib` passed all 133 focused library tests.
- `cargo nextest run --features with-bitwuzla-built` passed the complete workspace: **3,688 passed, 0 failed, 12 skipped**.
- The native-library matrix passed on macOS arm64, Rocky 8, Ubuntu 20.04, and Ubuntu 24.04 with the correct real platform libraries: **133 focused tests per platform; 532 total**.

<!-- spr-stack:start -->
**Stack**:
-   #1045
- ➡ #1047

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
